### PR TITLE
Create workflow to ensure a consistent set of labels

### DIFF
--- a/.github/GITHUB.md
+++ b/.github/GITHUB.md
@@ -29,6 +29,3 @@ minimum set of consistent labels.
 **Purpose:**
 Creates the standard list of labels in all repos, updating the color and 
 description where they do not match the standard values.
-
-
-

--- a/.github/GITHUB.md
+++ b/.github/GITHUB.md
@@ -18,3 +18,17 @@ issue and PR cards across columns.
 - Add new PRs to the "Needs review" column.
 - Move issues with linked PRs from the columns "Backlog" and "To do" to 
   the "In progress" column.
+
+### Label sync
+
+This workflow ensures that all repos associated with the project have the
+minimum set of consistent labels.
+
+**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)
+
+**Purpose:**
+Creates the standard list of labels in all repos, updating the color and 
+description where they do not match the standard values.
+
+
+

--- a/.github/workflows/label_sync.yml
+++ b/.github/workflows/label_sync.yml
@@ -1,0 +1,35 @@
+name: Label sync
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 * * *" # at 00:00
+
+env:
+  LOGGING_LEVEL: 20 # corresponds to INFO
+  ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+jobs:
+  sync_labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      working-directory: ./python
+      run: |
+        python -m pip install --user --upgrade pip
+        python -m pip install --user pipenv
+        pipenv install --deploy
+
+    - name: Sync standard labels
+      working-directory: ./python
+      run: |
+        pipenv run python sync_labels.py

--- a/data/labels.yml
+++ b/data/labels.yml
@@ -1,0 +1,141 @@
+colors:
+  UNFAVOURABLE: 'b60205'
+  NEGATIVE: 'ff9f1c'
+  NEUTRAL: 'ffcc00'
+  POSITIVE: 'cfda2c'
+  FAVOURABLE: '008672'
+  BLACK: '000000'
+  DARKER: '333333'
+  DARK: '666666'
+  MEDIUM: '999999'
+  LIGHT: 'cccccc'
+  LIGHTER: 'eeeeee'
+  WHITE: 'ffffff'
+
+groups:
+- name: priority
+  is_required: true
+  labels:
+  - name: critical
+    color: 'UNFAVOURABLE'
+    description: Must be fixed ASAP
+    emoji: "🟥"
+  - name: high
+    color: 'NEGATIVE'
+    description: Stalls work on the project or its dependents
+    emoji: "🟧"
+  - name: medium
+    color: 'NEUTRAL'
+    description: Not blocking but should be fixed soon
+    emoji: "🟨"
+  - name: low
+    color: 'POSITIVE'
+    description: Low priority and doesn't need to be rushed
+    emoji: "🟩"
+
+- name: status
+  is_required: true
+  labels:
+  - name: ready for work
+    color: 'LIGHT'
+    description: Ready for work
+    emoji: "🏁"
+  - name: blocked
+    color: 'MEDIUM'
+    description: Blocked & therefore, not ready for work
+    emoji: "🚧"
+  - name: ticket work required
+    color: 'DARK'
+    description: Needs more details before it can be worked on
+    emoji: "🧹"
+  - name: label work required
+    color: 'DARK'
+    description: Needs proper labelling before it can be worked on
+    emoji: "🏷"
+  - name: discarded
+    color: 'LIGHTER'
+    description: Will not be worked on
+    emoji: "⛔️"
+  - name: discontinued
+    color: 'LIGHTER'
+    description: Not suitable for work as repo is in maintenance
+    emoji: "🙅"
+  - name: awaiting triage
+    color: 'DARKER'
+    description: Has not been triaged & therefore, not ready for work
+    emoji: "🚦"
+
+- name: goal
+  color: 'ffffff'
+  is_required: true
+  labels:
+  - name: addition
+    description: Addition of new feature
+    emoji: "🌟"
+  - name: improvement
+    description: Improvement to an existing feature
+    emoji: "✨"
+  - name: fix
+    description: Bug fix
+    emoji: "🛠"
+
+- name: aspect
+  color: '04338c'
+  is_required: true
+  labels:
+  - name: text
+    description: Concerns the textual material in the repository
+    emoji: "📄"
+  - name: code
+    description: Concerns the software code in the repository
+    emoji: "💻"
+  - name: interface
+    description: Concerns end-users' experience with the software
+    emoji: "🕹"
+  - name: dx
+    description: Concerns developers' experience with the codebase
+    emoji: "🤖"
+
+- name: talk
+  color: 'f9bbe5'
+  labels:
+  - name: question
+    description: Can be resolved with an answer
+    emoji: "❓"
+  - name: discussion
+    description: Open for discussions and feedback
+    emoji: "💬"
+
+- name: friendliness
+  color: '7f0799'
+  is_prefixed: false
+  labels:
+  - name: good first issue
+    description: New-contributor friendly
+    emoji: "🤗"
+    has_emoji_name: false
+  - name: help wanted
+    description: Open to participation from the community
+    emoji: "🙏"
+    has_emoji_name: false
+  - name: staff only
+    description: Restricted to CC staff members
+    emoji: "🔒"
+
+standalone:
+- name: 'ノಠ益ಠノ彡┻━┻'
+  color: '000000'
+  description: Aaargh!
+  emoji: "🤯"
+
+- name: Hacktoberfest
+  color: '883255'
+  description: Ideal for Hacktoberfest participation
+  emoji: "🎃"
+  has_emoji_name: false
+
+- name: invalid
+  color: 'LIGHTER'
+  description: Inappropriate or invalid (ex. Hacktoberfest spam)
+  emoji: "⛔️"
+  has_emoji_name: false

--- a/python/README.md
+++ b/python/README.md
@@ -4,3 +4,4 @@
 |-------------------------|---------------------------------------------------------------------|
 | `issues_with_prs.py`    | Move issue cards with linked PRs from one project column to another |
 | `new_issues_and_prs.py` | Add project cards for issues and PRs created in a given timeframe   |
+| `sync_labels.py`        | Ensure the presence of a consistent set of labels on all repos      |

--- a/python/models/label.py
+++ b/python/models/label.py
@@ -1,0 +1,137 @@
+from models.label_group import LabelGroup
+from shared.data import get_data
+
+
+class Label:
+    """
+    This model represents a single label. A label is defined by four parameters
+    - name, which appears on the label
+    - description, which describes it in a little more detail
+    - emoji, which is a pictorial representation of the purpose of the label
+    - color, which is used as a background on the label element
+    A ``Label`` instance is associated to a ``Group`` instance by a many to one
+    relationship.
+    """
+
+    def __init__(
+        self,
+        group: LabelGroup = None,
+        color: str = None,
+        has_emoji_name: bool = True,
+        **kwargs
+    ):
+        self.name = kwargs["name"]
+        self.description = kwargs["description"]
+        self.emoji = kwargs["emoji"]
+        self.own_color = color
+        self.has_emoji_name = has_emoji_name
+
+        self.group = group
+        if group and self not in group.labels:
+            group.labels.append(self)
+
+    @property
+    def color(self) -> str:
+        """
+        Return the color to use on the emoji label, given as a 6-digit
+        hexadecimal code without the prefix '#'. Labels can have their color
+        specified as a constant and if missing inherit color from the parent
+        group. If not resolved, the color defaults to pure black.
+
+        :return: the 6-digit hexadecimal code of the background color
+        """
+
+        colors = get_data('labels.yml')['colors']
+
+        color = self.own_color
+        if color is None and self.group is not None:
+            color = self.group.color
+        if color is None:
+            color = colors["BLACK"]
+        elif color in colors:
+            color = colors[color]
+        return color
+
+    @property
+    def qualified_name(self) -> str:
+        """
+        Return the fully qualified name of the label. Most label groups prefix
+        the group name to the name of the label, separated by a colon, as
+        indicated by the ``is_prefixed`` attribute on the associated ``Group``
+        instance.
+
+        :return: the fully qualified name of the label
+        """
+
+        name = self.name
+        if self.group and self.group.is_prefixed:
+            name = f"{self.group}: {name}"
+        if self.has_emoji_name:
+            name = f"{self.emoji} {name}"
+        return name
+
+    @property
+    def emojified_description(self) -> str:
+        """
+        TODO: Use this when GitHub supports Unicode in label descriptions
+        Get the description of the label prefixed with the emoji.
+
+        :return: the emoji-prefixed description
+        """
+
+        return f"{self.emoji} {self.description}"
+
+    @property
+    def api_arguments(self) -> dict[str, str]:
+        """
+        Get the dictionary of arguments to pass to the API for creating the
+        label. The API only accepts ``name``, ``color`` and ``description``.
+
+        :return: the API arguments as a dictionary
+        """
+
+        return {
+            "name": self.qualified_name,
+            "color": self.color,
+            "description": self.description,
+        }
+
+    def __eq__(self, remote: 'Label') -> bool:
+        """
+        Compare this instance with the corresponding PyGithub instance to
+        determine whether the two are equal.
+
+        :param remote: the PyGithub label instance to compare itself against
+        :return: whether the instance is equal to its remote counterpart
+        """
+
+        return all(
+            [
+                self.qualified_name == remote.name,
+                self.color == remote.color,
+                self.description == remote.description,
+            ]
+        )
+
+    def __ne__(self, remote: 'Label') -> bool:
+        """
+        Compare this instance with the corresponding PyGithub instance to
+        determine whether the two are unequal and would need to be reconciled.
+
+        :param remote: the PyGithub label instance to compare itself against
+        :return: whether the instance is unequal to its remote counterpart
+        """
+
+        return any(
+            [
+                self.qualified_name != remote.name,
+                self.color != remote.color,
+                self.description != remote.description,
+            ]
+        )
+
+    def __str__(self) -> str:
+        return self.qualified_name
+
+    def __repr__(self) -> str:
+        return f"<Label '{self}'>"

--- a/python/models/label_group.py
+++ b/python/models/label_group.py
@@ -1,0 +1,22 @@
+class LabelGroup:
+    """
+    This model represents a group of labels. A group has some fixed parameters
+    - name, which may be prefixed to all child label names
+    - color, which acts as a fallback for child labels that do not specify one
+    - is_prefixed, which determines if group name is prefixed on child labels
+    - is_required, which determines if >=1 sub-label must be applied on issues
+    """
+
+    def __init__(self, color=None, is_prefixed=True, is_required=False, **kwargs):
+        self.name = kwargs["name"]
+        self.color = color
+        self.is_prefixed = is_prefixed
+        self.is_required = is_required
+
+        self.labels = []  # This may or may not be populated, do not rely
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return f"<Group '{self}'>"

--- a/python/sync_labels.py
+++ b/python/sync_labels.py
@@ -75,7 +75,7 @@ def main():
     labels = get_labels()
     log.info(f"Synchronizing {len(labels)} standard labels")
     for label in labels:
-        print(f"• {label.qualified_name}")
+        log.info(f"• {label.qualified_name}")
     repos = [org.get_repo(repo_name) for repo_name in repo_names]
     for repo in repos:
         set_labels(repo, get_labels())

--- a/python/sync_labels.py
+++ b/python/sync_labels.py
@@ -1,0 +1,85 @@
+import logging
+from copy import deepcopy
+
+from github import Repository
+
+from models.label import Label
+from models.label_group import LabelGroup
+from shared.data import get_data
+from shared.github import get_client
+from shared.log import configure_logger
+
+log = logging.getLogger(__name__)
+
+
+def get_labels() -> list[Label]:
+    """
+    Get all the standard labels as a list.
+
+    :return: a list of Label objects
+    """
+
+    labels_file = deepcopy(get_data("labels.yml"))
+    standard_labels = []
+    for group_info in labels_file["groups"]:
+        labels = group_info.pop("labels", [])
+        group = LabelGroup(**group_info)
+        for label_info in labels:
+            label = Label(**label_info, group=group)
+            standard_labels.append(label)
+    for label_info in labels_file["standalone"]:
+        label = Label(**label_info)
+        standard_labels.append(label)
+    return standard_labels
+
+
+def set_labels(repo: Repository, labels: list[Label]):
+    """
+    Set the given list of labels on the given repository. Missing labels will
+    be added, but extraneous labels will be left intact.
+
+    :param repo: the repo in which to set the given labels
+    :param labels: the list of labels to define on the repo
+    """
+
+    log.info(f"Fetching existing labels from {repo.full_name}")
+    existing_labels = {label.name.casefold(): label for label in repo.get_labels()}
+    log.info(f"Found {len(existing_labels)} existing labels")
+
+    for label in labels:
+        qualified_name = label.qualified_name
+        folded_name = qualified_name.casefold()
+        if folded_name not in existing_labels:
+            log.info(f"Creating label {qualified_name}")
+            repo.create_label(**label.api_arguments)
+        elif label != existing_labels[folded_name]:
+            log.info(f"Updating label {qualified_name}")
+            existing_label = existing_labels[folded_name]
+            existing_label.edit(**label.api_arguments)
+        else:
+            log.info(f"Label {qualified_name} already exists")
+
+
+def main():
+    configure_logger()
+
+    github_info = get_data("github.yml")
+    org_handle = github_info["org"]
+    log.info(f"Organization handle: {org_handle}")
+    repo_names = github_info["repos"].values()
+    log.info(f"Repository names: {', '.join(repo_names)}")
+
+    gh = get_client()
+    org = gh.get_organization(org_handle)
+
+    labels = get_labels()
+    log.info(f"Synchronizing {len(labels)} standard labels")
+    for label in labels:
+        print(f"• {label.qualified_name}")
+    repos = [org.get_repo(repo_name) for repo_name in repo_names]
+    for repo in repos:
+        set_labels(repo, get_labels())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #16.

This PR adds the script and workflow to ensure that the given set of standard labels are present on all repositories, in addition to whatever extra labels the repo has defined.