### PR TITLE
Drop the word 'CC'

### DIFF
--- a/data/labels.yml
+++ b/data/labels.yml
@@ -119,7 +119,7 @@ groups:
     emoji: "🙏"
     has_emoji_name: false
   - name: staff only
-    description: Restricted to CC staff members
+    description: Restricted to staff members
     emoji: "🔒"
 
 standalone:


### PR DESCRIPTION
This PR removes the word "CC" from the phrase "CC staff members".