### PR TITLE
Include the browser extension in the list of repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository **does not** contain most of the codebase. The code is divided i
 - [Front-end](https://github.com/wordpress/openverse-frontend)
 - [Catalog](https://github.com/wordpress/openverse-catalog)
 - [API](https://github.com/wordpress/openverse-api)
+- [Browser extension](https://github.com/wordpress/openverse-browser-extension)
 
 It is possible we will explore a monorepo structure in the future, but as all the repos are decoupled from each other and use different technologies, we've felt it best to keep them distinct.
 

--- a/data/github.yml
+++ b/data/github.yml
@@ -4,3 +4,5 @@ repos:
   catalog: openverse-catalog
   api: openverse-api
   frontend: openverse-frontend
+  extension: openverse-browser-extension
+


### PR DESCRIPTION
Addresses #37.

Now that we have an [Openverse browser extension](https://github.com/WordPress/openverse-browser-extension), it's time to include it in our workflows and project board automations.