### PR TITLE
Add a label for a11y

### DIFF
--- a/.github/workflows/pr_label_check.yml
+++ b/.github/workflows/pr_label_check.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check aspect label
       uses: sugarshin/required-labels-action@v0.3.1
       with:
-        required_oneof: '💻 aspect: code,📄 aspect: text,🤖 aspect: dx,🕹 aspect: interface'
+        required_oneof: '💻 aspect: code,📄 aspect: text,🤖 aspect: dx,🕹 aspect: interface,♿️ aspect: a11y'
 
   check_goal_label:
     name: Check goal label

--- a/data/labels.yml
+++ b/data/labels.yml
@@ -99,7 +99,7 @@ groups:
     description: Concerns developers' experience with the codebase
     emoji: "🤖"
   - name: a11y
-    description: Concerns related to the projects accessibility
+    description: Concerns related to the project's accessibility
     emoji: ♿️
 
 - name: talk

--- a/data/labels.yml
+++ b/data/labels.yml
@@ -98,6 +98,9 @@ groups:
   - name: dx
     description: Concerns developers' experience with the codebase
     emoji: "🤖"
+  - name: a11y
+    description: Concerns related to the projects accessibility
+    emoji: ♿️
 
 - name: talk
   color: 'f9bbe5'


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #59 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds a label for accessibity. This will ideally be used for issues that point out problems and shortcomings with accessibility of our components and PRs that help to improve them.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
This makes the most sense for the frontend and extension repos, which are the primary user-facing codebases.

## Additional context
The proper a11y icon (see image) is not an emoji (yet; unfortunately).

<img width="65" alt="Screenshot 2021-09-14 at 9 32 24 PM" src="https://user-images.githubusercontent.com/16580576/133293090-5ecf6818-3597-4ea1-a5f9-6358efc11e91.png">

The [♿️ wheel chair symbol](https://emojipedia.org/wheelchair-symbol/) is the next best alternative based on the Emojipedia description.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
