### PR TITLE
Update bug_report.md to remove default priority label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "🛠 goal: fix, 🚦 status: awaiting triage, 💻 aspect: code"
+labels: "🛠 goal: fix, 🚦 status: awaiting triage"
 title: "<Replace this with actual title>"
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "🛠 goal: fix, 🚦 status: awaiting triage, 💻 aspect: code, 🟧 priority: high"
+labels: "🛠 goal: fix, 🚦 status: awaiting triage, 💻 aspect: code"
 title: "<Replace this with actual title>"
 ---
 


### PR DESCRIPTION
As discussed, removes the default priority label for bug reports. 