### PR TITLE
Adding Sentry Label for issues originating from a Sentry report

### DIFF
--- a/automations/data/labels.yml
+++ b/automations/data/labels.yml
@@ -83,10 +83,10 @@ groups:
         emoji: "🛠"
 
   - name: tooling
-    color: "#362D59"
     is_required: true
     labels:
       - name: sentry
+        color: "#362D59"
         description: Sentry issue
         emoji: "🐛"
 

--- a/automations/data/labels.yml
+++ b/automations/data/labels.yml
@@ -82,6 +82,14 @@ groups:
         description: Bug fix
         emoji: "🛠"
 
+  - name: tooling
+    color: "#362D59"
+    is_required: true
+    labels:
+      - name: sentry
+        description: Sentry issue
+        emoji: "🐛"
+
   - name: aspect
     color: "04338c"
     is_required: true

--- a/automations/data/labels.yml
+++ b/automations/data/labels.yml
@@ -83,7 +83,6 @@ groups:
         emoji: "🛠"
 
   - name: tooling
-    is_required: true
     labels:
       - name: sentry
         color: "#362D59"


### PR DESCRIPTION
## Fixes
Fixes #154 by @chukkyiii

## Description
PR adds tooling group with sentry label for issues taht include sentry. 


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
