### PR TITLE
Add `aspect: design` label

### DIFF
--- a/automations/data/labels.yml
+++ b/automations/data/labels.yml
@@ -108,6 +108,9 @@ groups:
       - name: a11y
         description: Concerns related to the project's accessibility
         emoji: "♿️"
+      - name: design
+        description: Concerns related to design
+        emoji: "🖼️"
 
   - name: talk
     color: "f9bbe5"


### PR DESCRIPTION
Adds a new `aspect: design` label for tracking design work, as discussed in #214.