### PR TITLE
Update CODEOWNERS to maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# All files are owned by the Openverse Developers team
-* @WordPress/openverse-developers
+# All files are owned by the Openverse Maintainers team
+* @WordPress/openverse-maintainers


### PR DESCRIPTION
 Updates the codeowners file to the  `openverse-maintainers` team, since we intend to add all contributors to the `openverse-developers` team and they might not be prepared to review all PRs.