### PR TITLE
Stop syncing CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS_FRONTEND
+++ b/.github/CODEOWNERS_FRONTEND
@@ -1,2 +1,0 @@
-# All files are owned by the Openverse Frontend Developers team
-* @WordPress/openverse-frontend

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -36,18 +36,3 @@ group:
         dest: .github/ISSUE_TEMPLATE/
       - source: .github/PULL_REQUEST_TEMPLATE.md
         dest: .github/PULL_REQUEST_TEMPLATE.md
-  # Frontend repositories
-  - repos: |
-      WordPress/openverse-frontend
-      WordPress/openverse-browser-extension
-    files:
-      - source: .github/CODEOWNERS_FRONTEND
-        dest: .github/CODEOWNERS
-  # Backend repositories
-  - repos: |
-      WordPress/openverse-catalog
-      WordPress/openverse-api
-      WordPress/openverse-infrastructure
-    files:
-      - source: .github/CODEOWNERS
-        dest: .github/CODEOWNERS


### PR DESCRIPTION
Each repository is going to move to being managed by an individual team, so the value in syncing the CODEOWNERS files, which will be unique per-repo, is significantly reduced.

Alternatively, we could track and sync a unique CODEOWNERS file for each repository here, if folks preferred, so they could be updated all at once in the future instead of requiring a discrete PR be made manually for each repo.