### PR TITLE
Auto-subscribe team & Gutenberg design for design issues

### DIFF
--- a/.github/subscribe_to_label.json
+++ b/.github/subscribe_to_label.json
@@ -1,4 +1,8 @@
 {
-  "WordPress/gutenberg-design": ["🖼️ aspect: design"],
-  "WordPress/openverse": ["🖼️ aspect: design"]
+  "WordPress/gutenberg-design": [
+    "\ud83d\uddbc\ufe0f aspect: design"
+  ],
+  "WordPress/openverse": [
+    "\ud83d\uddbc\ufe0f aspect: design"
+  ]
 }

--- a/.github/subscribe_to_label.json
+++ b/.github/subscribe_to_label.json
@@ -1,0 +1,4 @@
+{
+  "WordPress/gutenberg-design": ["🖼️ aspect: design"],
+  "WordPress/openverse": ["🖼️ aspect: design"]
+}

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -26,6 +26,10 @@ group:
         dest: .github/workflows/actionlint.yml
       - source: .github/actionlint-matcher.json
         dest: .github/actionlint-matcher.json
+      - source: .github/workflows/subscribe_to_label.yml
+        dest: .github/workflows/subscribe_to_label.yml
+      - source: .github/subscribe_to_label.json
+        dest: .github/subscribe_to_label.json
       # Downstream workflows
       - source: .github/workflows_downstream/draft_release.yml
         dest: .github/workflows/draft_release.yml

--- a/.github/workflows/subscribe_to_label.yml
+++ b/.github/workflows/subscribe_to_label.yml
@@ -1,0 +1,14 @@
+name: "Subscribe to Label"
+# link: https://github.com/bytecodealliance/subscribe-to-label-action
+
+on:
+  issues:
+    types: ["labeled"]
+
+jobs:
+  subscribe:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: bytecodealliance/subscribe-to-label-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/subscribe_to_label.yml
+++ b/.github/workflows/subscribe_to_label.yml
@@ -9,6 +9,6 @@ jobs:
   subscribe:
     runs-on: ubuntu-latest
     steps:
-    - uses: bytecodealliance/subscribe-to-label-action@v1
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: bytecodealliance/subscribe-to-label-action@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -128,7 +128,7 @@ def get_linked_issues(url: str) -> list[str]:
         return []
 
     soup = BeautifulSoup(text, "html.parser")
-    form = soup.find("form",  **{"aria-label": "Link issues"})
+    form = soup.find("form", **{"aria-label": "Link issues"})
     if form is None:
         return []
     return [a["href"] for a in form.find_all("a")]


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #297 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a new, synced, GitHub action which will automatically @ `WordPress/openverse` and `WordPress/gutenberg-design` for issues that get tagged with "🖼️ aspect: design".

We can always remove or adjust certain groups (or remove the auto-subscribe altogether) down the line if we don't find this helpful :slightly_smiling_face:

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Unfortunately due to the nature of GHA, I'm not sure how to test this without merging it first.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
