### PR TITLE
No longer allow"🚦 status: awaiting triage" label on MRs

### DIFF
--- a/.github/workflows/pr_label_check.yml
+++ b/.github/workflows/pr_label_check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check aspect label
         uses: sugarshin/required-labels-action@v0.3.2
         with:
-          required_oneof: "🚦 status: awaiting triage,💻 aspect: code,📄 aspect: text,🤖 aspect: dx,🕹 aspect: interface,♿️ aspect: a11y"
+          required_oneof: "💻 aspect: code,📄 aspect: text,🤖 aspect: dx,🕹 aspect: interface,♿️ aspect: a11y"
 
   check_goal_label:
     name: Check goal label
@@ -24,7 +24,7 @@ jobs:
       - name: Check goal label
         uses: sugarshin/required-labels-action@v0.3.2
         with:
-          required_oneof: "🚦 status: awaiting triage,🌟 goal: addition,🛠 goal: fix,✨ goal: improvement,🧰 goal: internal improvement"
+          required_oneof: "🌟 goal: addition,🛠 goal: fix,✨ goal: improvement,🧰 goal: internal improvement"
 
   check_priority_label:
     name: Check priority label
@@ -33,4 +33,4 @@ jobs:
       - name: Check priority label
         uses: sugarshin/required-labels-action@v0.3.2
         with:
-          required_oneof: "🚦 status: awaiting triage,🟩 priority: low,🟨 priority: medium,🟧 priority: high,🟥 priority: critical"
+          required_oneof: "🟩 priority: low,🟨 priority: medium,🟧 priority: high,🟥 priority: critical"

--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -128,7 +128,7 @@ def get_linked_issues(url: str) -> list[str]:
         return []
 
     soup = BeautifulSoup(text, "html.parser")
-    form = soup.find("form",  **{"aria-label": "Link issues"})
+    form = soup.find("form", **{"aria-label": "Link issues"})
     if form is None:
         return []
     return [a["href"] for a in form.find_all("a")]


### PR DESCRIPTION
## Fixes

Fixes #311 by @AetherUnbound 

## Description

We can currently open and merge PRs which go entirely unlabeled. This can cause issues with our release notes, since they're sectioned by label ([see the first 2 lines in this set of release notes as an example](https://github.com/WordPress/openverse-api/releases/tag/v2.5.11)).

We should remove them as acceptable options for the PR label check workflow.

## Testing Instructions

After merging, we can create a new MR, which should fail the check if it has the `🚦 status: awaiting triage` label

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
