### PR TITLE
Update lint configs and templates to use double quotes

### DIFF
--- a/.pre-commit-config.frontend.yaml.jinja
+++ b/.pre-commit-config.frontend.yaml.jinja
@@ -50,11 +50,11 @@ Dependencies must be indented by 10 spaces.
 
 {% block eslint_dependencies %}
 {{ super() }}
-          - '@babel/eslint-parser@7.17.0'
-          - '@intlify/eslint-plugin-vue-i18n@1.4.0'
-          - '@nuxtjs/eslint-module@3.1.0'
-          - '@typescript-eslint/eslint-plugin@5.23.0'
-          - '@typescript-eslint/parser@5.23.0'
+          - "@babel/eslint-parser@7.17.0"
+          - "@intlify/eslint-plugin-vue-i18n@1.4.0"
+          - "@nuxtjs/eslint-module@3.1.0"
+          - "@typescript-eslint/eslint-plugin@5.23.0"
+          - "@typescript-eslint/parser@5.23.0"
           - eslint-import-resolver-custom-alias@1.3.0
           - eslint-plugin-eslint-comments@3.2.0
           - eslint-plugin-import@2.26.0

--- a/prettier.config.frontend.js.jinja
+++ b/prettier.config.frontend.js.jinja
@@ -7,6 +7,6 @@
 
 {% block additional_config %}
   vueIndentScriptAndStyle: false,
-  plugins: [require('prettier-plugin-tailwindcss')],
-  tailwindConfig: 'tailwind.config.js',
+  plugins: [require("prettier-plugin-tailwindcss")],
+  tailwindConfig: "tailwind.config.js",
 {% endblock %}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -10,7 +10,7 @@ module.exports = {
   proseWrap: "always",
   overrides: [
     {
-      files: "*.yml",
+      files: ["*.yml", "*.yaml"],
       options: {
         proseWrap: "preserve",
       },

--- a/prettier.config.js.jinja
+++ b/prettier.config.js.jinja
@@ -13,7 +13,7 @@ module.exports = {
   proseWrap: "always",
   overrides: [
     {
-      files: "*.yml",
+      files: ["*.yml", "*.yaml"],
       options: {
         proseWrap: "preserve",
       },


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the lint configs and templates. 

- Uses double quotes in `prettier.config.frontend.js.jinja` as per the new JS rule code style.
- Includes `*.yaml` extension with the YAML rules to match certain files that have the alternate extension.

This PR should prevent automated sync PRs like https://github.com/WordPress/openverse-frontend/pull/2054 from failing their own CI lint checks.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
