### PR TITLE
Add pydocstyle and guide for editing templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,20 @@ repos:
         args:
           - --safe
 
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.2.2 # 6.2.3 is slightly broken
+    hooks:
+      - id: pydocstyle
+        args:
+          - --convention=pep257
+          # Additional ignore reasons:
+          # D1xx: we do not want to force contributors to write redundant or useless docstrings
+          # D202: additional whitespace helps with readability
+          # D211: same as D202
+          # See the following documentation for what each rule does:
+          # https://www.pydocstyle.org/en/6.2.3/error_codes.html#error-codes
+          - --add-ignore=D1,D202,D211
+
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.15.0
     hooks:

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -51,8 +51,7 @@ def get_open_issues_with_prs(
     repo_names: list[str],
 ) -> list[Issue]:
     """
-    From given repos in the given organization, retrieve a list of open issues
-    that have PRs linked to them.
+    Retrieve open issues with linked PRs.
 
     :param gh: the GitHub client
     :param org_handle: the name of the org in which to look for issues
@@ -86,8 +85,9 @@ def get_open_issues_with_prs(
 
 def get_issue_cards(col: ProjectColumn) -> list[tuple[ProjectCard, Issue]]:
     """
-    Get all cards linked to issues in the given column. This excludes cards that
-    either have no links (just notes) or are linked to PRs.
+    Get all cards linked to issues in the given column.
+
+    This excludes cards that either have no links (just notes) or are linked to PRs.
 
     :param col: the project column from which to retrieve issue cards
     :return: the list of cards linked to issues in the given column

--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -81,8 +81,11 @@ def get_pull_request(gh: Github, html_url: str) -> PullRequest:
 
 def get_authenticated_html(url: str) -> str:
     """
-    Login to the GitHub UI using the username and password, followed by 2FA. Then
-    navigate to the specified URL as the authenticated user and scrape the text body.
+    Retrieve HTML for GitHub webpages that require authentication to view.
+
+    Login to the GitHub UI using the username and password, followed by 2FA.
+    Then navigate to the specified URL as the authenticated user and scrape the
+    text body.
 
     :param url: the URL to scrape after authenticating in GitHub
     :return: the text content of the scraped page
@@ -106,9 +109,10 @@ def get_authenticated_html(url: str) -> str:
 
 def get_linked_issues(url: str) -> list[str]:
     """
-    Get the list of linked issues from the GitHub UI by parsing the HTML. This is a
-    workaround because GitHub API does not provide a reliable way to find the linked
-    issues for a PR.
+    Get the list of linked issues from the GitHub UI by parsing the HTML.
+
+    This is a workaround because GitHub API does not provide a reliable way
+    to find the linked issues for a PR.
 
     If the page returns a 404 response, it is assumed that the page belongs to a private
     repository and needs authentication. In these cases, ``get_authenticated_html`` is

--- a/automations/python/models/label.py
+++ b/automations/python/models/label.py
@@ -3,8 +3,11 @@ from shared.data import get_data
 
 
 class Label:
+
     """
-    This model represents a single label. A label is defined by four parameters
+    Represents a single label.
+
+    A label is defined by four parameters:
     - name, which appears on the label
     - description, which describes it in a little more detail
     - emoji, which is a pictorial representation of the purpose of the label
@@ -33,10 +36,11 @@ class Label:
     @property
     def color(self) -> str:
         """
-        Return the color to use on the emoji label, given as a 6-digit
-        hexadecimal code without the prefix '#'. Labels can have their color
-        specified as a constant and if missing inherit color from the parent
-        group. If not resolved, the color defaults to pure black.
+        Get the hex code (sans '#') to use on the emoji label.
+
+        Labels can have their color specified as a constant and if
+        missing inherit color from the parent group. If not resolved,
+        the color defaults to pure black.
 
         :return: the 6-digit hexadecimal code of the background color
         """
@@ -55,10 +59,11 @@ class Label:
     @property
     def qualified_name(self) -> str:
         """
-        Return the fully qualified name of the label. Most label groups prefix
-        the group name to the name of the label, separated by a colon, as
-        indicated by the ``is_prefixed`` attribute on the associated ``Group``
-        instance.
+        Get the fully qualified name of the label.
+
+        Most label groups prefix the group name to the name
+        of the label, separated by a colon, as indicated by the
+        ``is_prefixed`` attribute on the associated ``Group`` instance.
 
         :return: the fully qualified name of the label
         """
@@ -73,6 +78,8 @@ class Label:
     @property
     def emojified_description(self) -> str:
         """
+        Get the label description with emoji prefix.
+
         TODO: Use this when GitHub supports Unicode in label descriptions
         Get the description of the label prefixed with the emoji.
 
@@ -84,8 +91,9 @@ class Label:
     @property
     def api_arguments(self) -> dict[str, str]:
         """
-        Get the dictionary of arguments to pass to the API for creating the
-        label. The API only accepts ``name``, ``color`` and ``description``.
+        Get label creation API parameters.
+
+        The API only accepts ``name``, ``color`` and ``description``.
 
         :return: the API arguments as a dictionary
         """
@@ -98,8 +106,7 @@ class Label:
 
     def __eq__(self, remote: "Label") -> bool:
         """
-        Compare this instance with the corresponding PyGithub instance to
-        determine whether the two are equal.
+        Compare ``self`` with PyGithub label object.
 
         :param remote: the PyGithub label instance to compare itself against
         :return: whether the instance is equal to its remote counterpart
@@ -115,8 +122,7 @@ class Label:
 
     def __ne__(self, remote: "Label") -> bool:
         """
-        Compare this instance with the corresponding PyGithub instance to
-        determine whether the two are unequal and would need to be reconciled.
+        Compare ``self`` with PyGithub label object.
 
         :param remote: the PyGithub label instance to compare itself against
         :return: whether the instance is unequal to its remote counterpart

--- a/automations/python/models/label_group.py
+++ b/automations/python/models/label_group.py
@@ -1,6 +1,3 @@
-# noqa: D100
-
-
 class LabelGroup:
     """
     Represents a group of labels.

--- a/automations/python/models/label_group.py
+++ b/automations/python/models/label_group.py
@@ -19,8 +19,6 @@ class LabelGroup:
         is_required=False,
         **kwargs,
     ):
-        """Initialise LabelGroup."""
-
         self.name = kwargs["name"]
         self.color = color
         self.is_prefixed = is_prefixed

--- a/automations/python/models/label_group.py
+++ b/automations/python/models/label_group.py
@@ -1,6 +1,11 @@
+# noqa: D100
+
+
 class LabelGroup:
     """
-    This model represents a group of labels. A group has some fixed parameters
+    Represents a group of labels.
+
+    A group has some fixed parameters:
     - name, which may be prefixed to all child label names
     - color, which acts as a fallback for child labels that do not specify one
     - is_prefixed, which determines if group name is prefixed on child labels
@@ -14,6 +19,8 @@ class LabelGroup:
         is_required=False,
         **kwargs,
     ):
+        """Initialise LabelGroup."""
+
         self.name = kwargs["name"]
         self.color = color
         self.is_prefixed = is_prefixed

--- a/automations/python/shared/data.py
+++ b/automations/python/shared/data.py
@@ -14,8 +14,9 @@ ROOT_DIR = CURR_FILE.parent.parent.parent
 @cache
 def get_data(file_name: str) -> dict:
     """
-    Access YAML files in the `data/` directory as Python objects. Calls to the
-    function with the same file name will be cached for performance.
+    Access YAML files in the `data/` directory as Python objects.
+
+    Calls to the function with the same file name will be cached for performance.
 
     :param file_name: the name of the YAML file to read
     :return: the contents of the YAML file as a Python object

--- a/automations/python/shared/github.py
+++ b/automations/python/shared/github.py
@@ -9,8 +9,10 @@ log = logging.getLogger(__name__)
 
 def get_client(is_authenticated: bool = True) -> Github:
     """
-    Get a PyGithub client to access the GitHub API. The client can optionally be
-    authenticated using the GITHUB_ACCESS_TOKEN from the environment variables.
+    Get a PyGithub client to access the GitHub API.
+
+    The client can optionally be authenticated using the GITHUB_ACCESS_TOKEN
+    from the environment variables.
 
     :param is_authenticated: whether to authenticate the client
     :return: the PyGithub client

--- a/automations/python/shared/log.py
+++ b/automations/python/shared/log.py
@@ -4,7 +4,9 @@ import os
 
 def configure_logger():
     """
-    Configures the logging module to
+    Configure the logging module.
+
+    Applies the following configuration:
     - change the log level names to lowercase
     - set the formatter that works with GitHub logging commands
     - set the default log level to LOGGING_LEVEL environment variable

--- a/automations/python/sync_labels.py
+++ b/automations/python/sync_labels.py
@@ -35,8 +35,10 @@ def get_labels() -> list[Label]:
 
 def set_labels(repo: Repository, labels: list[Label]):
     """
-    Set the given list of labels on the given repository. Missing labels will
-    be added, but extraneous labels will be left intact.
+    Set the given list of labels on the given repository.
+
+    Missing labels will be added, but extraneous labels will
+    be left intact.
 
     :param repo: the repo in which to set the given labels
     :param labels: the list of labels to define on the repo

--- a/dead_links/dead_link_tally.py
+++ b/dead_links/dead_link_tally.py
@@ -1,4 +1,6 @@
 """
+Retrives dead link tallies from Openverse API Redis.
+
 This script assumes that the API Redis instance you care about is present
 on localhost (usually via tunneling). It will run through the link validation
 entries in Redis.

--- a/justfile
+++ b/justfile
@@ -53,3 +53,10 @@ render-prettier:
 # Render GitHub issue & PR templates
 render-github:
     just render templates/PULL_REQUEST_TEMPLATE.md.jinja .github/PULL_REQUEST_TEMPLATE.md
+
+
+# Render all templates (shortcut for easy iteration)
+render-templates:
+    just render-precommit
+    just render-prettier
+    just render-github

--- a/justfile
+++ b/justfile
@@ -53,8 +53,6 @@ render-prettier:
 # Render GitHub issue & PR templates
 render-github:
     just render templates/PULL_REQUEST_TEMPLATE.md.jinja .github/PULL_REQUEST_TEMPLATE.md
-
-
 # Render all templates (shortcut for easy iteration)
 render-templates:
     just render-precommit

--- a/templates/.pre-commit-config.yaml.jinja
+++ b/templates/.pre-commit-config.yaml.jinja
@@ -70,6 +70,20 @@ repos:
         args:
           - --safe
 
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.2.2 # 6.2.3 is slightly broken
+    hooks:
+      - id: pydocstyle
+        args:
+          - --convention=pep257
+          # Additional ignore reasons:
+          # D1xx: we do not want to force contributors to write redundant or useless docstrings
+          # D202: additional whitespace helps with readability
+          # D211: same as D202
+          # See the following documentation for what each rule does:
+          # https://www.pydocstyle.org/en/6.2.3/error_codes.html#error-codes
+          - --add-ignore=D1,D202,D211
+
   {% endif %}
   {% if contains_js_code | default(true) %}
   - repo: https://github.com/pre-commit/mirrors-eslint

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,27 @@
+# Template workflow
+
+Contributing to the linting templates can be unintuitive at first. If you follow
+the process outlined below, it makes things a _lot_ easier to manage and
+iterate.
+
+## Process for editing jinja templates
+
+1. Make changes to the jinja template
+1. Run `just render-templates` to re-render all templates. This runs pretty
+   quickly but if you need to go even faster, you can run the
+   `render-precommit`, `render-prettier`, or `render-github` recipes instead to
+   render only the specific files you're changing.
+1. Confirm your rendered changes meet prettier's requirements by:
+   1. Staging `.pre-commit-config.yaml` with `git add .pre-commit-config.yaml`
+   1. Run `pre-commit run prettier`
+   1. Run `git diff` to see any differences prettier may have made to the final
+      output
+   - This separate step is necessary because prettier does not lint the jinja
+     files. For the rendered output of the jinja files to pass prettier, the
+     templates themselves must be perfect, so you have to manually push changes
+     that prettier will make into the templates. Often this is stuff like
+     tedious whitespace, line-break, and indentation issues in the YAML or the
+     Markdown templates.
+1. If you had to make changes to appease prettier, follow steps 2 and 3 again
+   and confirm there are no more changes from prettier.
+1. You're done!


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #247 by @krysal

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds `pydocstyle` as a pre-commit hook and configures some ignores with reasons for each ignore embedded in the configuration.

I had to make tweaks to existing documentation to get the style rules to pass. If we don't like these changes, then honestly pydocstyle or any other documentation linting too probably isn't that helpful for us as these kinds of style tweaks are most of what they enforce.

I also added a guide for how best to iterate on template contributions as it's quite tedious to try to do it any other way.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Review the changes and confirm they're acceptable to enforce in our Python code across the board. Confirm CI linting passes.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
