### PR TITLE
Don't run pre-commit on retired files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # - https://github.com/WordPress/openverse/blob/main/.pre-commit-config.yaml.jinja
 # - https://github.com/WordPress/openverse/blob/main/templates/.pre-commit-config.local.yaml.jinja
 
-exclude: Pipfile\.lock|migrations|\.idea|node_modules|archive
+exclude: Pipfile\.lock|migrations|\.idea|node_modules|archive|retired
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/templates/.pre-commit-config.yaml.jinja
+++ b/templates/.pre-commit-config.yaml.jinja
@@ -5,7 +5,7 @@
 {%- endblock %}
 
 {# This comment adds a blank line. #}
-exclude: Pipfile\.lock|migrations|\.idea|node_modules|archive
+exclude: Pipfile\.lock|migrations|\.idea|node_modules|archive|retired
 
 repos:
   {% block repos_top %}


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Small follow up to #363, while working on https://github.com/WordPress/openverse-catalog/pull/963 I noticed that some of the linting is done on the `retired` directory. We really don't need to do that (and I doubt the term `retired` is used or will be used in any of our other python repos) so I've added `retired` to the excluded list at the top level.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out the catalog repo at https://github.com/WordPress/openverse-catalog/pull/963
1. Add `retired` to the `.pre-commit-config.yaml` file as it's shown in this PR
1. Run `just lint` and check that the output doesn't include any references to the `retired` folder

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
