### PR TITLE
Add additional rules to ignore for pydocstyle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,10 +72,12 @@ repos:
           # Additional ignore reasons:
           # D1xx: we do not want to force contributors to write redundant or useless docstrings
           # D202: additional whitespace helps with readability
+          # D205: we don't want to always require a single line summary
           # D211: same as D202
+          # D400: first line doesn't need to end in a period
           # See the following documentation for what each rule does:
           # https://www.pydocstyle.org/en/6.2.3/error_codes.html#error-codes
-          - --add-ignore=D1,D202,D211
+          - --add-ignore=D1,D202,D205,D211,D400
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.15.0

--- a/templates/.pre-commit-config.yaml.jinja
+++ b/templates/.pre-commit-config.yaml.jinja
@@ -79,10 +79,12 @@ repos:
           # Additional ignore reasons:
           # D1xx: we do not want to force contributors to write redundant or useless docstrings
           # D202: additional whitespace helps with readability
+          # D205: we don't want to always require a single line summary
           # D211: same as D202
+          # D400: first line doesn't need to end in a period
           # See the following documentation for what each rule does:
           # https://www.pydocstyle.org/en/6.2.3/error_codes.html#error-codes
-          - --add-ignore=D1,D202,D211
+          - --add-ignore=D1,D202,D205,D211,D400
 
   {% endif %}
   {% if contains_js_code | default(true) %}


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Follow up to discussion in https://github.com/WordPress/openverse-catalog/pull/963 and during the Make WP Slack meeting, this adds two further rules to the list of those we'll be ignoring for pydocstyle. This should be backwards compatible with the changes already made for the API repo.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just lint` passes successfully.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
