### PR TITLE
Addition of "waiting for triage" label in case label_pr.yml fails

### DIFF
--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -25,3 +25,8 @@ jobs:
           client_payload: ${{ format('{{"pr_url":"{0}"}}', env.PR_URL) }}
           wait_time: 5 # check every 5 seconds
           max_time: 120 # timeout after 2 minutes
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ failure() }}
+        with:
+          labels: "🚦 status: awaiting triage"

--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -25,7 +25,7 @@ jobs:
           client_payload: ${{ format('{{"pr_url":"{0}"}}', env.PR_URL) }}
           wait_time: 5 # check every 5 seconds
           max_time: 120 # timeout after 2 minutes
-          
+
       - uses: actions/checkout@v2
       - name: Add default label in case of failure
         uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -25,8 +25,10 @@ jobs:
           client_payload: ${{ format('{{"pr_url":"{0}"}}', env.PR_URL) }}
           wait_time: 5 # check every 5 seconds
           max_time: 120 # timeout after 2 minutes
+          
       - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
-        if: ${{failure()}}
+      - name: Add default label in case of failure
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ failure() }}
         with:
           labels: "🚦 status: awaiting triage"

--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -27,6 +27,6 @@ jobs:
           max_time: 120 # timeout after 2 minutes
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
-        if: ${{ failure() }}
+        if: ${{failure()}}
         with:
           labels: "🚦 status: awaiting triage"

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -37,8 +37,4 @@ jobs:
         run: |
           pipenv run python label_pr.py \
             --pr-url "$PR_URL"
-      - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
-        if: ${{ failure() }}
-        with:
-          labels: "🚦 status: awaiting triage"
+

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -37,3 +37,8 @@ jobs:
         run: |
           pipenv run python label_pr.py \
             --pr-url "$PR_URL"
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ failure() }}
+        with:
+          labels: "Status: awaiting triage"

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -31,6 +31,7 @@ jobs:
           python -m pip install --user --upgrade pip
           python -m pip install --user pipenv
           pipenv install --deploy
+
       - name: Label PR
         working-directory: ./automations/python
         run: |

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -41,4 +41,4 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         if: ${{ failure() }}
         with:
-          labels: "Status: awaiting triage"
+          labels: "🚦 status: awaiting triage"

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -31,10 +31,8 @@ jobs:
           python -m pip install --user --upgrade pip
           python -m pip install --user pipenv
           pipenv install --deploy
-
       - name: Label PR
         working-directory: ./automations/python
         run: |
           pipenv run python label_pr.py \
             --pr-url "$PR_URL"
-


### PR DESCRIPTION
## Fixes



Fixes #338 by @dhruvkb

## Description

<!-- Concisely describe what the pull request does. -->
If the workflow to label new PR fails at any point this applies a "🚦 status: awaiting triage" label to it rather than leaving it unlabelled.
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
