### PR TITLE
fix: Remove references to the unmaintained browser extension

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,7 +8,6 @@ group:
       WordPress/openverse-catalog
       WordPress/openverse-api
       WordPress/openverse-frontend
-      WordPress/openverse-browser-extension
       WordPress/openverse-infrastructure
     files:
       # Synced workflows

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ into individual repositories, and managed via a
   Airflow-powered system for downloading and storing Openverse's metadata
 - [API](https://github.com/wordpress/openverse-api) | The Django REST API for
   querying the catalog data, used by the frontend
-- [Browser extension](https://github.com/wordpress/openverse-browser-extension)
-  | An extension to view Openverse images directly in your web browser
 
 It is possible we will explore a monorepo structure in the future, but since all
 the repos are decoupled from each other and use different technologies, we've

--- a/automations/data/github.yml
+++ b/automations/data/github.yml
@@ -4,5 +4,4 @@ repos:
   catalog: openverse-catalog
   api: openverse-api
   frontend: openverse-frontend
-  extension: openverse-browser-extension
   infra: openverse-infrastructure


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #374 by @dhruvkb

## Description

As the extension isn't maintained and the repo is being archived, all references to the extension repo are to be removed from the codebase to prevent workflows and automations from failing.

## Deleted Occurences
- [x] `README.md` Line 29
[openverse/README.md](https://github.com/WordPress/openverse/blob/6b9ce3a3a75e01e7d776b751cf8e1d871704a430/README.md?plain=1#L29)
```diff
- - [Browser extension](https://github.com/wordpress/openverse-browser-extension) 
```
- [x] `automations/data/github.yml` Line 7
[openverse/automations/data/github.yml](https://github.com/WordPress/openverse/blob/6b9ce3a3a75e01e7d776b751cf8e1d871704a430/automations/data/github.yml#L7)
```diff
- extension: openverse-browser-extension 
```
- [x] `.github/sync.yml` Line 11
[openverse/.github/sync.yml](https://github.com/WordPress/openverse/blob/6b9ce3a3a75e01e7d776b751cf8e1d871704a430/.github/sync.yml#L11)
```diff
- WordPress/openverse-browser-extension 
```

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
