### PR TITLE
Match frontend linting dependency versions to frontend/pull/2121

### DIFF
--- a/templates/.pre-commit-config.frontend.yaml.jinja
+++ b/templates/.pre-commit-config.frontend.yaml.jinja
@@ -50,23 +50,24 @@ Dependencies must be indented by 10 spaces.
 
 {% block eslint_dependencies %}
 {{ super() }}
-          - "@babel/eslint-parser@7.17.0"
+          - "@babel/eslint-parser@7.19.1"
           - "@intlify/eslint-plugin-vue-i18n@1.4.0"
           - "@nuxtjs/eslint-module@3.1.0"
-          - "@typescript-eslint/eslint-plugin@5.23.0"
-          - "@typescript-eslint/parser@5.23.0"
+          - "@typescript-eslint/eslint-plugin@5.44.0"
+          - "@typescript-eslint/parser@5.44.0"
+          - eslint-config-prettier@8.6.0
           - eslint-import-resolver-custom-alias@1.3.0
           - eslint-plugin-eslint-comments@3.2.0
-          - eslint-plugin-import@2.26.0
-          - eslint-plugin-prettier@4.0.0
-          - eslint-plugin-tsdoc@0.2.16
+          - eslint-plugin-import@2.27.5
+          - eslint-plugin-prettier@4.2.1
+          - eslint-plugin-tsdoc@0.2.17
           - eslint-plugin-unicorn@42.0.0
-          - eslint-plugin-vue@9.4.0
+          - eslint-plugin-vue@9.9.0
           - eslint-plugin-vuejs-accessibility@1.1.1
 {%- endblock %}
 
 {% block prettier_dependencies %}
 {{ super() }}
-          - prettier-plugin-tailwindcss@0.1.12
-          - typescript@4.6.2
+          - prettier-plugin-tailwindcss@0.2.2
+          - typescript@4.9.3
 {%- endblock %}


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR updates the dependency versions for linting dependencies to match the current versions and the ones updated in https://github.com/WordPress/openverse-frontend/pull/2121

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
