### PR TITLE
Fix project automation logic around closed PRs

### DIFF
--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -45,7 +45,7 @@ jobs:
           pipenv run python issues_with_prs.py \
           --project-number 3 \
           --source-column "To do" \
-          --target-column "In progress" \ 
+          --target-column "In progress" \
           --linked-pr-state "open"
 
       - name: Move issues from "Backlog"

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -36,7 +36,8 @@ jobs:
           pipenv run python issues_with_prs.py \
           --project-number 3 \
           --source-column "To do" \
-          --target-column "In progress"
+          --target-column "In progress" \ 
+          --linked-pr-state "open"
 
       - name: Move issues from "Backlog"
         working-directory: ./automations/python
@@ -44,4 +45,14 @@ jobs:
           pipenv run python issues_with_prs.py \
           --project-number 3 \
           --source-column "Backlog" \
-          --target-column "In progress"
+          --target-column "In progress" \
+          --linked-pr-state "open"
+
+      - name: Move stale issues from "In progress"
+        working-directory: ./automations/python
+        run: |
+          pipenv run python issues_with_prs.py \
+          --project-number 3 \
+          --source-column "In progress" \
+          --target-column "Backlog" \
+          --linked-pr-state "closed"

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -30,6 +30,15 @@ jobs:
           python -m pip install --user pipenv
           pipenv install --deploy
 
+      - name: Move stale issues from "In progress"
+        working-directory: ./automations/python
+        run: |
+          pipenv run python issues_with_prs.py \
+          --project-number 3 \
+          --source-column "In progress" \
+          --target-column "Backlog" \
+          --linked-pr-state "closed"
+
       - name: Move issues from "To do"
         working-directory: ./automations/python
         run: |
@@ -47,12 +56,3 @@ jobs:
           --source-column "Backlog" \
           --target-column "In progress" \
           --linked-pr-state "open"
-
-      - name: Move stale issues from "In progress"
-        working-directory: ./automations/python
-        run: |
-          pipenv run python issues_with_prs.py \
-          --project-number 3 \
-          --source-column "In progress" \
-          --target-column "Backlog" \
-          --linked-pr-state "closed"

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -134,7 +134,7 @@ def get_open_issues_with_prs(
         }
         log.info(f"Found {len(issues)} issues")
         for number, title in issues.items():
-            log.info(f"• #{number} | {title}")
+            log.info(f"• #{number: >5} | {title}")
             all_issues.add((repo_name, number))
 
     log.info(

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import sys
+from collections import defaultdict
 
 from github import Github, GithubException, Issue, ProjectCard, ProjectColumn
 from shared.data import get_data
@@ -40,7 +41,19 @@ parser.add_argument(
     default="In progress",
     help="column in which to move cards containing issues with PRs",
 )
+parser.add_argument(
+    "--linked-pr-state",
+    dest="linked_pr_state",
+    metavar="linked-pr-state",
+    type=str,
+    default="open",
+    help="filter issues by this state of their linked PRs",
+)
 
+# TODO: Add a new argument, which is like "closed PRs" or something which tells the
+# TODO: script logic to only filter down to issues with linked PRs which are closed.
+# TODO: The rest of the logic can be the same because we're just moving issue from
+# TODO: one column to another
 
 # endregion
 
@@ -49,6 +62,7 @@ def get_open_issues_with_prs(
     gh: Github,
     org_handle: str,
     repo_names: list[str],
+    linked_pr_state: str,
 ) -> list[Issue]:
     """
     Retrieve open issues with linked PRs.
@@ -56,10 +70,11 @@ def get_open_issues_with_prs(
     :param gh: the GitHub client
     :param org_handle: the name of the org in which to look for issues
     :param repo_names: the name of the repos in which to look for issues
+    :param linked_pr_state: the state of the linked PRs to filter by
     :return: the list of open issues with linked PRs
     """
 
-    all_issues = []
+    issues_by_repo = {}
     for repo_name in repo_names:
         log.info(f"Looking for issues with PRs in {org_handle}/{repo_name}")
         issues = gh.search_issues(
@@ -77,7 +92,40 @@ def get_open_issues_with_prs(
         log.info(f"Found {len(issues)} issues")
         for issue in issues:
             log.info(f"• #{issue.number} | {issue.title}")
-        all_issues += issues
+        issues_by_repo[repo_name] = issues
+
+    # Have to either make individual queries per-PR or search by PR ID. Problem with the
+    # latter is that it also returns PRs which reference the number inside it.
+    # So we will further have to filter out PRs which are returned from the search but
+    # are not in any of the PRs supplied
+    # Extract the PR ID
+    # FIXME: This doesn't work because the pull request key is only available for pull requests actually
+    pr_mapping: dict[str, dict[str, Issue]] = {
+        repo_name: {issue.pull_request.html_url.rsplit("/", 1)[-1]: issue for issue in issues}
+        for repo_name, issues in issues_by_repo.items()
+    }
+    all_issues = []
+    for repo_name, pr_issue_mapping in pr_mapping.items():
+        pr_ids = set(pr_issue_mapping.keys())
+        log.info(
+            f"Looking for {linked_pr_state} PRs with the following IDs in "
+            f"{org_handle}/{repo_name}: {pr_ids}"
+        )
+        prs = gh.search_issues(
+            query=" ".join(pr_ids),
+            sort="updated",
+            order="desc",
+            **{
+                "repo": f"{org_handle}/{repo_name}",
+                "is": "pr",
+                "state": linked_pr_state,
+            },
+        )
+        # Ensure PR actually *is* within the listed IDs rather than just referencing it
+        prs = [pr for pr in prs if pr.number in pr_ids]
+        # Match PRs back to issues
+        for pr in prs:
+            all_issues.append(pr_issue_mapping[str(pr.number)])
 
     log.info(f"Found a total of {len(all_issues)} open issues with linked PRs")
     return all_issues
@@ -114,6 +162,7 @@ def main():
     log.debug(f"Project number: {args.proj_number}")
     log.debug(f"Source column name: {args.source_col_name}")
     log.debug(f"Target column name: {args.target_col_name}")
+    log.debug(f"Linked issue PR state: {args.linked_pr_state}")
 
     github_info = get_data("github.yml")
     org_handle = github_info["org"]
@@ -128,6 +177,7 @@ def main():
         gh=gh,
         org_handle=org_handle,
         repo_names=repo_names,
+        linked_pr_state=args.linked_pr_state,
     )
     if len(issues_with_prs) == 0:
         log.warning("Found no issues with PRs, stopping")
@@ -150,7 +200,7 @@ def main():
 
     for (issue_card, issue) in cards_to_move:
         log.info(f"Moving card for issue {issue.html_url} to {target_column.name}")
-        issue_card.move("bottom", target_column)
+        # issue_card.move("bottom", target_column)
 
 
 if __name__ == "__main__":

--- a/automations/python/shared/github.py
+++ b/automations/python/shared/github.py
@@ -7,6 +7,19 @@ from github import Github
 log = logging.getLogger(__name__)
 
 
+def get_access_token() -> str:
+    """
+    Get the GitHub access token from the environment variables.
+
+    :return: the GitHub access token
+    """
+    access_token: str | None = os.getenv("ACCESS_TOKEN")
+    if access_token is None:
+        log.error("Access token was not found in env.ACCESS_TOKEN.")
+        raise ValueError("Access token not found")
+    return access_token
+
+
 def get_client(is_authenticated: bool = True) -> Github:
     """
     Get a PyGithub client to access the GitHub API.
@@ -20,10 +33,7 @@ def get_client(is_authenticated: bool = True) -> Github:
 
     log.info("Setting up GitHub client")
     if is_authenticated:
-        access_token: str | None = os.getenv("ACCESS_TOKEN")
-        if access_token is None:
-            log.error("Access token was not found in env.ACCESS_TOKEN.")
-            raise ValueError("Access token not found")
+        access_token = get_access_token()
     else:
         log.debug("Generating a non-authenticated client")
         access_token = None


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #276 by @krysal

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR changes the project automation to make it more adaptive to closed PRs. Due to limitations of the GitHub REST API, the previous implementation was only able to check if an issue _had an associated PR at all_; it was not able to check what state the linked PR was in. The PR information isn't returned in the response either, so there was no way to even match linked PRs with issues using the REST API. This meant that cards with linked, closed PRs were also unconditionally moved. Even if we were to move the stale cards from "In progress" to the "Backlog" column, the next run of the project automation would move them back to "In progress".

Instead, I opted to use the GraphQL API which allows for a bit more configuration. The new query is against PRs (rather than issues), and gathers all PRs _in a particular state_ along with any linked issues. This allows us to only query for open PRs when we want to move something to "In progress", and query for closed PRs when looking to move something back into the "Backlog".

Here's the log output from a local run:

```
::info::[shared.data] Reading file /home/madison/git-a8c/openverse/automations/data/github.yml
::info::[__main__] Organization handle: WordPress
::info::[__main__] Repository names: openverse, openverse-catalog, openverse-api, openverse-frontend, openverse-infrastructure
::info::[shared.github] Setting up GitHub client
::info::[__main__] Looking for closed PRs in WordPress/openverse with linked issues
::info::[__main__] Found 7 PRs in WordPress/openverse
::info::[__main__] Found 2 issues
::info::[__main__] • #276 | Omit issues with closed PRs of moving to the "In Progress" column in the project board
::info::[__main__] • #154 | Add `sentry` label for issues originating from a Sentry report
::info::[__main__] Looking for closed PRs in WordPress/openverse-catalog with linked issues
::info::[__main__] Found 46 PRs in WordPress/openverse-catalog
::info::[__main__] Found 15 issues
::info::[__main__] • #989 | Remove "Implementation" section from issue templates
::info::[__main__] • #954 | Increase Europeana reingestion timeout
::info::[__main__] • #935 | Replace `execution_date` with `logical_date`
::info::[__main__] • #829 | PT-BR translation for README.md
::info::[__main__] • #846 | Retire Common Crawl DAGs
::info::[__main__] • #734 | Truncate data refresh percent change report to 3 digits after the decimal
::info::[__main__] • #511 | Ensure that all media have `license_url` in `meta_data` field
::info::[__main__] • #564 | Elasticsearch metrics reporting DAG
::info::[__main__] • #166 | [Infrastructure] Simplify the TSV to Postgres loading process
::info::[__main__] • #121 | [Feature] Add 'category' field to the image database
::info::[__main__] • #191 | [API Integration] Example WordPress REST API Photo Directory
::info::[__main__] • #182 | [Feature] Stocksnap Popularity
::info::[__main__] • #51 | [API Integration - AUDIO] Jamendo (original #345)
::info::[__main__] • #101 | [Bug] Fix flake8 warnings
::info::[__main__] • #96 | [Bug] CI linting and testing jobs are run twice
::info::[__main__] Looking for closed PRs in WordPress/openverse-api with linked issues
::info::[__main__] Found 100 PRs in WordPress/openverse-api
::info::[__main__] Found 14 issues
::info::[__main__] • #1109 | [Feature] Use metadata keywords to help detect if something is NSFW (original #482)
::info::[__main__] • #713 | Remove the `tags` and `URL` cleanup process from the ingestion server
::info::[__main__] • #896 | Use `thumbnail_url` for thumbnail generation when present
::info::[__main__] • #1046 | Make dependabot update github actions
::info::[__main__] • #845 | `MEDIA_INDEX_MAPPING` not retrievable from settings
::info::[__main__] • #401 | Pagination unit tests
::info::[__main__] • #1042 | Remove resendverificationemails command and tests
::info::[__main__] • #952 | `just` command to list services and their ports
::info::[__main__] • #843 | Remove `get_api_exception` and replace with built in DRF exceptions
::info::[__main__] • #698 | Use `terms` instead of `term`
::info::[__main__] • #828 | Loop code is always running ingestion for images thrice
::info::[__main__] • #692 | Dev doc preview should only be run on maintainer PRs
::info::[__main__] • #775 | Add additional logging around search_controller's ES query building
::info::[__main__] • #558 | Define categories as constants
::info::[__main__] Looking for closed PRs in WordPress/openverse-frontend with linked issues
::info::[__main__] Found 100 PRs in WordPress/openverse-frontend
::info::[__main__] Found 33 issues
::info::[__main__] • #2010 | Minimize the use of JS for layout in the VAudioTrack component
::info::[__main__] • #2047 | Refactor recent searches to reduce code duplication
::info::[__main__] • #2150 | The header is not fixed when scrolling to bottom
::info::[__main__] • #1855 | The external link should disclose to the screenreaders that it opens in a new tab 
::info::[__main__] • #2013 | Update header internal to use a popover between `sm` and `md`
::info::[__main__] • #1752 | initialFocus did not return a node
::info::[__main__] • #1970 | Replace the border color in the LanguageSelect
::info::[__main__] • #1937 | Replace deprecated `set-output` command 
::info::[__main__] • #1894 | Add accessible button components for mobile searchbar
::info::[__main__] • #887 | Add required `aria-label` prop to VIconButton
::info::[__main__] • #1600 | AudioElement.play()'s promise is not properly handled when erroring
::info::[__main__] • #1605 | `NotSupportedError: The operation is not supported` raised in audio search in blink browsers (Safari + Chrome)
::info::[__main__] • #1656 | Attribution box does not show for some results when navigating to them from search results page
::info::[__main__] • #1197 | Rename "Meta Search" to "External Sources"
::info::[__main__] • #1617 | Correct heading order for the Sources page
::info::[__main__] • #1612 | Playwright - ar.json Missing 
::info::[__main__] • #1587 | Incorrect text styles in metadata information
::info::[__main__] • #1026 | Convert `usage-data` store from Vuex to Pinia
::info::[__main__] • #1329 | Try `dprint`
::info::[__main__] • #631 | Content switcher with Audio as beta and Video as Meta search
::info::[__main__] • #1456 | Sources filter choices don't display on client-side render
::info::[__main__] • #959 | Add types to `composables/use-pages.js`
::info::[__main__] • #1235 | Audio search result page non-interactive if there are fewer than 20 results
::info::[__main__] • #1086 | Outdated dependencies
::info::[__main__] • #400 | Dependencies are miscategorized as `devDependencies`
::info::[__main__] • #1025 | Convert `user` store from Vuex to Pinia
::info::[__main__] • #1104 | Replace `lodash.debounce` and `lodash.throttle` with `throttle-debounce`
::info::[__main__] • #830 | Rename getters that have the same name as state properties in Vuex stores
::info::[__main__] • #442 | Configure Dependabot using a YAML config file
::info::[__main__] • #1090 | Create `VContentPage` component
::info::[__main__] • #1110 | Fix play/pause button focus outline placement
::info::[__main__] • #596 | Redirect /search/ page to the Openverse homepage
::info::[__main__] • #875 | Pages menu lacks focus styles
::info::[__main__] Looking for closed PRs in WordPress/openverse-infrastructure with linked issues
::info::[__main__] Found 10 PRs in WordPress/openverse-infrastructure
::info::[__main__] Found 2 issues
::info::[__main__] • #385 | Update API key for Brooklyn Museum
::info::[__main__] • #197 | Gracefully handle frontend task failures
::info::[__main__] Found a total of 66 open issues with linked closed PRs
::info::[shared.project] Getting project 3 in org WordPress
::info::[__main__] Found project: Openverse
::info::[shared.project] Getting column In progress in project Openverse
::info::[shared.project] Getting column Backlog in project Openverse
::info::[__main__] Found 13 cards to move
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-api/issues/713 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-frontend/issues/1855 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-frontend/issues/2047 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-api/issues/1109 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-catalog/issues/989 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-api/issues/896 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-api/issues/952 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-catalog/issues/734 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-catalog/issues/935 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-api/issues/401 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-frontend/issues/887 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse-catalog/issues/511 to Backlog
::info::[__main__] Moving card for issue https://github.com/WordPress/openverse/issues/276 to Backlog
```

While the details and accuracy of this log are sure to change as we continue working on PRs, it's notable that at the time of writing, all of the cards moved in this case did have closed PRs attached to them.

There's also a potential case where an issue has both closed and open PRs linked to it - in order to handle this appropriately I put the closed PR check before the open PR checks. This means that the card will get moved twice, but it seemed easier than cross referencing each PR. I suppose this has the possibility of clogging up the issue timeline with useless events, that's something we can revisit down the road if we feel it's a problem.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This can be tested locally by running `ACCESS_TOKEN=<redacted> LOGGING_LEVEL=20 python issues_with_prs.py --project-number 3 --source-column "In progress" --target-column "Backlog" --linked-pr-state closed`.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
