### PR TITLE
Fix authenticated logins for the label PR action

### DIFF
--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -101,7 +101,7 @@ def get_authenticated_html(url: str) -> str:
         browser.submit()
 
         browser.select_form(nr=0)  # focus on the first (and only) form on the page
-        browser.form["otp"] = pyotp.TOTP(os.getenv("GH_2FA_SECRET")).now()
+        browser.form["app_otp"] = pyotp.TOTP(os.getenv("GH_2FA_SECRET")).now()
         browser.submit()
     except mechanize.ControlNotFoundError as err:
         form_name = err.args[0].replace("no control matching name ", "").strip("'")

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -65,8 +65,8 @@ relevant step of the process is complete.
 
 ## Providing project updates
 
-At all stages of a project (except for `Not Started` projects), fortnightly public
-updates are the best way for Openverse contributors and maintainers to
+At all stages of a project (except for `Not Started` projects), fortnightly
+public updates are the best way for Openverse contributors and maintainers to
 understand the health of a project. Importantly, these updates allow us to
 allocate more time or material resources to projects that need them before work
 stalls completely.


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Recent runs of the `label_pr` action were failing, but _only against the infra repo_ with the following exception:

```
Traceback (most recent call last):
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 104, in get_authenticated_html
    browser.form["otp"] = pyotp.TOTP(os.getenv("GH_2FA_SECRET")).now()
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 1963, in __setitem__
    control = self.find_control(name)
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 2355, in find_control
    return self._find_control(name, type, kind, id, label, predicate, nr)
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 2448, in _find_control
    raise ControlNotFoundError("no control matching " + description)
mechanize._form_controls.ControlNotFoundError: no control matching name 'otp'
```

After doing some digging, it appears that this is because the OTP login form's input field name changed from `otp` to `app_otp`. I've added a more specific exception message for if this happens in the future:

```
Traceback (most recent call last):
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 104, in get_authenticated_html
    browser.form["otp"] = pyotp.TOTP(os.getenv("GH_2FA_SECRET")).now()
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 1963, in __setitem__
    control = self.find_control(name)
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 2355, in find_control
    return self._find_control(name, type, kind, id, label, predicate, nr)
  File "/home/madison/.local/share/virtualenvs/python-d7ZGB4cT/lib/python3.10/site-packages/mechanize/_form_controls.py", line 2448, in _find_control
    raise ControlNotFoundError("no control matching " + description)
mechanize._form_controls.ControlNotFoundError: no control matching name 'otp'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 206, in <module>
    main()
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 182, in main
    linked_issues = get_linked_issues(pr.html_url)
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 134, in get_linked_issues
    text = get_authenticated_html(url)
  File "/home/madison/git-a8c/openverse/automations/python/label_pr.py", line 108, in get_authenticated_html
    raise ValueError(
ValueError: Unable to locate form 'otp' on login page, perhaps its name has changed?
```

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The new script has worked to successfully label https://github.com/WordPress/openverse-infrastructure/pull/375 !

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
