### PR TITLE
Remove front matter from project proposal template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/project_proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/project_proposal.md
@@ -1,10 +1,3 @@
----
-name: Project Proposal
-about: A suggestion for a new project to work on
-labels: "💬 talk: discussion"
-title: "<Replace this with actual title>"
----
-
 ## Due date:
 
 <!--


### PR DESCRIPTION
Apparently PR templates don't use yaml frontmatter in the same way issue templates do. 