### PR TITLE
Don't move issues back & forth in project, reduce API calls for project automation

### DIFF
--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -114,11 +114,12 @@ def get_pulls_with_linked_issues(
     org_handle: str, repo_name: str, state: IssueState
 ) -> dict[str, str]:
     """
+    Query all the pull requests with issues of a linked state.
 
-    :param org_handle:
-    :param repo_name:
-    :param state:
-    :return:
+    This uses the GraphQL API since the REST API doesn't support querying for linked
+    issues.
+
+    :return: a dict of issue numbers to issue titles
     """
     results = run_query(LINKED_PR_QUERY % (org_handle, repo_name, state.upper()))
     pulls = results["repository"]["pullRequests"]["nodes"]
@@ -156,6 +157,7 @@ def get_open_issues_with_prs(
         # In the case where we're querying for closed PRs, we'll also need to consider
         # open PRs - if there's an issue with both an open PR and a closed PR, we should
         # not take any action on it
+        open_issues = {}
         if linked_pr_state == CLOSED:
             open_issues = get_pulls_with_linked_issues(org_handle, repo_name, OPEN)
 

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -5,7 +5,7 @@ import sys
 from typing import Literal
 
 import requests
-from github import Github, GithubException, Issue, ProjectCard, ProjectColumn
+from github import Github, ProjectCard, ProjectColumn
 from shared.data import get_data
 from shared.github import get_access_token, get_client
 from shared.log import configure_logger
@@ -165,9 +165,7 @@ def get_open_issues_with_prs(
         for number, title in issues.items():
             log.info(f"• #{number: >5} | {title}")
             if linked_pr_state == CLOSED and number in open_issues:
-                log.info(
-                    f"{' ' * 11}(skipped because there's an open PR)"
-                )
+                log.info(f"{' ' * 11}(skipped because there's an open PR)")
                 continue
             all_issues.add((repo_name, number))
 

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -161,13 +161,12 @@ def get_open_issues_with_prs(
 
         log.info(f"Found {len(issues)} issues")
         for number, title in issues.items():
+            log.info(f"• #{number: >5} | {title}")
             if linked_pr_state == CLOSED and number in open_issues:
                 log.info(
-                    f"• #{number: >5} | {title} "
-                    f"(skipped because there's an open PR)"
+                    f"{' ' * 11}(skipped because there's an open PR)"
                 )
                 continue
-            log.info(f"• #{number: >5} | {title}")
             all_issues.add((repo_name, number))
 
     log.info(


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR addresses two issues we've been seeing with the project automation.

The first is the direct result of #396, wherein the moving back and forth of issues between columns completely pollutes an issue's timeline (for an example, see https://github.com/WordPress/openverse-catalog/issues/935). This was resolved by making an additional call to prevent taking any action on closed PRs where the issue also has an open PR. This will thus leave issues in the "In progress" column rather than move them back to the "Backlog" (only for a subsequent call to move them from the "Backlog" to "In progress").

The second issue is that we've been hitting our API rate limit pretty consistently. I determined that this was because we were calling `get_content()` on each card of the 600+ cards on the project board. Ever time this python script is run it would rack up at least 600 calls, and we went from calling it twice every 15 minutes to three times every 15 minutes as the result of #396. The new implementation instead derives the issue number (all that's needed for our check) from the card's `content_url`. This was something I found from poking around in the API, it's certainly possible that it'll be inconsistent or won't match our expectations. That said, it's better than hitting our rate limit and we're perhaps going to be moving away from the "classic" project board anyway, in which case we can use some of the automations that GitHub has directly built in.

> **Note**
> The [project automation action](https://github.com/WordPress/openverse/actions/workflows/project_automation.yml) is currently disabled until this is merged to prevent further limit breaking.

Here's an example of the script skipping the move of a few cards:

```
::info::[shared.data] Reading file /home/madison/git-a8c/openverse/automations/data/github.yml
::info::[__main__] Organization handle: WordPress
::info::[__main__] Repository names: openverse, openverse-catalog, openverse-api, openverse-frontend, openverse-infrastructure
::info::[shared.github] Setting up GitHub client
::info::[__main__] Looking for closed PRs in WordPress/openverse with linked issues
::info::[__main__] Found 17 closed PRs in WordPress/openverse
::info::[__main__] Found 9 open PRs in WordPress/openverse
::info::[__main__] Found 3 issues
::info::[__main__] • #  693 | API Docs Guides root page is empty
::info::[__main__] • #  276 | Omit issues with closed PRs of moving to the "In Progress" column in the project board
::info::[__main__] • #  154 | Add `sentry` label for issues originating from a Sentry report
::info::[__main__] Looking for closed PRs in WordPress/openverse-catalog with linked issues
::info::[__main__] Found 47 closed PRs in WordPress/openverse-catalog
::info::[__main__] Found 11 open PRs in WordPress/openverse-catalog
::info::[__main__] Found 15 issues
::info::[__main__] • #  935 | Replace `execution_date` with `logical_date`
::info::[__main__] • #  989 | Remove "Implementation" section from issue templates
::info::[__main__]            (skipped because there's an open PR)
::info::[__main__] • #  954 | Increase Europeana reingestion timeout
::info::[__main__] • #  829 | PT-BR translation for README.md
::info::[__main__] • #  846 | Retire Common Crawl DAGs
::info::[__main__] • #  734 | Truncate data refresh percent change report to 3 digits after the decimal
::info::[__main__] • #  511 | Ensure that all media have `license_url` in `meta_data` field
::info::[__main__] • #  564 | Elasticsearch metrics reporting DAG
::info::[__main__] • #  166 | [Infrastructure] Simplify the TSV to Postgres loading process
::info::[__main__] • #  121 | [Feature] Add 'category' field to the image database
::info::[__main__] • #  191 | [API Integration] Example WordPress REST API Photo Directory
::info::[__main__] • #  182 | [Feature] Stocksnap Popularity
::info::[__main__] • #   51 | [API Integration - AUDIO] Jamendo (original #345)
::info::[__main__] • #  101 | [Bug] Fix flake8 warnings
::info::[__main__] • #   96 | [Bug] CI linting and testing jobs are run twice
::info::[__main__] Looking for closed PRs in WordPress/openverse-api with linked issues
::info::[__main__] Found 100 closed PRs in WordPress/openverse-api
::info::[__main__] Found 4 open PRs in WordPress/openverse-api
::info::[__main__] Found 14 issues
::info::[__main__] • #  750 | [Feature] Use metadata keywords to help detect if something is NSFW (original #482)
::info::[__main__] • #  742 | Pagination unit tests
::info::[__main__] • #  700 | Remove the `tags` and `URL` cleanup process from the ingestion server
::info::[__main__] • #  689 | Add additional logging around search_controller's ES query building
::info::[__main__] • # 1042 | Remove resendverificationemails command and tests
::info::[__main__] • #  675 | Use `thumbnail_url` for thumbnail generation when present
::info::[__main__]            (skipped because there's an open PR)
::info::[__main__] • #  667 | `just` command to list services and their ports
::info::[__main__] • # 1046 | Make dependabot update github actions
::info::[__main__] • #  845 | `MEDIA_INDEX_MAPPING` not retrievable from settings
::info::[__main__] • #  843 | Remove `get_api_exception` and replace with built in DRF exceptions
::info::[__main__] • #  698 | Use `terms` instead of `term`
::info::[__main__] • #  828 | Loop code is always running ingestion for images thrice
::info::[__main__] • #  692 | Dev doc preview should only be run on maintainer PRs
::info::[__main__] • #  558 | Define categories as constants
::info::[__main__] Looking for closed PRs in WordPress/openverse-frontend with linked issues
::info::[__main__] Found 100 closed PRs in WordPress/openverse-frontend
::info::[__main__] Found 4 open PRs in WordPress/openverse-frontend
::info::[__main__] Found 33 issues
::info::[__main__] • #   75 | Update URL metadata to reflect rebranding to Openverse
::info::[__main__] • #  618 | Add required `aria-label` prop to VIconButton
::info::[__main__] • # 1090 | Create `VContentPage` component
::info::[__main__] • #  496 | The external link should disclose to the screenreaders that it opens in a new tab 
::info::[__main__] • #  480 | Refactor recent searches to reduce code duplication
::info::[__main__] • # 2010 | Minimize the use of JS for layout in the VAudioTrack component
::info::[__main__] • # 2150 | The header is not fixed when scrolling to bottom
::info::[__main__] • # 2013 | Update header internal to use a popover between `sm` and `md`
::info::[__main__] • # 1752 | initialFocus did not return a node
::info::[__main__] • # 1970 | Replace the border color in the LanguageSelect
::info::[__main__] • # 1937 | Replace deprecated `set-output` command 
::info::[__main__] • # 1894 | Add accessible button components for mobile searchbar
::info::[__main__] • # 1600 | AudioElement.play()'s promise is not properly handled when erroring
::info::[__main__] • # 1605 | `NotSupportedError: The operation is not supported` raised in audio search in blink browsers (Safari + Chrome)
::info::[__main__] • # 1656 | Attribution box does not show for some results when navigating to them from search results page
::info::[__main__] • # 1197 | Rename "Meta Search" to "External Sources"
::info::[__main__] • # 1617 | Correct heading order for the Sources page
::info::[__main__] • # 1612 | Playwright - ar.json Missing 
::info::[__main__] • # 1587 | Incorrect text styles in metadata information
::info::[__main__] • # 1026 | Convert `usage-data` store from Vuex to Pinia
::info::[__main__] • # 1329 | Try `dprint`
::info::[__main__] • #  631 | Content switcher with Audio as beta and Video as Meta search
::info::[__main__] • # 1456 | Sources filter choices don't display on client-side render
::info::[__main__] • #  959 | Add types to `composables/use-pages.js`
::info::[__main__] • # 1235 | Audio search result page non-interactive if there are fewer than 20 results
::info::[__main__] • # 1086 | Outdated dependencies
::info::[__main__] • #  400 | Dependencies are miscategorized as `devDependencies`
::info::[__main__] • # 1025 | Convert `user` store from Vuex to Pinia
::info::[__main__] • # 1104 | Replace `lodash.debounce` and `lodash.throttle` with `throttle-debounce`
::info::[__main__] • #  830 | Rename getters that have the same name as state properties in Vuex stores
::info::[__main__] • #  442 | Configure Dependabot using a YAML config file
::info::[__main__] • # 1110 | Fix play/pause button focus outline placement
::info::[__main__] • #  596 | Redirect /search/ page to the Openverse homepage
::info::[__main__] Looking for closed PRs in WordPress/openverse-infrastructure with linked issues
::info::[__main__] Found 10 closed PRs in WordPress/openverse-infrastructure
::info::[__main__] Found 5 open PRs in WordPress/openverse-infrastructure
::info::[__main__] Found 2 issues
::info::[__main__] • #  385 | Update API key for Brooklyn Museum
::info::[__main__] • #  197 | Gracefully handle frontend task failures
::info::[__main__] Found a total of 65 open issues with linked closed PRs
::info::[shared.project] Getting project 3 in org WordPress
::info::[__main__] Found project: Openverse
::info::[shared.project] Getting column In progress in project Openverse
::info::[shared.project] Getting column Backlog in project Openverse
::info::[__main__] Found 0 cards to move
```

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This can be run locally, after activating the environment with `pipenv shell` and setting the `ACCESS_TOKEN` variable, by running: `LOGGING_LEVEL=20 python issues_with_prs.py --project-number 3 --source-column "In progress" --target-column "Backlog" --linked-pr-state closed`.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
