### PR TITLE
Update home link screen reader text

### DIFF
--- a/frontend/src/components/VHeader/VHomeLink.vue
+++ b/frontend/src/components/VHeader/VHomeLink.vue
@@ -4,7 +4,10 @@
     class="flex items-stretch rounded-sm focus-visible:outline-none focus-visible:ring focus-visible:ring-pink focus-visible:ring-offset-1 focus-visible:ring-offset-tx"
     :class="variant === 'dark' ? 'text-dark-charcoal' : 'text-white'"
   >
-    <VBrand :is-fetching="false" :sr-text="$t('header.home-link').toString()" />
+    <VBrand
+      :is-fetching="false"
+      :sr-text="$t('header.home-link', { openverse: 'Openverse' }).toString()"
+    />
   </VLink>
 </template>
 

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -28,7 +28,7 @@
     },
   },
   header: {
-    "home-link": "Home",
+    "home-link": "{openverse} Home",
     "about-nav-item": "Our Story",
     "source-nav-item": "Sources",
     "search-guide-nav-item": "Search Guide",

--- a/frontend/test/playwright/e2e/header-internal.spec.ts
+++ b/frontend/test/playwright/e2e/header-internal.spec.ts
@@ -84,7 +84,9 @@ test.describe("Header internal", () => {
       const homeUrl = page.url()
       await clickMenuButton(page)
       await page.getByRole("link", { name: t("navigation.about") }).click()
-      await page.getByRole("link", { name: t("header.home-link") }).click()
+      // "Openverse Home" is hardcoded because our translation helper
+      // doesn't support named interpolation.
+      await page.getByRole("link", { name: "Openverse Home" }).click()
       expect(page.url()).toBe(homeUrl)
     })
   })


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #448

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Updates the text for screen readers from "Home" to "Openverse Home" on the header logo link.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Test Openverse using a screen reader and verify the correct text is read out. Also inspect the html and view the "Openverse home" text.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
