### PR TITLE
Fix crash when more than one `q` parameter is provided in URL

### DIFF
--- a/frontend/src/utils/search-query-transform.ts
+++ b/frontend/src/utils/search-query-transform.ts
@@ -260,3 +260,13 @@ export const areQueriesEqual = (
   }
   return true
 }
+
+/**
+ * Converts the API query `q` parameter to a single string that can
+ * be used as a search term. Use the first item if `q` is an array.
+ * @param q - the URL `q` parameter
+ */
+export const qToSearchTerm = (q: string | null | (string | null)[]) => {
+  const searchTerm = Array.isArray(q) ? q[0] : q
+  return searchTerm ? searchTerm.trim() : ""
+}


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #781 by @obulat
Fixes OPENVERSE-FRONTEND-Z7

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a validator function `qToSearchTerm` that takes the `q` parameter from router's query, and returns:
- the first string if `q` is a list of strings
- the string of `q`
- blank string `""` if `q` is null or if the first string is null or blank

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try re-creating the app crash described in the linked issue by going to `https://localhost:8443/search?q=cat&q=`. It should set the search term to the value of the first `q`.
If you swap the two `q`s, `https://localhost:8443/search?q=&q=cat`, you should be redirected to the homepage because that's what is expected when the search term is blank.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
