### PR TITLE
Fix `always()` logic for dependent tasks in CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -923,7 +923,7 @@ jobs:
   deploy-api:
     name: Deploy staging API
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (needs.get-changes.outputs.ingestion_server == 'true' || needs.get-changes.outputs.api == 'true')
+    if: github.event_name == 'push' && needs.get-changes.outputs.api == 'true'
     needs:
       - get-image-tag
       - get-changes

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -900,7 +900,10 @@ jobs:
   deploy-frontend:
     name: Deploy staging frontend
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && needs.get-changes.outputs.frontend == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      github.event_name == 'push' && needs.get-changes.outputs.frontend == 'true' &&
+      (needs.nuxt-playwright-e2e.result == 'success' && needs.nuxt-playwright-vr.result == 'success' && needs.storybook-playwright.result == 'success')
     needs:
       - get-image-tag
       - get-changes

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -926,7 +926,10 @@ jobs:
   deploy-api:
     name: Deploy staging API
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && needs.get-changes.outputs.api == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      github.event_name == 'push' && needs.get-changes.outputs.api == 'true' &&
+      (needs.test-ing.result == 'success' && needs.publish-images.result == 'success')
     needs:
       - get-image-tag
       - get-changes

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -186,14 +186,14 @@ jobs:
         run: just ingestion_server/test-local
 
       - name: Upload ingestion test logs
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: ing_logs
           path: ingestion_server/test/ingestion_logs.txt
 
       - name: Print ingestion test logs
-        if: always()
+        if: success() || failure()
         run: cat ingestion_server/test/ingestion_logs.txt
 
   #######
@@ -233,13 +233,13 @@ jobs:
         run: just api/test
 
       - name: Print API test logs
-        if: always()
+        if: success() || failure()
         run: |
           just logs > api_logs
           cat api_logs
 
       - name: Upload API test logs
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: api_logs
@@ -593,7 +593,10 @@ jobs:
 
   playwright-test-failure-comment:
     name: Post Playwright test debugging instructions
-    if: always() && github.event_name == 'pull_request' && (needs.nuxt-playwright-vr.result == 'failure' || needs.nuxt-playwright-e2e.result == 'failure' || needs.storybook-playwright.result == 'failure')
+    if: |
+      (success() || failure()) &&
+      github.event_name == 'pull_request' &&
+      (needs.nuxt-playwright-vr.result == 'failure' || needs.nuxt-playwright-e2e.result == 'failure' || needs.storybook-playwright.result == 'failure')
     runs-on: ubuntu-latest
     needs:
       - nuxt-playwright-e2e
@@ -680,7 +683,7 @@ jobs:
     name: Publish full-stack docs
     # https://github.com/actions/runner/issues/491#issuecomment-850884422
     if: |
-      always() &&
+      !failure() && !cancelled() &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
       (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
       (needs.nuxt-build.result == 'success' || needs.nuxt-build.result == 'skipped') &&
@@ -730,7 +733,7 @@ jobs:
     name: Preview full-stack docs
     # https://github.com/actions/runner/issues/491#issuecomment-850884422
     if: |
-      always() &&
+      !failure() && !cancelled() &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
       (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
       (needs.nuxt-build.result == 'success' || needs.nuxt-build.result == 'skipped') &&
@@ -845,7 +848,7 @@ jobs:
     runs-on: ubuntu-latest
     # prevent running on fork PRs
     if: |
-      always() &&
+      !failure() && !cancelled() &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
       (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
       ((github.event_name == 'push' && github.repository == 'WordPress/openverse') || (github.event_name == 'release' && github.repository == 'WordPress/openverse'))


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

I noticed that we weren't receiving any API deployment messages in Slack, even though we've merged PRs which _should_ have initiated an API deploy. After some investigation, I found that we were requiring changes made to the ingestion server prior to deploying the API:

https://github.com/WordPress/openverse/blob/a2782e8b45300be669c90b4da1abd801caa0263b/.github/workflows/ci_cd.yml#L926

Since these services are distinct, we shouldn't need changes made to the ingestion server in order to deploy the API. This PR removes that requirement.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Merge and hope :slightly_smiling_face:

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
