### PR TITLE
Merge renovate bot configuration files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: /
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "💻 aspect: code"
       - "🧰 goal: internal improvement"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,14 +16,6 @@
   "docker": {
     "labels": ["🐳 tech: docker"]
   },
-  "ignorePaths": [
-    ".github/workflows/draft_release.yml",
-    ".github/workflows/label_new_pr.yml",
-    ".github/workflows/new_isssues.yml",
-    ".github/workflows/new_prs.yml",
-    ".github/workflows/pr_label_check.yml",
-    ".github/workflows/pr_ping.yml",
-    "package.json"
-  ],
+  "ignorePaths": ["package.json"],
   "includeForks": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "extends": ["config:base", ":preserveSemverRanges", "schedule:monthly"],
-  "labels": [
-    "dependencies",
-    "💻 aspect: code",
-    "🧰 goal: internal improvement",
-    "🟩 priority: low"
-  ]
-}


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Minor PR to remove a leftover from the monorepo. This keeps a single `renovate.json` file inside the `.github` folder and includes all the workflows for updates as well. 

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
