### PR TITLE
Remove `prepare` script to prevent i18n overwrites inside Docker

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "lint": "prettier --check .; eslint --ext .js,.vue,.ts --ignore-path .gitignore --ignore-path .eslintignore --max-warnings=0 .",
     "lint:fix": "prettier --write --loglevel=warn .; pnpm lint --fix",
     "i18n": "pnpm i18n:create-locales-list && pnpm i18n:get-translations && pnpm i18n:update-locales",
-    "i18n:watch-en": "pnpm i18n:get-translations --en-only --watch",
+    "i18n:en": "pnpm i18n:get-translations --en-only",
     "i18n:copy-test-locales": "cp -r test/locales/* src/locales/",
     "i18n:no-get": "pnpm i18n:create-locales-list && pnpm i18n:update-locales",
     "i18n:create-locales-list": "node src/locales/scripts/create-wp-locale-list",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "version": "2.2.1",
   "scripts": {
-    "prepare": "pnpm i18n:get-translations --en-only && cp -r test/locales/* src/locales",
     "predev": "pnpm install && pnpm i18n:no-get",
     "dev": "pnpm dev:only",
     "dev:only": "nuxt --hostname 0.0.0.0",

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ DC_USER := env_var_or_default("DC_USER", "opener")
 # Installs Node.js dependencies for the entire monorepo.
 node-install:
     pnpm i
+    just frontend/run i18n:en
     just frontend/run i18n:copy-test-locales
 
 # Install all dependencies

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ DC_USER := env_var_or_default("DC_USER", "opener")
 # Installs Node.js dependencies for the entire monorepo.
 node-install:
     pnpm i
+    just frontend/run i18n:copy-test-locales
 
 # Install all dependencies
 install: node-install


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #857 by @dhruvkb

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR removes the `prepare` script altogether. Without it we can be more deliberate about the steps that need to be taken after running `pnpm install`.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR and run the Docker build steps as described in `ci_cd.yml`.
  
   ```console
   $ just frontend/run i18n
   $ cp .npmrc .pnpmfile.cjs pnpm-lock.yaml frontend/
   $ docker build --tag ovfront frontend
   ```

3. Verify that all the locales show up.

   ```console
   $ docker run -it --rm -p 8443:8443 --entrypoint /bin/sh ovfront -c 'cat src/locales/scripts/valid-locales.json'
   ```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
