### PR TITLE
Add feature flag for fake marking results as sensitive

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -1,5 +1,13 @@
 {
   "features": {
+    "fake_sensitive": {
+      "status": {
+        "staging": "switchable",
+        "production": "disabled"
+      },
+      "description": "Mark 50% of results as mature to test content safety.",
+      "defaultState": "off"
+    },
     "external_sources": {
       "status": {
         "staging": "switchable",

--- a/frontend/src/stores/media/index.ts
+++ b/frontend/src/stores/media/index.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia"
 
 import axios from "axios"
 
-import { log, warn } from "~/utils/console"
+import { warn } from "~/utils/console"
 import { hash, rand as prng } from "~/utils/prng"
 import prepareSearchQueryParams from "~/utils/prepare-search-query-params"
 import type { DetailFromMediaType, Media } from "~/types/media"
@@ -20,6 +20,7 @@ import { isSearchTypeSupported, useSearchStore } from "~/stores/search"
 import { useRelatedMediaStore } from "~/stores/media/related-media"
 import { deepFreeze } from "~/utils/deep-freeze"
 import { useFeatureFlagStore } from "~/stores/feature-flag"
+import { markFakeSensitive } from "~/utils/content-safety"
 
 export type MediaStoreResult = {
   count: number
@@ -431,12 +432,7 @@ export const useMediaStore = defineStore("media", {
         // Fake ~50% of results as mature. This leaves actual mature results unchanged.
         const featureFlagStore = useFeatureFlagStore()
         if (featureFlagStore.isOn("fake_sensitive")) {
-          Object.values(data.results).forEach((item) => {
-            if (prng(hash(item.id))() > 0.5) {
-              item.mature = true
-              log("Fake mature", item.id)
-            }
-          })
+          Object.values(data.results).forEach(markFakeSensitive)
         }
 
         this.setMedia({

--- a/frontend/src/stores/media/index.ts
+++ b/frontend/src/stores/media/index.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia"
 
 import axios from "axios"
 
-import { warn } from "~/utils/console"
+import { log, warn } from "~/utils/console"
 import { hash, rand as prng } from "~/utils/prng"
 import prepareSearchQueryParams from "~/utils/prepare-search-query-params"
 import type { DetailFromMediaType, Media } from "~/types/media"
@@ -19,6 +19,7 @@ import { initServices } from "~/stores/media/services"
 import { isSearchTypeSupported, useSearchStore } from "~/stores/search"
 import { useRelatedMediaStore } from "~/stores/media/related-media"
 import { deepFreeze } from "~/utils/deep-freeze"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 export type MediaStoreResult = {
   count: number
@@ -426,6 +427,18 @@ export const useMediaStore = defineStore("media", {
           page = undefined
         }
         this._updateFetchState(mediaType, "end", errorMessage)
+
+        // Fake ~50% of results as mature. This leaves actual mature results unchanged.
+        const featureFlagStore = useFeatureFlagStore()
+        if (featureFlagStore.isOn("fake_sensitive")) {
+          Object.values(data.results).forEach((item) => {
+            if (prng(hash(item.id))() > 0.5) {
+              item.mature = true
+              log("Fake mature", item.id)
+            }
+          })
+        }
+
         this.setMedia({
           mediaType,
           media: data.results,

--- a/frontend/src/stores/media/single-result.ts
+++ b/frontend/src/stores/media/single-result.ts
@@ -10,8 +10,7 @@ import { useMediaStore } from "~/stores/media/index"
 import { useRelatedMediaStore } from "~/stores/media/related-media"
 import { useProviderStore } from "~/stores/provider"
 import { useFeatureFlagStore } from "~/stores/feature-flag"
-import { hash, rand as prng } from "~/utils/prng"
-import { log } from "~/utils/console"
+import { markFakeSensitive } from "~/utils/content-safety"
 
 export type MediaItemState =
   | {
@@ -123,10 +122,7 @@ export const useSingleResultStore = defineStore("single-result", {
         // Fake ~50% of results as mature. This leaves actual mature results unchanged.
         const featureFlagStore = useFeatureFlagStore()
         if (featureFlagStore.isOn("fake_sensitive")) {
-          if (prng(hash(item.id))() > 0.5) {
-            item.mature = true
-            log("Fake mature", item.id)
-          }
+          markFakeSensitive(item)
         }
 
         this.mediaItem = item

--- a/frontend/src/types/media.ts
+++ b/frontend/src/types/media.ts
@@ -44,6 +44,8 @@ export interface Media {
 
   tags: Tag[]
   fields_matched?: string[]
+
+  mature: boolean
 }
 
 export interface ImageDetail extends Media {

--- a/frontend/src/utils/content-safety.ts
+++ b/frontend/src/utils/content-safety.ts
@@ -1,0 +1,23 @@
+/**
+ * Contains utilities related to content safety.
+ */
+
+import type { Media } from "~/types/media"
+import { hash, rand as prng } from "~/utils/prng"
+import { log } from "~/utils/console"
+
+/**
+ * Marks the given item as mature based on a random number seeded with the
+ * item's UUID v4 identifier. The `frac` param controls the probability of an
+ * item being marked as mature.
+ *
+ * @param item - the item to mark as mature
+ * @param frac - the fraction of items to mark as mature
+ */
+export const markFakeSensitive = (item: Media, frac = 0.5) => {
+  const random = prng(hash(item.id))()
+  if (random < frac) {
+    item.mature = true
+    log("Fake mature", item.frontendMediaType, item.id)
+  }
+}


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #854 by @zackkrida 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a feature flag `fake_sensitive` to mark roughly half the results as mature. It uses a random (but deterministic) approach which allows results to be marked mature consistently and across Pinia stores and browsing sessions.

This PR makes no UI changes. It is limited in scope to just adding the feature flag and setting up its behaviour. UI changes are already necessitated by #791 so this PR does not put in effort that's destined to be repeated.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR and run the dev server.
0. Enable the flag 'fake_sensitive' from `/preferences`.
0. Search for somethine.
   - You will see the console logs printing `Fake mature <uuid4>` for ~50% of results.
   - This list should remain the same no matter how many times you refresh the page.
0. Pick any ID out of this list and see the single result page for that ID. 
   - You should get the `Fake mature <uuid4>` log again because it also works on the single media store.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
