### PR TITLE
Add issues to the new Project and set Priority field value

### DIFF
--- a/.github/GITHUB.md
+++ b/.github/GITHUB.md
@@ -27,7 +27,7 @@ This workflow ensures that all repos associated with the project have the
 minimum set of consistent labels. It creates missing labels, and updates the
 color and description where they do not match the standard values.
 
-**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)
+**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)  
 **Dispatch:** enabled
 
 ### Weekly updates

--- a/.github/GITHUB.md
+++ b/.github/GITHUB.md
@@ -10,7 +10,7 @@ the Openverse project.
 This workflow move issues with linked PRs from the "Backlog" and "To do" columns
 to the "In progress" column.
 
-**Cron:** [at every 15th minute](https://crontab.guru/#*/15_*_*_*_*)  
+**Cron:** [at every 15th minute](https://crontab.guru/#*/15_*_*_*_*)
 **Dispatch:** enabled
 
 ### PR project automation
@@ -27,7 +27,7 @@ This workflow ensures that all repos associated with the project have the
 minimum set of consistent labels. It creates missing labels, and updates the
 color and description where they do not match the standard values.
 
-**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)  
+**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)
 **Dispatch:** enabled
 
 ### Weekly updates
@@ -35,7 +35,7 @@ color and description where they do not match the standard values.
 This workflow creates and publishes a post on the Make Openverse site once a
 week, outlining the closed issues and merged PRs of the preceding week.
 
-**Cron:** [at 00:01 on Monday](https://crontab.guru/#1_0_*_*_1)  
+**Cron:** [at 00:01 on Monday](https://crontab.guru/#1_0_*_*_1)
 **Dispatch:** enabled
 
 ### New discussion notification
@@ -52,19 +52,22 @@ This workflow ensures that the files specified in [`sync.yml`](sync.yml) are
 synchronised across all Openverse repos. Treating this repo as the source of
 truth, it creates PRs to resolve any differences.
 
-**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)  
-**Push:** Branch `main`  
-**Dispatch:** enabled  
+**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)
+**Push:** Branch `main`
+**Dispatch:** enabled
 **Config:** `.github/sync.yml`
 
 ## Synced workflows
 
 ### New issue automation
 
-This workflow adds issues to the "Backlog" column in the Openverse project as
+This workflow adds issues to the "Backlog" column in the [(old) Openverse project](https://github.com/orgs/WordPress/projects/3/) as
 soon as they are created.
+This workflow also adds issues to the "Backlog" column in the
+ [Openverse project](https://github.com/orgs/WordPress/projects/75/) as soon as they are created. It also adds a priority field
+value to the project item based on the priority label applied to the issue.
 
-**Issue:** opened  
+**Issue:** opened
 **Dispatch:** disabled
 
 ### New PR automation
@@ -72,7 +75,7 @@ soon as they are created.
 This workflow adds PRs to the "In progress" or "Needs review" columns in the
 Openverse PRs project, based on whether they are marked as draft or ready.
 
-**PR:** opened, converted_to_draft, ready_for_review  
+**PR:** opened, converted_to_draft, ready_for_review
 **Dispatch:** disabled
 
 ### PR label check
@@ -80,7 +83,7 @@ Openverse PRs project, based on whether they are marked as draft or ready.
 This workflow ensures that all PRs have one label from each of the groups
 'aspect', 'goal' and 'priority' applied on them.
 
-**PR:** opened, edited, labeled, unlabeled, synchronize  
+**PR:** opened, edited, labeled, unlabeled, synchronize
 **Dispatch:** disabled
 
 ### New PR notification
@@ -101,5 +104,5 @@ These workflows run only in the downstream synced repos and not in `openverse`.
 This workflow updates the draft release message when new commits are added to
 `main` so that there is a ready-to-go changelog when publishing a new release.
 
-**Push:** Branch `main`  
+**Push:** Branch `main`
 **Config:** `.github/release_drafter.yml`

--- a/.github/GITHUB.md
+++ b/.github/GITHUB.md
@@ -10,7 +10,7 @@ the Openverse project.
 This workflow move issues with linked PRs from the "Backlog" and "To do" columns
 to the "In progress" column.
 
-**Cron:** [at every 15th minute](https://crontab.guru/#*/15_*_*_*_*)
+**Cron:** [at every 15th minute](https://crontab.guru/#*/15_*_*_*_*)  
 **Dispatch:** enabled
 
 ### PR project automation
@@ -35,7 +35,7 @@ color and description where they do not match the standard values.
 This workflow creates and publishes a post on the Make Openverse site once a
 week, outlining the closed issues and merged PRs of the preceding week.
 
-**Cron:** [at 00:01 on Monday](https://crontab.guru/#1_0_*_*_1)
+**Cron:** [at 00:01 on Monday](https://crontab.guru/#1_0_*_*_1)  
 **Dispatch:** enabled
 
 ### New discussion notification
@@ -52,9 +52,9 @@ This workflow ensures that the files specified in [`sync.yml`](sync.yml) are
 synchronised across all Openverse repos. Treating this repo as the source of
 truth, it creates PRs to resolve any differences.
 
-**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)
-**Push:** Branch `main`
-**Dispatch:** enabled
+**Cron:** [at 00:00](https://crontab.guru/#0_0_*_*_*)  
+**Push:** Branch `main`  
+**Dispatch:** enabled  
 **Config:** `.github/sync.yml`
 
 ## Synced workflows
@@ -67,7 +67,7 @@ This workflow also adds issues to the "Backlog" column in the
  [Openverse project](https://github.com/orgs/WordPress/projects/75/) as soon as they are created. It also adds a priority field
 value to the project item based on the priority label applied to the issue.
 
-**Issue:** opened
+**Issue:** opened  
 **Dispatch:** disabled
 
 ### New PR automation
@@ -75,7 +75,7 @@ value to the project item based on the priority label applied to the issue.
 This workflow adds PRs to the "In progress" or "Needs review" columns in the
 Openverse PRs project, based on whether they are marked as draft or ready.
 
-**PR:** opened, converted_to_draft, ready_for_review
+**PR:** opened, converted_to_draft, ready_for_review  
 **Dispatch:** disabled
 
 ### PR label check
@@ -83,7 +83,7 @@ Openverse PRs project, based on whether they are marked as draft or ready.
 This workflow ensures that all PRs have one label from each of the groups
 'aspect', 'goal' and 'priority' applied on them.
 
-**PR:** opened, edited, labeled, unlabeled, synchronize
+**PR:** opened, edited, labeled, unlabeled, synchronize  
 **Dispatch:** disabled
 
 ### New PR notification
@@ -104,5 +104,5 @@ These workflows run only in the downstream synced repos and not in `openverse`.
 This workflow updates the draft release message when new commits are added to
 `main` so that there is a ready-to-go changelog when publishing a new release.
 
-**Push:** Branch `main`
+**Push:** Branch `main`  
 **Config:** `.github/release_drafter.yml`

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -46,6 +46,8 @@ jobs:
 
           echo 'ITEM_ID='"$(jq '.data.addProjectV2ItemById.item.id' issue_data.json)" >> "$GITHUB_ENV"
           ITEM_PRIORITY="$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json)" >> "$GITHUB_ENV"
+          # The IDs for the project's Priority custom field options.
+          # These IDs were manually retrieved from the GitHub API.
           if [[ $ITEM_PRIORITY == "low" ]]; then
               PRIORITY_VALUE_ID="279ae886"
           elif [[ $ITEM_PRIORITY == "medium" ]]; then
@@ -63,7 +65,7 @@ jobs:
     steps:
       - name: Set issue priority
         env:
-          PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
+          PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo" # The ID for the project Priority custom field.
         run: |
           # shellcheck disable=SC2016
           gh api graphql -f query='

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -18,3 +18,70 @@ jobs:
           column: Backlog
           # TODO: Switch to GITHUB_TOKEN if the project is moved to a repo
           repo-token: ${{ secrets.ACCESS_TOKEN }}
+
+  add_issue_to_project:
+    name: Add new issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to "Backlog"
+        with:
+          repo-token: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          gh api graphql -f query='
+          mutation($project:ID!, $issue:ID!) {
+            addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+              item {
+                id
+                content {
+                  ... on Issue {
+                    labels(first: 10) {
+                      nodes {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f project=$PROJECT_ID -f issue=$ISSUE_ID >> issue_data.json
+
+          echo 'ITEM_ID='$(jq '.data.addProjectV2ItemById.item.id' issue_data.json) >> $GITHUB_ENV
+          echo 'ITEM_PRIORITY='$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json) >> $GITHUB_ENV
+
+  set_issue_priority_field:
+    name: Set issue priority
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set issue priority
+        env:
+          PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
+        run: |
+          if [[ $ITEM_PRIORITY == "low" ]]; then
+              PRIORITY_VALUE_ID="279ae886"
+          elif [[ $ITEM_PRIORITY == "medium" ]]; then
+              PRIORITY_VALUE_ID="333b3c1d"
+          elif [[ $ITEM_PRIORITY == "high" ]]; then
+              PRIORITY_VALUE_ID="03fe8945"
+          else
+              PRIORITY_VALUE_ID="fb76bdbc"
+          fi
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $priority_field: ID!
+              $priority_value: String!
+            ) {
+              set_priority_field: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $priority_field
+                value: {
+                  singleSelectOptionId: $priority_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f priority_field=$PRIORITY_FIELD_ID -f priority_value=$PRIORITY_VALUE_ID --silent

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -62,7 +62,8 @@ jobs:
   set_issue_priority_field:
     name: Set issue priority
     runs-on: ubuntu-latest
-    needs: add_issue_to_project
+    needs:
+      - add_issue_to_project
     steps:
       - name: Set issue priority
         env:

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -54,7 +54,7 @@ jobs:
           else
               PRIORITY_VALUE_ID="fb76bdbc"
           fi
-          echo 'PRIORITY_VALUE_ID='$PRIORITY_VALUE_ID >> $GITHUB_ENV
+          echo "PRIORITY_VALUE_ID="$PRIORITY_VALUE_ID >> $GITHUB_ENV
 
   set_issue_priority_field:
     name: Set issue priority

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -62,9 +62,9 @@ jobs:
   set_issue_priority_field:
     name: Set issue priority
     runs-on: ubuntu-latest
+    needs: add_issue_to_project
     steps:
       - name: Set issue priority
-        needs: add_issue_to_project
         env:
           PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo" # The ID for the project Priority custom field.
         run: |

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Add issue to "Backlog"
         run: |
+          # shellcheck disable=SC2016
           gh api graphql -f query='
           mutation($project:ID!, $issue:ID!) {
             addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
@@ -64,6 +65,7 @@ jobs:
         env:
           PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
         run: |
+          # shellcheck disable=SC2016
           gh api graphql -f query='
             mutation (
               $project: ID!

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Add issue to "Backlog"
         run: |
-          gh api graphql -f query='
+          gh api graphql -f query="
           mutation($project:ID!, $issue:ID!) {
             addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
               item {
@@ -41,9 +41,9 @@ jobs:
                 }
               }
             }
-          }' -f project=$PROJECT_ID -f issue=$ISSUE_ID >> issue_data.json
+          }" -f project=$PROJECT_ID -f issue=$ISSUE_ID >> issue_data.json
 
-          echo 'ITEM_ID='$(jq '.data.addProjectV2ItemById.item.id' issue_data.json) >> $GITHUB_ENV
+          echo "ITEM_ID="$(jq '.data.addProjectV2ItemById.item.id' issue_data.json) >> $GITHUB_ENV
           ITEM_PRIORITY=$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json) >> $GITHUB_ENV
           if [[ $ITEM_PRIORITY == "low" ]]; then
               PRIORITY_VALUE_ID="279ae886"
@@ -64,7 +64,7 @@ jobs:
         env:
           PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
         run: |
-          gh api graphql -f query='
+          gh api graphql -f query="
             mutation (
               $project: ID!
               $item: ID!
@@ -83,4 +83,4 @@ jobs:
                   id
                   }
               }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f priority_field=$PRIORITY_FIELD_ID -f priority_value=$PRIORITY_VALUE_ID --silent
+            }" -f project=$PROJECT_ID -f item=$ITEM_ID -f priority_field=$PRIORITY_FIELD_ID -f priority_value=$PRIORITY_VALUE_ID --silent

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Add issue to "Backlog"
         run: |
-          gh api graphql -f query="
+          gh api graphql -f query='
           mutation($project:ID!, $issue:ID!) {
             addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
               item {
@@ -41,10 +41,10 @@ jobs:
                 }
               }
             }
-          }" -f project=$PROJECT_ID -f issue=$ISSUE_ID >> issue_data.json
+          }' -f project="$PROJECT_ID" -f issue="$ISSUE_ID" >> issue_data.json
 
-          echo "ITEM_ID="$(jq '.data.addProjectV2ItemById.item.id' issue_data.json) >> $GITHUB_ENV
-          ITEM_PRIORITY=$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json) >> $GITHUB_ENV
+          echo 'ITEM_ID='"$(jq '.data.addProjectV2ItemById.item.id' issue_data.json)" >> "$GITHUB_ENV"
+          ITEM_PRIORITY="$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json)" >> "$GITHUB_ENV"
           if [[ $ITEM_PRIORITY == "low" ]]; then
               PRIORITY_VALUE_ID="279ae886"
           elif [[ $ITEM_PRIORITY == "medium" ]]; then
@@ -54,7 +54,7 @@ jobs:
           else
               PRIORITY_VALUE_ID="fb76bdbc"
           fi
-          echo "PRIORITY_VALUE_ID="$PRIORITY_VALUE_ID >> $GITHUB_ENV
+          echo 'PRIORITY_VALUE_ID='"$PRIORITY_VALUE_ID" >> "$GITHUB_ENV"
 
   set_issue_priority_field:
     name: Set issue priority
@@ -64,7 +64,7 @@ jobs:
         env:
           PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
         run: |
-          gh api graphql -f query="
+          gh api graphql -f query='
             mutation (
               $project: ID!
               $item: ID!
@@ -83,4 +83,4 @@ jobs:
                   id
                   }
               }
-            }" -f project=$PROJECT_ID -f item=$ITEM_ID -f priority_field=$PRIORITY_FIELD_ID -f priority_value=$PRIORITY_VALUE_ID --silent
+            }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f priority_field="$PRIORITY_FIELD_ID" -f priority_value="$PRIORITY_VALUE_ID"

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to "Backlog"
-        with:
-          repo-token: ${{ secrets.ACCESS_TOKEN }}
         run: |
           gh api graphql -f query='
           mutation($project:ID!, $issue:ID!) {
@@ -46,16 +44,7 @@ jobs:
           }' -f project=$PROJECT_ID -f issue=$ISSUE_ID >> issue_data.json
 
           echo 'ITEM_ID='$(jq '.data.addProjectV2ItemById.item.id' issue_data.json) >> $GITHUB_ENV
-          echo 'ITEM_PRIORITY='$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json) >> $GITHUB_ENV
-
-  set_issue_priority_field:
-    name: Set issue priority
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set issue priority
-        env:
-          PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
-        run: |
+          ITEM_PRIORITY=$(jq '.data.addProjectV2ItemById.item.content.labels.nodes[] | select(.name | contains("priority")).name | split(": ")[1]' issue_data.json) >> $GITHUB_ENV
           if [[ $ITEM_PRIORITY == "low" ]]; then
               PRIORITY_VALUE_ID="279ae886"
           elif [[ $ITEM_PRIORITY == "medium" ]]; then
@@ -65,6 +54,16 @@ jobs:
           else
               PRIORITY_VALUE_ID="fb76bdbc"
           fi
+          echo 'PRIORITY_VALUE_ID='$PRIORITY_VALUE_ID >> $GITHUB_ENV
+
+  set_issue_priority_field:
+    name: Set issue priority
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set issue priority
+        env:
+          PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo"
+        run: |
           gh api graphql -f query='
             mutation (
               $project: ID!

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set issue priority
+        needs: add_issue_to_project
         env:
           PRIORITY_FIELD_ID: "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo" # The ID for the project Priority custom field.
         run: |


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #868 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds steps to the `new_issues`:
1. When the issue is opened, it is added to the new Openverse project with "Backlog" status. Its ID and priority are saved in GITHUB_ENV
2. The matching priority label is added to the issue that was added in the previous step.

The code is heavily based on [Automating projects using actions docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions). 

I ran the queries locally, using my own (old) GitHub Personal Access Token with the `project` permission. I hope that our `ACCESS_TOKEN` works, but I am not sure. The token needs to have the `project` permission to run these queries.

The field and field value IDs are hard-coded because getting them from GitHub during the run of the action would require much more code - this could be done in a later PR. 

Edit: Here are the GraphQL queries I used to get the hard-coded values (for posterity :) )
<details>

<summary>Query to get the project ID</summary>

```
my_org="WordPress"
my_num=75 // From the URL: https://github.com/orgs/WordPress/projects/75
gh api graphql -f query='
  query($organization: String! $number: Int!){
    organization(login: $organization){
      projectV2(number: $number) {
        id
      }
    }
  }' -f organization=$my_org -F number=$my_num
```
Result:
```
{
  "data": {
    "organization": {
      "projectV2": {
        "id": "PVT_kwDOAAQ2Js4AMZdL"
      }
    }
  }
}
```
</details>


<details>

<summary>Query to get the Priority *custom field* (not the labels) ID and its options ids</summary>

```gh api graphql -f query='
  query{
  node(id: "PVT_kwDOAAQ2Js4AMZdL") {
    ... on ProjectV2 {
      fields(first: 20) {
        nodes {
          ... on ProjectV2Field {
            id
            name
          }
          ... on ProjectV2SingleSelectField {
            id
            name
            options {
              id
              name
            }
          }
        }
      }
    }
  }
}'
```

Results: 
```
{
"id": "PVTSSF_lADOAAQ2Js4AMZdLzgH6Kbo",
"name": "Priority",
"options": [
  {
	"id": "fb76bdbc",
	"name": "🟥 priority: critical"
  },
  {
	"id": "03fe8945",
	"name": "🟧 priority: high"
  },
  {
	"id": "333b3c1d",
	"name": "🟨 priority: medium"
  },
  {
	"id": "279ae886",
	"name": "🟩 priority: low"
  }
]
}
```
</details>


## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I ran the queries locally, setting the env variables manually - and they worked and added the correct priority label.
@dhruvkb, do you know if we can use the ACCESS_TOKEN for project automations? 

Is there a way of testing this without merging?

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
