### PR TITLE
Make deployment action "uses" explicit

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,7 +54,38 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/${{ github.event.inputs.environment }}-${{ github.event.inputs.service }}-deploy
+      # Cannot dynamically set "uses" due to security implications:
+      # https://github.com/orgs/community/discussions/25446
+
+      - uses: ./.github/actions/staging-nuxt-deploy
+        if: ${{ github.event.inputs.environment == 'staging' && github.event.inputs.service == 'nuxt' }}
+        with:
+          tag: ${{ github.event.inputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          gh-slack-username-map: ${{ secrets.GH_SLACK_USERNAME_MAP }}
+
+      - uses: ./.github/actions/production-nuxt-deploy
+        if: ${{ github.event.inputs.environment == 'production' && github.event.inputs.service == 'nuxt' }}
+        with:
+          tag: ${{ github.event.inputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          gh-slack-username-map: ${{ secrets.GH_SLACK_USERNAME_MAP }}
+
+      - uses: ./.github/actions/staging-api-deploy
+        if: ${{ github.event.inputs.environment == 'staging' && github.event.inputs.service == 'api' }}
+        with:
+          tag: ${{ github.event.inputs.tag }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          gh-slack-username-map: ${{ secrets.GH_SLACK_USERNAME_MAP }}
+
+      - uses: ./.github/actions/production-api-deploy
+        if: ${{ github.event.inputs.environment == 'production' && github.event.inputs.service == 'api' }}
         with:
           tag: ${{ github.event.inputs.tag }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This fixes an issue that @stacimc and I discovered when attempting to use the new deployment workflow. Apparently, the `uses` field in GitHub actions [*cannot be determined dynamically for security reasons*](https://github.com/orgs/community/discussions/25446). This means that we have to explicitly define each of our environments & applications, and the services therein.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This was used to deploy both the staging and production APIs:

- [Staging run](https://github.com/WordPress/openverse/actions/runs/4367507631/jobs/7638904212)
- [Production run](https://github.com/WordPress/openverse/actions/runs/4367572857/jobs/7639059705)

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
