### PR TITLE
Add stack to label sync, allow emoji to be defined for whole group

### DIFF
--- a/automations/data/labels.yml
+++ b/automations/data/labels.yml
@@ -82,6 +82,24 @@ groups:
         description: Bug fix
         emoji: "🛠"
 
+  - name: stack
+    color: "006b75"
+    emoji: "🧱"
+    is_required: true
+    labels:
+      - name: frontend
+        description: Related to the Nuxt frontend
+      - name: mgmt
+        description: Related to repo management and automations
+      - name: api
+        description: Related to the Django API
+      - name: catalog
+        description: Related to the catalog and Airflow DAGs
+      - name: analytics
+        description: Related to the analytics setup
+      - name: ingestion server
+        description: Related to the ingestion/data refresh server
+
   - name: tooling
     labels:
       - name: sentry

--- a/automations/python/models/label.py
+++ b/automations/python/models/label.py
@@ -23,15 +23,18 @@ class Label:
         has_emoji_name: bool = True,
         **kwargs,
     ):
+        self.group = group
         self.name = kwargs["name"]
         self.description = kwargs["description"]
-        self.emoji = kwargs["emoji"]
+        self.emoji = kwargs.get("emoji")
         self.own_color = color
         self.has_emoji_name = has_emoji_name
 
-        self.group = group
-        if group and self not in group.labels:
-            group.labels.append(self)
+        if group:
+            if self not in group.labels:
+                group.labels.append(self)
+            if self.emoji is None:
+                self.emoji = group.emoji
 
     @property
     def color(self) -> str:

--- a/automations/python/models/label_group.py
+++ b/automations/python/models/label_group.py
@@ -5,6 +5,7 @@ class LabelGroup:
     A group has some fixed parameters:
     - name, which may be prefixed to all child label names
     - color, which acts as a fallback for child labels that do not specify one
+    - emoji, which acts as a fallback for child labels that do not specify one
     - is_prefixed, which determines if group name is prefixed on child labels
     - is_required, which determines if >=1 sub-label must be applied on issues
     """
@@ -12,12 +13,14 @@ class LabelGroup:
     def __init__(
         self,
         color=None,
+        emoji=None,
         is_prefixed=True,
         is_required=False,
         **kwargs,
     ):
         self.name = kwargs["name"]
         self.color = color
+        self.emoji = emoji
         self.is_prefixed = is_prefixed
         self.is_required = is_required
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Addresses a prerequisite for https://github.com/WordPress/openverse-infrastructure/pull/410 and https://github.com/WordPress/openverse-catalog/pull/1037

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the stack label to the list of labels synced across all repos. It also changes the sync label script to allow an emoji to be defined once for an entire group.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. `cd automations/python`
1. `pipenv install`
1. `pipenv sync_labels.py` (you will need to have the GitHub credentials in your environment

I've run this for testing locally (without it actually running the set label operation):

```
::info::[shared.data] Reading file /home/madison/git-a8c/openverse/automations/data/labels.yml
::info::[__main__] Synchronizing 50 standard labels
::info::[__main__] • 🟥 priority: critical
::info::[__main__] • 🟧 priority: high
::info::[__main__] • 🟨 priority: medium
::info::[__main__] • 🟩 priority: low
::info::[__main__] • 🏁 status: ready for work
::info::[__main__] • ⛔ status: blocked
::info::[__main__] • 🧹 status: ticket work required
::info::[__main__] • 🏷 status: label work required
::info::[__main__] • ⛔️ status: discarded
::info::[__main__] • 🙅 status: discontinued
::info::[__main__] • 🚦 status: awaiting triage
::info::[__main__] • 🌟 goal: addition
::info::[__main__] • ✨ goal: improvement
::info::[__main__] • 🧰 goal: internal improvement
::info::[__main__] • 🛠 goal: fix
::info::[__main__] • 🧱 stack: frontend
::info::[__main__] • 🧱 stack: mgmt
::info::[__main__] • 🧱 stack: api
::info::[__main__] • 🧱 stack: catalog
::info::[__main__] • 🧱 stack: analytics
::info::[__main__] • 🧱 stack: ingestion server
::info::[__main__] • 🐛 tooling: sentry
::info::[__main__] • 📄 aspect: text
::info::[__main__] • 💻 aspect: code
::info::[__main__] • 🕹 aspect: interface
::info::[__main__] • 🤖 aspect: dx
::info::[__main__] • ♿️ aspect: a11y
::info::[__main__] • 🖼️ aspect: design
::info::[__main__] • ❓ talk: question
::info::[__main__] • 💬 talk: discussion
::info::[__main__] • 🟨 tech: javascript
::info::[__main__] • 🐍 tech: python
::info::[__main__] • 🐘 tech: php
::info::[__main__] • 🔧 tech: vue
::info::[__main__] • 🔧 tech: django
::info::[__main__] • 🔧 tech: airflow
::info::[__main__] • 🐳 tech: docker
::info::[__main__] • 💾 tech: postgres
::info::[__main__] • 🎨 tech: css
::info::[__main__] • 💲 tech: bash
::info::[__main__] • ⌨️ tech: typescript
::info::[__main__] • good first issue
::info::[__main__] • help wanted
::info::[__main__] • 🔒 staff only
::info::[__main__] • 💥 versioning: major
::info::[__main__] • 🎉 versioning: minor
::info::[__main__] • 🐛 versioning: patch
::info::[__main__] • 🤯 ノಠ益ಠノ彡┻━┻
::info::[__main__] • Hacktoberfest
::info::[__main__] • invalid
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
