### PR TITLE
Add a stemming override for the word "universe"

### DIFF
--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -22,6 +22,9 @@ def index_settings(table_name):
                         "anime => anime",
                         "animate => animate",
                         "animated => animate",
+                        # Override "universe" to prevent matching to
+                        # "university" or "universal".
+                        "universe => universe",
                     ],
                 },
                 "english_stop": {"type": "stop", "stopwords": "_english_"},


### PR DESCRIPTION
Add a stemming override for the word "universe" so it isn't matched to "universal" or "university".