### PR TITLE
Add ability to boost search results by authority

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -376,10 +376,7 @@ def search(
 
     if settings.USE_RANK_FEATURES:
         feature_boost = {"standardized_popularity": DEFAULT_BOOST}
-        if (
-            "unstable__authority" in search_params.data
-            and search_params.data["unstable__authority"]
-        ):
+        if search_params.data["unstable__authority"]:
             feature_boost["authority_boost"] = (
                 search_params.data["unstable__authority_boost"] * DEFAULT_BOOST
             )

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -33,6 +33,7 @@ URL = "url"
 PROVIDER = "provider"
 DEEP_PAGINATION_ERROR = "Deep pagination is not allowed."
 QUERY_SPECIAL_CHARACTER_ERROR = "Unescaped special characters are not allowed."
+DEFAULT_BOOST = 10000
 
 
 class RankFeature(Query):
@@ -374,7 +375,15 @@ def search(
             s = s.query("simple_query_string", fields=["tags.name"], query=tags)
 
     if settings.USE_RANK_FEATURES:
-        feature_boost = {"standardized_popularity": 10000}
+        feature_boost = {"standardized_popularity": DEFAULT_BOOST}
+        if (
+            "unstable__authority" in search_params.data
+            and search_params.data["unstable__authority"]
+        ):
+            feature_boost["authority_boost"] = (
+                search_params.data["unstable__authority_boost"] * DEFAULT_BOOST
+            )
+
         rank_queries = []
         for field, boost in feature_boost.items():
             rank_queries.append(Q("rank_feature", field=field, boost=boost))

--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -50,6 +50,8 @@ class MediaSearchRequestSerializer(serializers.Serializer):
         "qa",
         # "unstable__sort_by",  # excluding unstable fields
         # "unstable__sort_dir",  # excluding unstable fields
+        # "unstable__authority",  # excluding unstable fields
+        # "unstable__authority_boost",  # excluding unstable fields
         "page_size",
         "page",
     ]
@@ -137,6 +139,22 @@ class MediaSearchRequestSerializer(serializers.Serializer):
         choices=SORT_DIRECTIONS,
         required=False,
         default=DESCENDING,
+    )
+    unstable__authority = serializers.BooleanField(
+        label="authority",
+        help_text="If enabled, the search will add a boost to results that are "
+        "from authoritative sources.",
+        required=False,
+        default=False,
+    )
+    unstable__authority_boost = serializers.FloatField(
+        label="authority_boost",
+        help_text="The boost coefficient to apply to authoritative sources, "
+        "multiplied with the popularity boost.",
+        required=False,
+        default=1.0,
+        min_value=0.0,
+        max_value=10.0,
     )
 
     page_size = serializers.IntegerField(


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds 2 search query parameters to the API to allow us to test boosting the results by their `authority` score. To make sure that no one relies on this test parameter, the query parameter `unstable__authority`.

By default, the boost is the same as the `popularity` boost: 10 000. You can also fine-tune the `authority` boost by adding a float value as `unstable__authority_boost`. This number will be multiplied with the default boost. So, if you want the authority boost to be lower than the `standard_popularity` boost, you can set it to a value lower than 1 (e.g., 0.5)

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the API and go to [http://localhost:50280/v1/images/?q=cat&unstable__authority=true&unstable__authority_boost=1.0](http://localhost:50280/v1/images/?q=cat&unstable__authority=true&unstable__authority_boost=1.0). Locally, you should see that the first 3 results are from Stocksnap (authority score 85) and not from Flickr (authority score 75)

Go to [http://localhost:50280/v1/images/?q=cat&unstable__authority=true&unstable__authority_boost=0.5](http://localhost:50280/v1/images/?q=cat&unstable__authority=true&unstable__authority_boost=0.5) - and you should see much more mixed results.

If you search for cat with `unstable__authority_boost=0.0`, you would probably only see Flickr results on the first page.
## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
