### PR TITLE
Save cleaned up data during the cleanup step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -327,13 +327,13 @@ jobs:
         run: just api/test
 
       - name: Print API test logs
-        if: success() || failure()
+        if: success() || failure() || cancelled()
         run: |
           just logs > api_logs
           cat api_logs
 
       - name: Upload API test logs
-        if: success() || failure()
+        if: success() || failure() || cancelled()
         uses: actions/upload-artifact@v3
         with:
           name: api_logs

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -327,13 +327,13 @@ jobs:
         run: just api/test
 
       - name: Print API test logs
-        if: success() || failure() || cancelled()
+        if: success() || failure()
         run: |
           just logs > api_logs
           cat api_logs
 
       - name: Upload API test logs
-        if: success() || failure() || cancelled()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: api_logs

--- a/ingestion_server/.gitignore
+++ b/ingestion_server/.gitignore
@@ -1,3 +1,4 @@
 # Mutex
 ingestion_server/db
 ingestion_server/lock
+ingestion_server/**.tsv

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -356,8 +356,11 @@ def clean_image_data(table):
 
                 for result in pool.starmap(_clean_data_worker, jobs):
                     batch_cleaned_counts = save_cleaned_data(result)
-                for field in batch_cleaned_counts:
-                    cleaned_counts_by_field[field] += batch_cleaned_counts[field]
+                    log.info(f"Batch cleaned counts: {batch_cleaned_counts}")
+                    log.info(f"Multiprocessing batch finished, result: {result}")
+                    for field in batch_cleaned_counts:
+                        cleaned_counts_by_field[field] += batch_cleaned_counts[field]
+                log.info("Finished cleaning jobs")
             num_cleaned += len(batch)
             batch_end_time = time.time()
             rate = len(batch) / (batch_end_time - batch_start_time)

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -351,16 +351,19 @@ def clean_image_data(table):
                         cleanable_fields_for_table,
                     )
                 )
-            with multiprocessing.Pool(processes=num_workers) as pool:
-                log.info(f"Starting {len(jobs)} cleaning jobs")
+            pool = multiprocessing.Pool(processes=num_workers)
+            log.info(f"Starting {len(jobs)} cleaning jobs")
 
-                for result in pool.starmap(_clean_data_worker, jobs):
-                    batch_cleaned_counts = save_cleaned_data(result)
-                    log.info(f"Batch cleaned counts: {batch_cleaned_counts}")
-                    log.info(f"Multiprocessing batch finished, result: {result}")
-                    for field in batch_cleaned_counts:
-                        cleaned_counts_by_field[field] += batch_cleaned_counts[field]
-                log.info("Finished cleaning jobs")
+            results = pool.starmap(_clean_data_worker, jobs)
+            log.info(f"Multiprocessing pool finished, results: {results}")
+            for result in results:
+                batch_cleaned_counts = save_cleaned_data(result)
+                log.info(f"Batch cleaned counts: {batch_cleaned_counts}")
+                log.info(f"Multiprocessing batch finished, result: {result}")
+                for field in batch_cleaned_counts:
+                    cleaned_counts_by_field[field] += batch_cleaned_counts[field]
+            pool.close()
+            log.info("Finished cleaning jobs")
             log.info("Finished multiprocessing pool")
             num_cleaned += len(batch)
             batch_end_time = time.time()

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -54,11 +54,12 @@ TAG_MIN_CONFIDENCE = 0.90
 TLS_CACHE = {
     "www.flickr.com": True,
     "commons.wikimedia.org": True,
-    "https://www.eol.org/": True,
     ".geograph.org.uk": True,
-    ".eol.org": True,
-    ".digitaltmuseum.org": True,
     "www.geograph.org.uk": True,
+    ".eol.org": True,
+    "www.eol.org": True,
+    ".digitaltmuseum.org": True,
+    "collections.musee-mccord.qc.ca": False,
 }
 
 
@@ -100,7 +101,7 @@ class CleanupFunctions:
             except KeyError:
                 tls_supported = TlsTest.test_tls_supported(url)
                 tls_support[_tld] = tls_supported
-                log.info(f"Tested domain {_tld}")
+                log.debug(f"Tested domain {_tld}")
 
             if tls_supported:
                 return f"'https://{url}'"

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -240,9 +240,9 @@ def _clean_data_worker(rows, temp_table, sources_config, all_fields: list[str]):
                 clean = cleaning_func(dirty_value)
             if clean:
                 cleaned_data[update_field] = clean
-                log.info(
+                log.debug(
                     f"Updated {update_field} for {identifier} "
-                    "from '{dirty_value}' to '{clean}'"
+                    f"from '{dirty_value}' to '{clean}'"
                 )
         # Generate SQL update for all the fields we just cleaned
         update_field_expressions = []

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -361,6 +361,7 @@ def clean_image_data(table):
                     for field in batch_cleaned_counts:
                         cleaned_counts_by_field[field] += batch_cleaned_counts[field]
                 log.info("Finished cleaning jobs")
+            log.info("Finished multiprocessing pool")
             num_cleaned += len(batch)
             batch_end_time = time.time()
             rate = len(batch) / (batch_end_time - batch_start_time)

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -355,23 +355,20 @@ def clean_image_data(table):
             log.info(f"Starting {len(jobs)} cleaning jobs")
 
             results = pool.starmap(_clean_data_worker, jobs)
-            log.info(f"Multiprocessing pool finished, results: {results}")
+
             for result in results:
                 batch_cleaned_counts = save_cleaned_data(result)
-                log.info(f"Batch cleaned counts: {batch_cleaned_counts}")
-                log.info(f"Multiprocessing batch finished, result: {result}")
                 for field in batch_cleaned_counts:
                     cleaned_counts_by_field[field] += batch_cleaned_counts[field]
             pool.close()
-            log.info("Finished cleaning jobs")
-            log.info("Finished multiprocessing pool")
+
             num_cleaned += len(batch)
             batch_end_time = time.time()
             rate = len(batch) / (batch_end_time - batch_start_time)
-            log.info(f"Batch finished, records/s: cleanup_rate={rate}")
             log.info(
-                f"Fetching next batch. Records cleaned so far: {num_cleaned},"
-                f"counts: {batch_cleaned_counts}"
+                f"Batch finished, records/s: cleanup_rate={rate}, "
+                f"items cleaned: {batch_cleaned_counts}.\n"
+                f"Fetching next batch."
             )
             jobs = []
             batch = iter_cur.fetchmany(size=CLEANUP_BUFFER_SIZE)

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -253,8 +253,12 @@ class TestIngestion(unittest.TestCase):
         stat_msg = "The job should launch successfully and return 202 ACCEPTED."
         self.assertEqual(res.status_code, 202, msg=stat_msg)
 
+        logging.info(
+            f"Waiting for the task to send us a callback {self.__class__.cb_queue}"
+        )
+
         # Wait for the task to send us a callback.
-        assert self.__class__.cb_queue.get(timeout=120) == "CALLBACK!"
+        assert self.__class__.cb_queue.get(timeout=240) == "CALLBACK!"
 
         # Check that the indices remained the same
         after_indices = self._get_indices(self.downstream_db, model)


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #861 by @krysal
Fixes #654 by @obulat

## Description

This PR adds more logging for the data refresh, but its main goal is to be a proof-of-concept of saving the data during weekly data refresh as a preparation step for data normalization.

Data refresh image cleanup steps:

- Add http or https protocol to URLs that don't have a scheme in "url", "creator_url", "foreign_landing_url" fields
- Clean up tags:
    - tags that contain anything from the TAG_CONTAINS_DENYLIST set
    - AI-generated tags ("provider": "clarifai") with confidence level below TAG_MIN_CONFIDENCE = 0.90

~~This PR also adds a Wikimedia title cleanup step that removes File: prefix and file extension suffix from the image title. This step was added because in the Openverse Inserter PR it was specifically pointed out that those titles are bad for UX.~~ The Wikimedia title cleanup step can be added after during the second run of this PR in prod.

There is also a step that we need to add to the cleanup process for incorrect utf-8 tags, but I think we should add it in a later refresh (gist with the implementation) so as the cleanup step does not become much longer.

This PR saves one file per cleaned field in a tsv format. The files contain the image identifier and the cleaned data. I don't know where the best place to save them is - all suggestions welcome!

## Testing Instructions

Replace `sample_data/sample_images.csv` with the file in this gist (https://gist.github.com/obulat/b31e43b131352b8f6cd66a2dd87061d8), and run `just recreate` (or `just start` -> `just init`, if you haven't run the API before). You should see the tsv files recreated, logging about the cleaned fields:
```
2023-02-05 10:11:52 2023-02-05 07:11:52,223 INFO cleanup.py:276 - Finished saving cleaned data in 0.059366464614868164
2023-02-05 10:11:52 2023-02-05 07:11:52,223 INFO cleanup.py:353 - Batch finished, records/s: cleanup_rate=229.1038788216563
2023-02-05 10:11:52 2023-02-05 07:11:52,223 INFO cleanup.py:354 - Fetching next batch. Records cleaned so far: 1899, counts: {'tags': 320, 'url': 2, 'creator_url': 404, 'foreign_landing_url': 294, 'title': 224}
2023-02-05 10:11:52 2023-02-05 07:11:52,238 INFO cleanup.py:362 - Cleaned all records in 8.332297325134277 seconds, counts: {'tags': 320, 'url': 2, 'creator_url': 404, 'foreign_landing_url': 294, 'title': 224}
```

Also, check the logs about updated fields/values and TLS_CACHE.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
