### PR TITLE
Add awaiting triage label onto existing labels

### DIFF
--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -23,7 +23,7 @@ from shared.log import configure_logger
 log = logging.getLogger(__name__)
 
 REQUIRED_LABEL_CATEGORIES = ["aspect", "priority", "goal", "stack"]
-# Categories where all labels should be retrievd rather than first only
+# Categories where all labels should be retrieved rather than first only
 GET_ALL_LABEL_CATEGORIES = {"stack"}
 
 # region argparse
@@ -150,7 +150,7 @@ def get_linked_issues(url: str) -> list[str]:
 
 def get_all_labels_of_cat(cat: str, labels: list[Label]) -> list[Label]:
     """
-    Get all of the available labels from a category from a given list of
+    Get all the available labels from a category from a given list of
     labels.
 
     :param cat: the category to which the label should belong
@@ -222,7 +222,8 @@ def main():
                 break
     else:
         log.info("Could not find properly labelled issue")
-        pr.set_labels("🚦 status: awaiting triage")
+        # Only add the triage label onto existing labels, don't replace them
+        pr.set_labels("🚦 status: awaiting triage", *pr.get_labels())
 
 
 if __name__ == "__main__":

--- a/automations/python/shared/github.py
+++ b/automations/python/shared/github.py
@@ -24,7 +24,7 @@ def get_client(is_authenticated: bool = True) -> Github:
     """
     Get a PyGithub client to access the GitHub API.
 
-    The client can optionally be authenticated using the GITHUB_ACCESS_TOKEN
+    The client can optionally be authenticated using the ACCESS_TOKEN
     from the environment variables.
 
     :param is_authenticated: whether to authenticate the client


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes an issue that came up after #786, wherein a PR lacking all labels would have the linked issue labels added _and then removed_, replaced with the "awaiting triage" label. This PR changes the behavior so that all available labels are added always, _in addition to_ the "awaiting triage" label if not all label categories are met.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I ran this successfully against a catalog PR which had the previous, incorrect behavior, and verified that it correctly added (instead of replaced) the "awaiting triage" label: https://github.com/WordPress/openverse-catalog/pull/1048#event-8761162349

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
