### PR TITLE
use old nginx image name

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -503,7 +503,7 @@ jobs:
           context: api
           target: nginx # from `api/Dockerfile`
           push: false
-          tags: openverse-api_nginx
+          tags: openverse-api-nginx
           cache-from: type=gha,scope=nginx
           cache-to: type=gha,scope=nginx
           outputs: type=docker,dest=/tmp/api_nginx.tar

--- a/.github/workflows/deploy-production-api.yml
+++ b/.github/workflows/deploy-production-api.yml
@@ -121,7 +121,7 @@ jobs:
               const { data: versions } =
                 await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
                   package_type: 'container',
-                  package_name: 'openverse-api_nginx',
+                  package_name: 'openverse-api-nginx',
                   org: 'WordPress',
                   page,
                   // max of `per_page`
@@ -134,7 +134,7 @@ jobs:
             }
             if (!exists) {
               throw new Error(
-                `'${{ inputs.tag }}' does not appear to be a valid tag for the ghcr.io/wordpress/openverse-api_nginx image.`
+                `'${{ inputs.tag }}' does not appear to be a valid tag for the ghcr.io/wordpress/openverse-api-nginx image.`
               )
             }
 
@@ -190,7 +190,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: nginx
-          image: "ghcr.io/wordpress/openverse-api_nginx:${{ inputs.tag }}"
+          image: "ghcr.io/wordpress/openverse-api-nginx:${{ inputs.tag }}"
 
       - name: "Fill in the new django image ID in the Amazon ECS task definition"
         id: "task-def-django"

--- a/.github/workflows/deploy-staging-api.yml
+++ b/.github/workflows/deploy-staging-api.yml
@@ -121,7 +121,7 @@ jobs:
               const { data: versions } =
                 await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
                   package_type: 'container',
-                  package_name: 'openverse-api_nginx',
+                  package_name: 'openverse-api-nginx',
                   org: 'WordPress',
                   page,
                   // max of `per_page`
@@ -134,7 +134,7 @@ jobs:
             }
             if (!exists) {
               throw new Error(
-                `'${{ inputs.tag }}' does not appear to be a valid tag for the ghcr.io/wordpress/openverse-api_nginx image.`
+                `'${{ inputs.tag }}' does not appear to be a valid tag for the ghcr.io/wordpress/openverse-api-nginx image.`
               )
             }
 
@@ -190,7 +190,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: nginx
-          image: "ghcr.io/wordpress/openverse-api_nginx:${{ inputs.tag }}"
+          image: "ghcr.io/wordpress/openverse-api-nginx:${{ inputs.tag }}"
 
       - name: "Fill in the new django image ID in the Amazon ECS task definition"
         id: "task-def-django"

--- a/docker/nginx/justfile
+++ b/docker/nginx/justfile
@@ -18,13 +18,13 @@ collectstatic:
 # Run the NGINX image locally
 build-run upstream_url='api.openverse.engineering': collectstatic
     # upstream_url can also be set to 172.17.0.1:50280 for local testing
-    docker build --target nginx . -t openverse-api_nginx:latest
+    docker build --target nginx . -t openverse-api-nginx:latest
     @echo "--> NGINX server will be run at http://localhost:9090, upstream at {{ upstream_url }}"
     @echo "--> Try a static URL like http://localhost:9090/static/admin/css/base.css to test"
     docker run --rm -p 9090:8080 -it \
       -e DJANGO_NGINX_UPSTREAM_URL="{{ upstream_url }}" \
       -e DJANGO_NGINX_GIT_REVISION="$(git rev-parse HEAD)" \
-      openverse-api_nginx:latest
+      openverse-api-nginx:latest
 
 # Make locally trusted certificates (requires mkcert installed)
 cert:


### PR DESCRIPTION
DO NOT MERGE. Used as the branch for a workflow, to deploy an old version of the API which needs the old name of the nginx image.

In the future when we rename a package we should push over all the historical versions as well.