### PR TITLE
Always build both api & ingestion server images for either service

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,7 +91,7 @@ jobs:
               build_matrix["image"].append("frontend")
               build_matrix["include"].append({"image": "frontend", "target": "app"})
               publish_matrix["image"].append("frontend")
-          else:
+          if "api" in changes or "ingestion_server" in changes:
               # Always build the ingestion server and API images for either changeset
               build_matrix["image"] += ["api", "ingestion_server"]
               build_matrix["include"] += [

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -87,22 +87,21 @@ jobs:
           build_matrix = {"image": [], "include": []}
           publish_matrix = {"image": []}
 
-          if "api" in changes:
-              build_matrix["image"].append("api")
-              build_matrix["include"].append({"image": "api", "target": "api"})
-              publish_matrix["image"] += ["api", "api_nginx"]
-          if "ingestion_server" in changes:
-              build_matrix["image"].append("ingestion_server")
-              build_matrix["include"].append({"image": "ingestion_server", "target": "ing"})
-              publish_matrix["image"].append("ingestion_server")
-              # The `api` image needs to be built to run the `test-api` job.
-              if "api" not in changes:
-                  build_matrix["image"].append("api")
-                  build_matrix["include"].append({"image": "api", "target": "api"})
           if "frontend" in changes:
               build_matrix["image"].append("frontend")
               build_matrix["include"].append({"image": "frontend", "target": "app"})
               publish_matrix["image"].append("frontend")
+          else:
+              # Always build the ingestion server and API images for either changeset
+              build_matrix["image"] += ["api", "ingestion_server"]
+              build_matrix["include"] += [
+                {"image": "ingestion_server", "target": "ing"},
+                {"image": "api", "target": "api"},
+              ]
+              if "api" in changes:
+                  publish_matrix["image"] += ["api", "api_nginx"]
+              if "ingestion_server" in changes:
+                  publish_matrix["image"].append("ingestion_server")
 
           build_matrix = json.dumps(build_matrix)
           publish_matrix = json.dumps(publish_matrix)


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This is a follow up to #925 which is currently affecting #933, #934, and #935. The ingestion server is also necessary for API tests, so we must unconditionally build it when only the API code is changed.

This PR modifies the logic so that the API and ingestion server images are always built for either API or ingestion server changes, only publish behavior is now affected by which service has been affected.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Based on this file being changed _all_ services will change so we won't be able to test this on this PR, but hopefully once merged we will see it work on any of the above PRs.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
