### PR TITLE
Log DB queries in production  

### DIFF
--- a/api/catalog/api/middleware/force_debug_cursor_middleware.py
+++ b/api/catalog/api/middleware/force_debug_cursor_middleware.py
@@ -1,0 +1,23 @@
+from django.db import connection
+
+
+# Makes DB query logging possible when debugging is disabled
+# by forcing the connection to use a debug cursor.
+#
+# WARNING: This can have performance implications and
+# should only be used in production temporarily.
+class ForceDebugCursorMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        self.before(request)
+        response = self.get_response(request)
+        self.after(request)
+        return response
+
+    def before(self, request):
+        connection.force_debug_cursor = True
+
+    def after(self, request):
+        pass

--- a/api/catalog/api/middleware/force_debug_cursor_middleware.py
+++ b/api/catalog/api/middleware/force_debug_cursor_middleware.py
@@ -6,18 +6,9 @@ from django.db import connection
 #
 # WARNING: This can have performance implications and
 # should only be used in production temporarily.
-class ForceDebugCursorMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        self.before(request)
-        response = self.get_response(request)
-        self.after(request)
-        return response
-
-    def before(self, request):
+def force_debug_cursor_middleware(get_response):
+    def middleware(request):
         connection.force_debug_cursor = True
+        return get_response(request)
 
-    def after(self, request):
-        pass
+    return middleware

--- a/api/catalog/configuration/logging.py
+++ b/api/catalog/configuration/logging.py
@@ -9,7 +9,7 @@ def health_check_filter(record: LogRecord) -> bool:
 
 
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
-
+DJANGO_DB_LOGGING = config("DJANGO_DB_LOGGING", cast=bool, default=False)
 
 # Logging configuration
 LOGGING = {
@@ -95,7 +95,7 @@ LOGGING = {
     },
 }
 
-if config("DJANGO_DB_LOGGING", cast=bool, default=False):
+if DJANGO_DB_LOGGING:
     # Behind a separate flag as it's a very noisy debug logger
     # and it's nice to be able to enable it conditionally within that context
     LOGGING["loggers"]["django.db.backends"] = {

--- a/api/catalog/configuration/logging.py
+++ b/api/catalog/configuration/logging.py
@@ -45,7 +45,7 @@ LOGGING = {
         },
         # Add a clause to log error messages to the console in production
         "console_prod": {
-            "level": "WARNING",
+            "level": LOG_LEVEL,
             "filters": ["require_debug_false", "request_id"],
             "class": "logging.StreamHandler",
             "formatter": "console",

--- a/api/catalog/configuration/logging.py
+++ b/api/catalog/configuration/logging.py
@@ -101,4 +101,5 @@ if config("DJANGO_DB_LOGGING", cast=bool, default=False):
     LOGGING["loggers"]["django.db.backends"] = {
         "level": "DEBUG",
         "handlers": ["console", "console_prod"],
+        "propagate": False,
     }

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -24,7 +24,7 @@ from catalog.configuration.elasticsearch import ES, MEDIA_INDEX_MAPPING
 from catalog.configuration.link_validation_cache import (
     LinkValidationCacheExpiryConfiguration,
 )
-from catalog.configuration.logging import LOGGING
+from catalog.configuration.logging import DJANGO_DB_LOGGING, LOGGING
 
 
 # Build paths inside the project like this: BASE_DIR.join('dir', 'subdir'...)
@@ -110,7 +110,7 @@ MIDDLEWARE = [
 ]
 
 # WARNING: This should not be run in production long-term as it can impact performance
-if config("DJANGO_DB_LOGGING", cast=bool, default=False):
+if not DEBUG and DJANGO_DB_LOGGING:
     MIDDLEWARE.append(
         "catalog.api.middleware.force_debug_cursor_middleware.force_debug_cursor_middleware"  # noqa: E501
     )

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -112,7 +112,7 @@ MIDDLEWARE = [
 # WARNING: This should not be run in production long-term as it can impact performance
 if config("DJANGO_DB_LOGGING", cast=bool, default=False):
     MIDDLEWARE.append(
-        "catalog.api.middleware.force_debug_cursor_middleware.ForceDebugCursorMiddleware"  # noqa: E501
+        "catalog.api.middleware.force_debug_cursor_middleware.force_debug_cursor_middleware"  # noqa: E501
     )
 
 

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -109,6 +109,13 @@ MIDDLEWARE = [
     "oauth2_provider.middleware.OAuth2TokenMiddleware",
 ]
 
+# WARNING: This should not be run in production long-term as it can impact performance
+if config("DJANGO_DB_LOGGING", cast=bool, default=False):
+    MIDDLEWARE.append(
+        "catalog.api.middleware.force_debug_cursor_middleware.ForceDebugCursorMiddleware"  # noqa: E501
+    )
+
+
 SWAGGER_SETTINGS = {
     "DEFAULT_INFO": "catalog.urls.swagger.open_api_info",
     "SECURITY_DEFINITIONS": {},


### PR DESCRIPTION
- Updates the `console_prod` log handler to respect `LOG_LEVEL` instead of only logging `WARNINGS`.
- Introduces a middleware which forces the db connection to use a debug cursor when `DJANGO_DB_LOGGING` is True. Without this middleware, Django is only able to log DB queries when debugging is enabled, which is a major security risk in production.

I am _not_ a python dev at all and I have no idea what the best way to get test coverage for this is.