### PR TITLE
Use formless default browsable API renderer

### DIFF
--- a/api/catalog/api/utils/drf_renderer.py
+++ b/api/catalog/api/utils/drf_renderer.py
@@ -1,0 +1,27 @@
+from rest_framework.renderers import BrowsableAPIRenderer
+
+
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """
+    Renders the browsable api, but excludes the forms.
+
+    See https://github.com/WordPress/openverse/issues/970
+
+    CC BY 3.0 Brad Montgomery
+    https://bradmontgomery.net/blog/disabling-forms-django-rest-frameworks-browsable-api/
+    """
+
+    def get_context(self, *args, **kwargs):
+        ctx = super().get_context(*args, **kwargs)
+        ctx["display_edit_forms"] = False
+        return ctx
+
+    def show_form_for_method(self, view, method, request, obj):
+        """We never want to do this! So just return False."""
+        return False
+
+    def get_rendered_html_form(self, data, view, method, request):
+        """Why render _any_ forms at all. This method should return
+        rendered HTML, so let's simply return an empty string.
+        """
+        return ""

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -145,7 +145,7 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     "DEFAULT_RENDERER_CLASSES": (
         "rest_framework.renderers.JSONRenderer",
-        "rest_framework.renderers.BrowsableAPIRenderer",
+        "catalog.api.utils.drf_renderer.BrowsableAPIRendererWithoutForms",
         "rest_framework_xml.renderers.XMLRenderer",
     ),
     "DEFAULT_THROTTLE_CLASSES": (

--- a/api/test/unit/utils/drf_renderer_test.py
+++ b/api/test/unit/utils/drf_renderer_test.py
@@ -1,0 +1,64 @@
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+import pytest
+
+from catalog.api.utils.drf_renderer import BrowsableAPIRendererWithoutForms
+
+
+@pytest.fixture
+def api_request(request_factory):
+    return request_factory.get("/")
+
+
+@pytest.fixture
+def view():
+    return APIView.as_view()
+
+
+@pytest.fixture
+def response(view, api_request):
+    return view(api_request)
+
+
+def test_without_forms_renderer_context_should_not_show_edit_forms(
+    api_request, response
+):
+    """
+    See https://github.com/encode/django-rest-framework/blob/master/tests/test_renderers.py
+    for example of test setup.
+    """
+    cls = BrowsableAPIRendererWithoutForms()
+
+    parent_context = {
+        "view": APIView(),
+        "request": Request(api_request),
+        "response": response,
+    }
+
+    ctx = cls.get_context({}, "text/html", parent_context)
+
+    assert ctx["display_edit_forms"] is False
+
+
+parametrize_methods = pytest.mark.parametrize(
+    "method", ("GET", "PUT", "POST", "DELETE", "OPTIONS")
+)
+
+
+@parametrize_methods
+def test_without_forms_renderer_show_form_for_method_returns_false(
+    method, api_request, view
+):
+    cls = BrowsableAPIRendererWithoutForms()
+
+    assert cls.show_form_for_method(view, method, api_request, None) is False
+
+
+@parametrize_methods
+def test_without_forms_renderer_get_rendered_html_form_empty(method, api_request, view):
+    cls = BrowsableAPIRendererWithoutForms()
+
+    data = {}
+
+    assert cls.get_rendered_html_form(data, view, method, api_request) == ""


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #970 by @zackkrida 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The view in question in the issue is the browsable API view. You'll get a 405 method not allowed, but the form below is the culprit here.

The new renderer added in this PR removes this form from all the views to prevent this kind of thing happening in any of our browsable views. This has the benefit of still maintaining the browsable API views which are quite useful to all developing the API or using it for their own purposes.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the branch (`just up`) and visit the browsable API views. Test something like http://localhost:50280/v1/images/2982c0bf-9c26-4543-a712-4d50a117ded8/report/ specifically. On `main` you'll see a form underneath the JSON blob reporting the method not allowed error. On this branch, you'll see no form.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
