### PR TITLE
Skip build and publish job if nothing to do

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -67,7 +67,9 @@ jobs:
     name: Determine images to build and publish
     runs-on: ubuntu-latest
     outputs:
+      do-build: ${{ steps.set-matrix.outputs.do-build }}
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+      do-publish: ${{ steps.set-matrix.outputs.do-publish }}
       publish-matrix: ${{ steps.set-matrix.outputs.publish-matrix }}
     needs:
       - get-changes
@@ -103,14 +105,20 @@ jobs:
               if "ingestion_server" in changes:
                   publish_matrix["image"].append("ingestion_server")
 
+          do_build = 'true' if len(build_matrix["image"]) != 0 else 'false'
           build_matrix = json.dumps(build_matrix)
+          do_publish = 'true' if len(publish_matrix["image"]) != 0 else 'false'
           publish_matrix = json.dumps(publish_matrix)
 
+          print(f"do-build={do_build}")
           print(f"build-matrix={build_matrix}")
+          print(f"do-publish={do_publish}")
           print(f"publish-matrix={publish_matrix}")
 
           with open(os.environ.get("GITHUB_OUTPUT"), "a") as gh_out:
+              print(f"do-build={do_build}", file=gh_out)
               print(f"build-matrix={build_matrix}", file=gh_out)
+              print(f"do-publish={do_publish}", file=gh_out)
               print(f"publish-matrix={publish_matrix}", file=gh_out)
 
   #############
@@ -176,6 +184,7 @@ jobs:
 
   build-images:
     name: Build Docker images
+    if: needs.determine-images.outputs.do-build == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.determine-images.outputs.build-matrix) }}
@@ -893,6 +902,7 @@ jobs:
     # prevent running on fork PRs
     if: |
       !failure() && !cancelled() &&
+      needs.determine-images.outputs.do-publish == 'true' &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
       (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
       (needs.nuxt-build.result == 'success' || needs.nuxt-build.result == 'skipped') &&


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR skips the `build-images` and `publish-images` jobs if there are no images to build or publish. This avoids the GitHub error which occurs when a matrix has no entries.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
