### PR TITLE
Add decoding of the strings that don't have backslashes

### DIFF
--- a/frontend/src/utils/decode-data.ts
+++ b/frontend/src/utils/decode-data.ts
@@ -9,7 +9,11 @@ export const decodeData = (data = ""): string => {
   if (!data) return ""
 
   try {
-    const regexes = [/\\x([\d\w]{2})/gi, /\\u([\d\w]{4})/gi]
+    const regexes = [
+      /\\x([\da-f]{2})/gi,
+      /\\u([\da-f]{4})/gi,
+      /u([\da-f]{4})/gi,
+    ]
     regexes.forEach((regex) => {
       data = data.replace(regex, (_, grp) =>
         String.fromCharCode(parseInt(grp, 16))

--- a/frontend/test/unit/specs/utils/decode-data.spec.js
+++ b/frontend/test/unit/specs/utils/decode-data.spec.js
@@ -31,6 +31,12 @@ describe("decodeData", () => {
     expect(decodeData(data)).toBe("s\u1234\xe9")
   })
 
+  it("returns decoded string when string does not contain backslash", () => {
+    const data = "musu00e9e"
+
+    expect(decodeData(data)).toBe("musée")
+  })
+
   it("shouldnt throw exception", () => {
     const data = "Classic Twill - SlipcoverFabrics.com 100% Cotton"
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #958 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a regex to match the strings like "u00e9" (without the backslashes) to the decodeData method we use to clean up the titles and tags on the frontend.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Open the pottery image from the homepage: localhost:8443/image/802d76cd-84cf-45bc-81ac-610331dab420
2. Look at the tags. There should be no unescaped unicode strings. There will be some duplicate tags, though, because of this.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
