### PR TITLE
Add release-drafter API configuration to enable testing in #987

### DIFF
--- a/.github/release-drafter-api.yml
+++ b/.github/release-drafter-api.yml
@@ -1,0 +1,27 @@
+# This file is generated from templates/release-drafter.yml.jinja
+# Changes to this file must be made in the template first
+
+name-template: "API $RESOLVED_VERSION"
+categories:
+  - title: New Features
+    label: "🌟 goal: addition"
+  - title: Improvements
+    label: "✨ goal: improvement"
+  - title: Internal Improvements
+    labels:
+      - "🤖 aspect: dx"
+      - "🧰 goal: internal improvement"
+  - title: Bug Fixes
+    label: "🛠 goal: fix"
+# Identical to the default except it uses `-` instead of `*` to match our Markdown linter
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+exclude-labels:
+  - "skip-changelog"
+include-labels:
+  - "🧱 stack: api"
+template: |
+  $CHANGES
+
+  ## Credits
+
+  Thanks to $CONTRIBUTORS for their contributions!


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Necessary for completing the testing in https://github.com/WordPress/openverse/pull/987

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the provisional api release-drafter configuration to `main` so that the release-drafter action can use it in the linked PR.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
