### PR TITLE
Defer the `tags_list` for media models

### DIFF
--- a/api/catalog/api/models/media.py
+++ b/api/catalog/api/models/media.py
@@ -26,7 +26,7 @@ DMCA = "dmca"
 OTHER = "other"
 
 
-class CustomTagsListDeferralManager(models.Manager):
+class TagsListDeferralManager(models.Manager):
     """
     Custom manager used temporarily to enable zero-downtime removal of the deprecated
     `tags_list` field from the media modals.
@@ -106,7 +106,7 @@ class AbstractMedia(
 
     meta_data = models.JSONField(blank=True, null=True)
 
-    objects = CustomManager()
+    objects = TagsListDeferralManager()
 
     @property
     def license_url(self) -> str:

--- a/api/catalog/api/models/media.py
+++ b/api/catalog/api/models/media.py
@@ -26,7 +26,7 @@ DMCA = "dmca"
 OTHER = "other"
 
 
-class CustomManager(models.Manager):
+class CustomTagsListDeferralManager(models.Manager):
     """
     Custom manager used temporarily to enable zero-downtime removal of the deprecated
     `tags_list` field from the media modals.

--- a/api/catalog/api/models/media.py
+++ b/api/catalog/api/models/media.py
@@ -26,6 +26,24 @@ DMCA = "dmca"
 OTHER = "other"
 
 
+class CustomManager(models.Manager):
+    """
+    Custom manager used temporarily to enable zero-downtime removal of the deprecated
+    `tags_list` field from the media modals.
+
+    @see https://github.com/WordPress/openverse/pull/956.
+    """
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .defer(
+                "tags_list",
+            )
+        )
+
+
 class AbstractMedia(
     IdentifierMixin, ForeignIdentifierMixin, MediaMixin, OpenLedgerModel
 ):
@@ -87,6 +105,8 @@ class AbstractMedia(
     )
 
     meta_data = models.JSONField(blank=True, null=True)
+
+    objects = CustomManager()
 
     @property
     def license_url(self) -> str:


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #704 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This is the first step of the three-step process we need to follow to remove the `tags_list` from the database for zero-downtime deployments. This PR adds a custom Manager to the AbstractMedia model that prevents querysets from trying to access `tags_list` field as part of the model. 

After this PR is deployed, we will need to drop the `tags_list` column from the database.

After the column is dropped, we can deploy the PR #956 that removes the `tags_list` field from the models and adds corresponding migrations. Note: the `CustomManager` needs to be removed from #956, otherwise we get an error when it is trying to defer the `tags_list` field that doesn't exist.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `just up` and search for something (http://localhost:50280/v1/images/?q=cat). In the logs (run `just logs web` or use the Docker UI to view the `openverse-web-1` logs), you should see a log line with SELECT query that does not have `tags_list`:
```
2023-03-26 21:04:00 [2023-03-26 18:04:00,636 - django.db.backends - 131][DEBUG] 
[5caaae77211340c0a6a0cd568d8e9ec3] (0.014) SELECT "image"."id", "image"."created_on", "image"."updated_on", "image"."identifier", "image"."foreign_identifier", "image"."title", "image"."foreign_landing_url", "image"."creator", "image"."creator_url", "image"."thumbnail", "image"."provider", "image"."url", "image"."filesize", "image"."filetype", "image"."watermarked", "image"."license", "image"."license_version", "image"."source", "image"."last_synced_with_source", "image"."removed_from_source", "image"."view_count", "image"."tags", "image"."category", "image"."meta_data", "image"."width", "image"."height", "api_matureimage"."created_on", "api_matureimage"."identifier" FROM "image" LEFT OUTER JOIN "api_matureimage" ON ("image"."identifier" = "api_matureimage"."identifier") WHERE "image"."identifier" IN (UUID('3b858852-67df-44e1-8d57-683991d3ec67'), ...)); alias=default
```

If you do the same on main, you should see that the query _does_ contain `tags_list` (see logs in [this comment](https://github.com/WordPress/openverse/pull/956#pullrequestreview-1353526516))

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
