### PR TITLE
Do not bind ports with docker-compose in CI

### DIFF
--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -62,6 +62,7 @@ if DEBUG:
         "localhost",
         "127.0.0.1",
         "0.0.0.0",
+        "web",  # used when requesting from within the docker network context
     ]
 
 USE_S3 = config("USE_S3", default=False, cast=bool)

--- a/api/justfile
+++ b/api/justfile
@@ -23,12 +23,12 @@ up *flags:
     env COMPOSE_PROFILES="api" just ../up {{ flags }}
 
 # Wait for all profile services to be up
-wait-up: up
+@wait-up: up
     just ../ingestion_server/wait # API profile includes ingestion server
     just wait # API waits for ES in entrypoint
 
 # Load sample data into API via ingestion server
-init: wait-up
+@init: wait-up
     cd .. && just exec "-T web /bin/bash < load_sample_data.sh"
 
 recreate:
@@ -41,27 +41,23 @@ recreate:
 ##########
 
 # Check the health of the service
-@health host="localhost:50280":
-    -curl -s -o /dev/null -w '%{http_code}' 'http://{{ host }}/healthcheck/'
+@health host="web:8000":
+    just ../curl "-s -o /dev/null -w %{http_code} 'http://{{ host }}/healthcheck/"
 
 # Wait for the service to be healthy
-@wait host="localhost:50280":
-    # The just command on the second line is executed in the context of the
-    # parent directory and so must be prefixed with `api/`.
-    just ../_loop \
-    '"$(just api/health {{ host }})" != "200"' \
-    "Waiting for the API to be healthy..."
+@wait host="web:8000":
+    just ../curl "--retry-connrefused --retry 5 --retry-delay 5 http://{{ host }}/healthcheck/"
 
 ########
 # cURL #
 ########
 
 # Make a cURL GET request to service at the given path
-_curl-get path host="localhost:50280":
-    curl "http://{{ host }}/v1/{{ path }}"
+_curl-get path host="web:8000":
+    just ../curl "http://{{ host }}/v1/{{ path }}"
 
 # Make a test cURL GET request to the API
-stats media="images" host="localhost:50280":
+stats media="images" host="web:8000":
     just _curl-get "{{ media }}/stats/" {{ host }}
 
 # Launch a `pgcli` shell in the web container (requires typing credentials)

--- a/api/justfile
+++ b/api/justfile
@@ -29,7 +29,7 @@ wait-up: up
 
 # Load sample data into API via ingestion server
 init: wait-up
-    cd .. && ./load_sample_data.sh
+    cd .. && just exec web load_sample_data.sh
 
 recreate:
     just ../down -v

--- a/api/justfile
+++ b/api/justfile
@@ -29,7 +29,7 @@ wait-up: up
 
 # Load sample data into API via ingestion server
 init: wait-up
-    cd .. && just exec web load_sample_data.sh
+    cd .. && just exec "-T web /bin/bash < load_sample_data.sh"
 
 recreate:
     just ../down -v

--- a/api/justfile
+++ b/api/justfile
@@ -98,7 +98,7 @@ test-local *args:
 
 # Run smoke test for the API docs
 doc-test: wait-up
-    curl --fail 'http://localhost:50280/v1/?format=openapi'
+    just ../curl "--fail http://web:8000/v1/\?format=openapi"
 
 #########
 # NGINX #

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,37 @@
+version: "2.4"
+services:
+  db:
+    ports:
+      - "50254:5432"
+
+  plausible:
+    ports:
+      - "50288:8000"
+
+  cache:
+    ports:
+      - "50263:6379"
+
+  es:
+    ports:
+      - "50292:9200"
+
+  web:
+    ports:
+      - "50280:8000" # Django
+      - "50230:3000" # Sphinx (unused by default; see `sphinx-live` recipe)
+    stdin_open: true
+    tty: true
+
+  ingestion_server:
+    ports:
+      - "50281:8001"
+    stdin_open: true
+    tty: true
+
+  proxy:
+    ports:
+      - "50200:9080"
+      - "50243:9443"
+    environment:
+      HTTPS_PORT: 50243 # See `ports` mapping above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       - ingestion_server
       - api
     image: postgres:13.2-alpine
-    ports:
-      - "50254:5432"
+    expose:
+      - "5432"
     volumes:
       - api-postgres:/var/lib/postgresql/data
     env_file:
@@ -60,8 +60,6 @@ services:
     profiles:
       - frontend
     image: plausible/analytics:latest
-    ports:
-      - "50288:8000"
     command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
     depends_on:
       - plausible_db
@@ -72,17 +70,17 @@ services:
   cache:
     profiles:
       - api
+    expose:
+      - "6379"
     image: redis:4.0.10
-    ports:
-      - "50263:6379"
 
   es:
     profiles:
       - ingestion_server
       - api
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
-    ports:
-      - "50292:9200"
+    expose:
+      - "9200"
     env_file:
       - docker/es/env.docker
     healthcheck:
@@ -116,9 +114,6 @@ services:
     image: openverse-api
     volumes:
       - ./api:/api
-    ports:
-      - "50280:8000" # Django
-      - "50230:3000" # Sphinx (unused by default; see `sphinx-live` recipe)
     depends_on:
       - db
       - es
@@ -139,8 +134,6 @@ services:
     build: ./ingestion_server/
     image: openverse-ingestion_server
     command: gunicorn -c ./gunicorn.conf.py
-    ports:
-      - "50281:8001"
     depends_on:
       - db
       - upstream_db
@@ -177,11 +170,6 @@ services:
     profiles:
       - api
     image: nginx:alpine
-    ports:
-      - "50200:9080"
-      - "50243:9443"
-    environment:
-      HTTPS_PORT: 50243 # See `ports` mapping above.
     depends_on:
       - web
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
     image: openverse-api
     volumes:
       - ./api:/api
+      - ./sample_data:/sample_data
     depends_on:
       - db
       - es
@@ -134,6 +135,8 @@ services:
     build: ./ingestion_server/
     image: openverse-ingestion_server
     command: gunicorn -c ./gunicorn.conf.py
+    expose:
+      - "8001"
     depends_on:
       - db
       - upstream_db

--- a/docker/es/justfile
+++ b/docker/es/justfile
@@ -15,30 +15,9 @@ NO_COLOR := "\\033[0m"
 ##########
 
 # Check the health of the service
-@health host:
-    -curl -s -o /dev/null -w '%{http_code}' 'http://{{ host }}/_cluster/health'
+@health host="es:9200":
+    just ../curl "-s -o /dev/null -w %{http_code} http://{{ host }}/_cluster/health"
 
 # Wait for the service to be healthy
-@wait host="localhost:50292":
-    # The just command on the second line is executed in the context of the
-    # root directory and so must be prefixed with `docker/es/`.
-    just ../../_loop \
-    '"$(just docker/es/health {{ host }})" != "200"' \
-    "Waiting for Elasticsearch to be healthy..."
-
-@check-index index="image":
-    -curl \
-      -s \
-      -H 'Accept: application/json' \
-      'http://localhost:50292/_cat/indices/{{ index }}' \
-    | grep -o "{{ index }}" \
-    | wc -l \
-    | xargs
-
-# Wait for the media to be indexed in Elasticsearch
-@wait-for-index index="image":
-    # The just command on the second line is executed in the context of the
-    # root directory and so must be prefixed with `docker/es/`.
-    just ../../_loop \
-    '"$(just docker/es/check-index {{ index }})" != "1"' \
-    "Waiting for index '{{ index }}' to be ready..."
+@wait host="es:9200":
+    just ../curl "--retry-connrefused --retry 5 --retry-delay 5 htt://{{ host }}/_cluster/health"

--- a/ingestion_server/justfile
+++ b/ingestion_server/justfile
@@ -31,45 +31,12 @@ wait-up: up
 ##########
 
 # Check the health of the service
-@health host="localhost:50281":
-    -curl -s -o /dev/null -w '%{http_code}' 'http://{{ host }}/'
+@health host="ingestion_server:8001":
+    just ../curl "-s -o -w %{http_code} {{ host }}"
 
 # Wait for the service to be healthy
-@wait host="localhost:50281":
-    # The just command on the second line is executed in the context of the
-    # parent directory and so must be prefixed with `ingestion_server/`.
-    just ../_loop \
-    '"$(just ingestion_server/health {{ host }})" != "200"' \
-    "Waiting for the ingestion-server to be healthy..."
-
-########
-# cURL #
-########
-
-# Make a cURL POST request to the service with the given data
-_curl-post data host="localhost:50281":
-    curl \
-      -X POST \
-      -H 'Content-Type: application/json' \
-      -d '{{ data }}' \
-      -w "\n" \
-      'http://{{ host }}/task'
-
-# Load QA data into QA indices in Elasticsearch
-load-test-data model="image":
-    just _curl-post '{"model": "{{ model }}", "action": "LOAD_TEST_DATA"}'
-
-# Load sample data into temp table in API and new index in Elasticsearch
-ingest-upstream model="image" suffix="init":
-    just _curl-post '{"model": "{{ model }}", "action": "INGEST_UPSTREAM", "index_suffix": "{{ suffix }}"}'
-
-# Promote temp table to prod in API and new index to primary in Elasticsearch
-promote model="image" suffix="init" alias="image":
-    just _curl-post '{"model": "{{ model }}", "action": "PROMOTE", "index_suffix": "{{ suffix }}", "alias": "{{ alias }}"}'
-
-# Delete an index in Elasticsearch
-delete model="image" suffix="init" alias="image":
-    just _curl-post '{"model": "{{ model }}", "action": "DELETE_INDEX", "index_suffix": "{{ suffix }}"}'
+@wait host="ingestion_server:8001":
+    just ../curl "--retry-connrefused --retry 5 --retry-delay 5 {{ host }}"
 
 #########
 # Tests #

--- a/justfile
+++ b/justfile
@@ -158,3 +158,7 @@ EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 # Execute statement in service containers using Docker Compose
 exec +args:
     just dc exec -u {{ DC_USER }} {{ EXEC_DEFAULTS }} "{{ args }}"
+
+# Execute curl within the stack's docker network.
+curl +args:
+    just exec "web /bin/bash -c 'curl {{ args }}'"

--- a/justfile
+++ b/justfile
@@ -21,21 +21,6 @@ DC_USER := env_var_or_default("DC_USER", "opener")
     cd documentation && just
     printf "\nTo run a nested recipe, add the folder path before it, like \`just frontend/install\`.\n"
 
-###########
-# Helpers #
-###########
-
-# Sleep for given time showing the given message as long as given condition is met
-@_loop condition message timeout="5m" time="5":
-    timeout --foreground {{ timeout }} bash -c 'while [ {{ condition }} ]; do \
-      echo "{{ message }}" && sleep {{ time }}; \
-    done'; \
-    EXIT_CODE=$?; \
-    if [ $EXIT_CODE -eq 124 ]; then \
-      echo "Timed out"; \
-      exit $EXIT_CODE; \
-    fi
-
 #######
 # Dev #
 #######

--- a/justfile
+++ b/justfile
@@ -157,4 +157,4 @@ EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 
 # Execute statement in service containers using Docker Compose
 exec +args:
-    just dc exec -u {{ DC_USER }} {{ EXEC_DEFAULTS }} {{ args }}
+    just dc exec -u {{ DC_USER }} {{ EXEC_DEFAULTS }} "{{ args }}"

--- a/justfile
+++ b/justfile
@@ -103,6 +103,9 @@ env:
 DOCKER_FILE := "-f " + (
     if IS_PROD == "true" { "ingestion_server/docker-compose.yml" }
     else { "docker-compose.yml" }
+) + (
+    if IS_CI == "" { " -f docker-compose.local.yml" }
+    else { "" }
 )
 
 # Run `docker-compose` configured with the correct files and environment

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -1,52 +1,96 @@
-#!/bin/bash
 set -e
-WEB_SERVICE_NAME="${WEB_SERVICE_NAME:-web}"
-CACHE_SERVICE_NAME="${CACHE_SERVICE_NAME:-cache}"
 UPSTREAM_DB_SERVICE_NAME="${UPSTREAM_DB_SERVICE_NAME:-upstream_db}"
 DB_SERVICE_NAME="${DB_SERVICE_NAME:-db}"
+ES_SERVICE_NAME="${ES_SERVICE_NAME:-es}"
+INGESTION_SERVER_SERVICE_NAME="${INGESTION_SERVER_SERVICE_NAME:-ingestion_server}"
 
 ###############
 # Upstream DB #
 ###############
 
+function psql_cmd {
+  echo "psql postgresql://deploy:deploy@$1/openledger"
+}
+
 # Load sample data
 function load_sample_data {
-  docker-compose exec -T "$UPSTREAM_DB_SERVICE_NAME" bash -c "psql <<-EOF
+  bash -c "$(psql_cmd $UPSTREAM_DB_SERVICE_NAME) <<-EOF
     DELETE FROM $1;
 		\copy $1 \
-			from './sample_data/sample_$1.csv' \
+			from '/sample_data/sample_$1.csv' \
 			with (FORMAT csv, HEADER true);
 		REFRESH MATERIALIZED VIEW $1_view;
 		EOF"
 }
 
-load_sample_data "image"
-load_sample_data "audio"
+load_sample_data image
+load_sample_data audio
 
 #######
 # API #
 #######
 
-# Set up API database and upstream
-docker-compose exec -T "$WEB_SERVICE_NAME" bash -c "python3 manage.py migrate --noinput"
-# Create a superuser and a user for integration testing
-# Not that the Python code uses 4 spaces for indentation after the tab that is stripped by <<-
-docker-compose exec -T "$WEB_SERVICE_NAME" bash -c "python3 manage.py shell <<-EOF
-	from django.contrib.auth.models import User
-	usernames = ['continuous_integration', 'deploy']
-	for username in usernames:
-	    if User.objects.filter(username=username).exists():
-	        print(f'User {username} already exists')
-	        continue
-	    if username == 'deploy':
-	        user = User.objects.create_superuser(username, f'{username}@example.com', 'deploy')
-	    else:
-	        user = User.objects.create_user(username, f'{username}@example.com', 'deploy')
-	    user.save()
-	EOF"
+echo "Waiting for ES... (I will time out after 25 seconds)"
+# Wait for ES as Django app depends on it
+index_count=$(
+  curl \
+    -s \
+    --retry 5 \
+    --retry-connrefused \
+    --retry-delay 5 \
+    "http://$ES_SERVICE_NAME:9200/_cat/indices" | wc -l
+)
 
-# Load content providers
-docker-compose exec -T "$DB_SERVICE_NAME" bash -c "psql <<-EOF
+if [ $index_count = 0 ]; then
+  # if indexes exist, then we don't need to wait for ES to initialise
+  # if they don't exist, however, then we will need to hold on a second for ES
+  # to be ready to start ingestion
+  # This ensures the script can be re-run without hanging on waiting for an
+  # ES cluster health status that will never materialise after the first run
+  curl \
+    -s \
+    --output /dev/null \
+    "http://$ES_SERVICE_NAME:9200/_cluster/health?wait_for_status=green&timeout=2s"
+fi
+
+function check_index_exists {
+  index=$1
+  curl \
+    -s \
+    --output /dev/null \
+    -I \
+    -w "%{http_code}\n" \
+    "http://$ES_SERVICE_NAME:9200/$index" | grep -v 404 || true
+}
+
+# Check if init indexes already exist
+image_init_exists=$(check_index_exists image-init)
+audio_init_exists=$(check_index_exists audio-init)
+
+if [ $image_init_exists ] && [ $audio_init_exists ]; then
+  echo 'Both init indexes already exist. Use `just recreate` to fully recreate your local environment.' > /dev/stderr
+  exit 1
+fi
+
+# Set up API database and upstream
+python3 manage.py migrate --noinput
+
+# Create a superuser and a user for integration testing
+bash -c "python3 manage.py shell <<-EOF
+from django.contrib.auth.models import User
+usernames = ['continuous_integration', 'deploy']
+for username in usernames:
+    if User.objects.filter(username=username).exists():
+        print(f'User {username} already exists')
+        continue
+    if username == 'deploy':
+        user = User.objects.create_superuser(username, f'{username}@example.com', 'deploy')
+    else:
+        user = User.objects.create_user(username, f'{username}@example.com', 'deploy')
+    user.save()
+EOF"
+
+bash -c "$(psql_cmd $DB_SERVICE_NAME) <<-EOF
 	DELETE FROM content_provider;
 	INSERT INTO content_provider
 		(created_on, provider_identifier, provider_name, domain_name, filter_content, media_type)
@@ -62,38 +106,89 @@ docker-compose exec -T "$DB_SERVICE_NAME" bash -c "psql <<-EOF
 # Ingestion #
 #############
 
+function _curl_post {
+  curl \
+    -X POST \
+    -s \
+    -H 'Content-Type: application/json' \
+    -d "$1" \
+    -w "\n" \
+    "http://$INGESTION_SERVER_SERVICE_NAME:8001/task"
+}
+
+function wait_for_index {
+  index=${1:-image}
+  suffix=${2:-init}
+  # Wait for no relocating shards. Cannot wait for index health to be green
+  # as it is always yellow in the local environment.
+  echo "Waiting for index $index-$suffix..."
+  curl \
+    -s \
+    --output /dev/null \
+    --max-time 10 \
+    "http://$ES_SERVICE_NAME:9200/_cluster/health/$index-$suffix?wait_for_no_relocating_shards=true"
+}
+
+function ingest_test_data {
+  echo "Loading $1 test data..."
+  _curl_post "{\"model\": \"$1\", \"action\": \"LOAD_TEST_DATA\"}"
+}
+
+function ingest_upstream {
+  model=${1:-image}
+  suffix=${2:-init}
+  echo "Ingesting $model-$suffix from upstream..."
+  _curl_post "{\"model\": \"$model\", \"action\": \"INGEST_UPSTREAM\", \"index_suffix\": \"$suffix\"}"
+}
+
+function promote {
+  model=${1:-image}
+  suffix=${2:-init}
+  alias=${3:-image}
+
+  echo "Promoting $model-$suffix to $alias..."
+  _curl_post "{\"model\": \"$model\", \"action\": \"PROMOTE\", \"index_suffix\": \"$suffix\", \"alias\": \"$alias\"}"
+}
+
+
 # Load search quality assurance data.
-just ingestion_server/load-test-data "audio"
+ingest_test_data audio
 sleep 2
 
-just ingestion_server/load-test-data "image"
+ingest_test_data image
 sleep 2
 
 # Ingest and index the data
-just ingestion_server/ingest-upstream "audio" "init"
-just docker/es/wait-for-index "audio-init"
-just ingestion_server/promote "audio" "init" "audio"
-just docker/es/wait-for-index "audio"
+if [ -z "$audio_init_exists" ]; then
+  ingest_upstream audio init
+  wait_for_index audio init
+  promote audio init audio
+  wait_for_index audio
+fi
 
-# Image ingestion is flaky; but usually works on the next attempt
-set +e
-while true; do
-	just ingestion_server/ingest-upstream "image" "init"
-	if just docker/es/wait-for-index "image-init"
-	then
-		break
-	fi
-	((c++)) && ((c==3)) && break
-done
-set -e
+if [ -z "$image_init_exists" ]; then
+  # Image ingestion is flaky; but usually works on the next attempt
+  set +e
+  while true; do
+    ingest_upstream image init
+    if wait_for_index image init
+    then
+      break
+    fi
+    ((c++)) && ((c==3)) && break
+  done
+  set -e
 
-just ingestion_server/promote "image" "init" "image"
-just docker/es/wait-for-index "image"
+  promote image init image
+  wait_for_index image
+fi
 
 #########
 # Redis #
 #########
 
-# Clear source cache since it's out of date after data has been loaded
-docker-compose exec -T "$CACHE_SERVICE_NAME" bash -c "echo \"del :1:sources-image\" | redis-cli"
-docker-compose exec -T "$CACHE_SERVICE_NAME" bash -c "echo \"del :1:sources-audio\" | redis-cli"
+python3 manage.py shell <<-EOF
+from django.core.cache import cache
+source_caches = ['image', 'audio']
+cache.delete_many([f'sources-{sc}' for sc in source_caches])
+EOF


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1035 by @sarayourfriend 

Follow-up to #990 

This is not a viable replacement for #990 as it requires further work to make `load_sample_data.sh` work in CI without bound ports.

cc @dhruvkb

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
As described in the issue, the idea here is that we shouldn't need to bind any ports in CI as no part of our CI environment makes requests from the host into the running containers. 

Unfortunately this PR ended up being a bit bigger than I anticipated, primarily due to the fact that I hadn't considered how much we actually rely on host-bound networking. In particular, the `load_sample_data.sh` script needed to change to be able to run inside the context of the `web` container. It needs to run there so that it actually has access to the docker network. Once inside, it no longer has docker-compose, so everything relying on docker-compose needed to be changed. Additionally, because `just` is not available in the web container (and I couldn't justify installing it), everything that previously called out to a just script needed to be inlined into the script. I put these in bash functions when it made sense to do so. I also made changes to the way we waited for task completion by leveraging the ingestion server's task status endpoint rather than trying to infer the state based on the ES index status (which I found was flaky). The `_cat` endpoints are useful, but they're explicitly not for machine reading, according to the ES documentation, so I also removed the usages of those endpoints as much as possible.

It ended up being more changes than I wanted, and I could definitely pair down a number of the changes by moving things like the `wait-for-index` just script directly into the load_sample_data.sh. If folks feel that would be easier to review and would increase confidence in the changes, just let me know, I'm more than happy to do it.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just down -v` (to clean your local environment) then `just up` and `just init` and make queries to local DB to ensure it all works. This will confirm that the local approach (with host-bound networking) still works. `just recreate` should also still work.

Next, to try the CI version. In addition to it passing in the CI on this PR, you should also be able to do the following locally (after `just down -v`):

```
$ CI=1 just up
$ CI=1 just api/init
$ CI=1 just curl '-H "Accept: application/json" http://web:8000/v1/images/'
```

The final command should yield a JSON blob with the same results that would have shown at localhost in the first pass.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
