### PR TITLE
Fix issues in the workflow simplifications of #1054

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -378,6 +378,24 @@ jobs:
           name: openverse-api-openapi-schema.yaml
           path: ./api/openapi.yaml
 
+  fake-django-checks:
+    name: Run Django checks
+    if: needs.get-changes.outputs.api != 'true'
+    runs-on: ubuntu-latest
+    needs:
+      - get-changes
+    strategy:
+      matrix:
+        recipe:
+          - "api/dj check"
+          - "api/dj validateopenapischema"
+          - "api/dj makemigrations --check --noinput --merge"
+          - "api/doc-test"
+
+    steps:
+      - name: Pass
+        run: echo 'Django checks are skipped because API is unchanged.'
+
   ############
   # Frontend #
   ############
@@ -491,6 +509,23 @@ jobs:
         with:
           name: ${{ matrix.name }}_test_results
           path: frontend/test-results
+
+  fake-playwright:
+    name: Run Playwright tests
+    if: needs.get-changes.outputs.frontend != 'true'
+    runs-on: ubuntu-latest
+    needs:
+      - get-changes
+    strategy:
+      matrix:
+        name:
+          - playwright_vr
+          - playwright_e2e
+          - storybook_vr
+
+    steps:
+      - name: Pass
+        run: echo 'Playwright tests are skipped because frontend is unchanged.'
 
   playwright-test-failure-comment:
     name: Post Playwright test debugging instructions

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -378,7 +378,9 @@ jobs:
           name: openverse-api-openapi-schema.yaml
           path: ./api/openapi.yaml
 
-  fake-django-checks:
+  # This job runs when `django-checks` doesn't and always passes, thus allowing
+  # PRs to meet the required checks criteria and be merged.
+  bypass-django-checks:
     name: Run Django checks
     if: needs.get-changes.outputs.api != 'true'
     runs-on: ubuntu-latest
@@ -510,7 +512,9 @@ jobs:
           name: ${{ matrix.name }}_test_results
           path: frontend/test-results
 
-  fake-playwright:
+  # This job runs when `playwright` doesn't and always passes, thus allowing
+  # PRs to meet the required checks criteria and be merged.
+  bypass-playwright:
     name: Run Playwright tests
     if: needs.get-changes.outputs.frontend != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -596,8 +596,6 @@ jobs:
       - test-ing
       - test-api
       - nuxt-build
-    env:
-      REPO_NAME: ${{ github.event.pull_request.head.repo.name }}
 
     steps:
       - name: Checkout repository
@@ -618,8 +616,8 @@ jobs:
       - name: Recreate working directory # to avoid superfluous files from getting tracked automatically
         run: |
           cd ..
-          sudo rm -rf "$REPO_NAME"
-          mkdir "$REPO_NAME"
+          sudo rm -rf openverse
+          mkdir openverse
 
       - name: Checkout repository at `gh-pages` branch
         uses: actions/checkout@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -585,7 +585,10 @@ jobs:
     if: |
       !failure() && !cancelled() &&
       (
-        github.event_name == 'push' ||
+        (
+          github.event_name == 'push' &&
+          github.repository == 'WordPress/openverse'
+        ) ||
         (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.owner.login == 'WordPress' &&


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

In GitHub, required checks which are part of a matrix are not expanded if skipped by an `if` condition. So making them required can block PRs.

![image](https://user-images.githubusercontent.com/16580576/228449094-b1821db1-e1ab-466d-b642-2dc1f5f4ab59.png)

The workaround for having them required yet skipping them when no changes is to create a fake job with the same `name` and pass it.

This PR
- creates fakes for the `django-checks` and `playwright` jobs
- uses the hardcoded repo name instead of an env var to prevent failures when building docs

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
