### PR TITLE
Add `GITHUB_TOKEN` to GitHub CLI step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -756,6 +756,8 @@ jobs:
 
       - name: Dispatch workflow
         run: "gh workflow run 'Deployment: staging-nuxt' -f tag=${{ needs.get-image-tag.outputs.image_tag }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   deploy-api:
     name: Deploy staging API
@@ -775,3 +777,5 @@ jobs:
 
       - name: Dispatch workflow
         run: "gh workflow run 'Deployment: staging-api' -f tag=${{ needs.get-image-tag.outputs.image_tag }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Adds to #1034 by @sarayourfriend 

## Description

The deployment was failing after #1034 was merged because GitHub CLI needs `GITHUB_TOKEN` to run inside GitHub Actions. See error log: https://github.com/WordPress/openverse/actions/runs/4571548989/jobs/8070585871

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This PR does what the error message says, except using GITHUB_TOKEN instead of GH_TOKEN. They're both [equally valid](https://cli.github.com/manual/gh_help_environment), although `GITHUB_TOKEN` is the name used in the [official docs](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows) so I went with that.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
