### PR TITLE
Analytics event: BACK_TO_SEARCH

### DIFF
--- a/frontend/src/components/VBackToSearchResultsLink.vue
+++ b/frontend/src/components/VBackToSearchResultsLink.vue
@@ -3,6 +3,7 @@
   <VLink
     class="time inline-flex flex-row items-center gap-2 rounded-sm p-2 pe-3 text-xs font-semibold text-dark-charcoal-70 hover:text-dark-charcoal"
     v-bind="$attrs"
+    @click="handleClick()"
   >
     <VIcon name="chevron-left" :rtl-flip="true" />
     {{ $t("single-result.back") }}
@@ -10,7 +11,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue"
+import { defineComponent, PropType } from "vue"
+
+import { useAnalytics } from "~/composables/use-analytics"
+import type { SupportedMediaType } from "~/constants/media"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
 import VLink from "~/components/VLink.vue"
@@ -24,6 +28,35 @@ export default defineComponent({
     VIcon,
     VLink,
   },
+  props: {
+    /**
+     * The unique ID of the media
+    */
+    id: {
+      type: String,
+      required: true,
+    },
+    /**
+     * The media type being searched
+     */
+     mediaType: {
+      type: String as PropType<SupportedMediaType>,
+      required: true,
+    },
+  },
   inheritAttrs: false,
+  setup(props) {
+    const { sendCustomEvent } = useAnalytics()
+    const handleClick = () => {
+      sendCustomEvent("BACK_TO_SEARCH", {
+        id: props.id,
+        mediaType: props.mediaType,
+      })
+    }
+
+    return {
+      handleClick
+    }
+  },
 })
 </script>

--- a/frontend/src/components/VBackToSearchResultsLink.vue
+++ b/frontend/src/components/VBackToSearchResultsLink.vue
@@ -3,7 +3,7 @@
   <VLink
     class="time inline-flex flex-row items-center gap-2 rounded-sm p-2 pe-3 text-xs font-semibold text-dark-charcoal-70 hover:text-dark-charcoal"
     v-bind="$attrs"
-    @click="handleClick"
+    @mousedown="handleClick"
   >
     <VIcon name="chevron-left" :rtl-flip="true" />
     {{ $t("single-result.back") }}

--- a/frontend/src/components/VBackToSearchResultsLink.vue
+++ b/frontend/src/components/VBackToSearchResultsLink.vue
@@ -3,7 +3,7 @@
   <VLink
     class="time inline-flex flex-row items-center gap-2 rounded-sm p-2 pe-3 text-xs font-semibold text-dark-charcoal-70 hover:text-dark-charcoal"
     v-bind="$attrs"
-    @click="handleClick()"
+    @click="handleClick"
   >
     <VIcon name="chevron-left" :rtl-flip="true" />
     {{ $t("single-result.back") }}
@@ -28,6 +28,7 @@ export default defineComponent({
     VIcon,
     VLink,
   },
+  inheritAttrs: false,
   props: {
     /**
      * The unique ID of the media
@@ -39,12 +40,11 @@ export default defineComponent({
     /**
      * The media type being searched
      */
-     mediaType: {
+    mediaType: {
       type: String as PropType<SupportedMediaType>,
       required: true,
     },
   },
-  inheritAttrs: false,
   setup(props) {
     const { sendCustomEvent } = useAnalytics()
     const handleClick = () => {

--- a/frontend/src/components/VBackToSearchResultsLink.vue
+++ b/frontend/src/components/VBackToSearchResultsLink.vue
@@ -11,10 +11,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue"
+import { defineComponent } from "vue"
 
 import { useAnalytics } from "~/composables/use-analytics"
-import type { SupportedMediaType } from "~/constants/media"
+import { useSearchStore } from "~/stores/search"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
 import VLink from "~/components/VLink.vue"
@@ -37,20 +37,15 @@ export default defineComponent({
       type: String,
       required: true,
     },
-    /**
-     * The media type being searched
-     */
-    mediaType: {
-      type: String as PropType<SupportedMediaType>,
-      required: true,
-    },
   },
   setup(props) {
     const { sendCustomEvent } = useAnalytics()
+    const searchStore = useSearchStore()
+
     const handleClick = () => {
       sendCustomEvent("BACK_TO_SEARCH", {
         id: props.id,
-        mediaType: props.mediaType,
+        searchType: searchStore.searchType,
       })
     }
 

--- a/frontend/src/components/VBackToSearchResultsLink.vue
+++ b/frontend/src/components/VBackToSearchResultsLink.vue
@@ -32,7 +32,7 @@ export default defineComponent({
   props: {
     /**
      * The unique ID of the media
-    */
+     */
     id: {
       type: String,
       required: true,
@@ -55,7 +55,7 @@ export default defineComponent({
     }
 
     return {
-      handleClick
+      handleClick,
     }
   },
 })

--- a/frontend/src/components/VLink.vue
+++ b/frontend/src/components/VLink.vue
@@ -5,6 +5,7 @@
     :class="{ 'inline-flex flex-row items-center gap-2': showExternalIcon }"
     :to="linkTo"
     v-on="$listeners"
+    @mousedown.native="$emit('mousedown', $event)"
     @click.native="$emit('click', $event)"
   >
     <slot />

--- a/frontend/src/components/meta/VBackToSearchResultsLink.stories.mdx
+++ b/frontend/src/components/meta/VBackToSearchResultsLink.stories.mdx
@@ -8,7 +8,7 @@ import VBackToSearchResultsLink from "~/components/VBackToSearchResultsLink.vue"
 />
 
 export const Template = (args) => ({
-  template: `<VBackToSearchResultsLink v-bind="args"/>`,
+  template: `<VBackToSearchResultsLink v-bind="args" :id="id" :media-type="mediaType" />`,
   components: { VBackToSearchResultsLink },
   setup() {
     return { args }

--- a/frontend/src/components/meta/VBackToSearchResultsLink.stories.mdx
+++ b/frontend/src/components/meta/VBackToSearchResultsLink.stories.mdx
@@ -8,7 +8,7 @@ import VBackToSearchResultsLink from "~/components/VBackToSearchResultsLink.vue"
 />
 
 export const Template = (args) => ({
-  template: `<VBackToSearchResultsLink v-bind="args" :id="id" :media-type="mediaType" />`,
+  template: `<VBackToSearchResultsLink v-bind="args" :id="id" />`,
   components: { VBackToSearchResultsLink },
   setup() {
     return { args }

--- a/frontend/src/pages/audio/_id/index.vue
+++ b/frontend/src/pages/audio/_id/index.vue
@@ -1,11 +1,7 @@
 <template>
   <VSkipToContentContainer as="main">
     <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
-      <VBackToSearchResultsLink
-        :id="audio.id"
-        :href="backToSearchPath"
-        :media-type="audio.frontendMediaType"
-      />
+      <VBackToSearchResultsLink :id="audio.id" :href="backToSearchPath" />
     </div>
 
     <VAudioTrack layout="full" :audio="audio" class="main-track" />

--- a/frontend/src/pages/audio/_id/index.vue
+++ b/frontend/src/pages/audio/_id/index.vue
@@ -1,7 +1,11 @@
 <template>
   <VSkipToContentContainer as="main">
     <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
-      <VBackToSearchResultsLink :href="backToSearchPath" />
+      <VBackToSearchResultsLink
+        :id="audio.id"
+        :href="backToSearchPath"
+        :media-type="audio.frontendMediaType"
+      />
     </div>
 
     <VAudioTrack layout="full" :audio="audio" class="main-track" />

--- a/frontend/src/pages/image/_id/index.vue
+++ b/frontend/src/pages/image/_id/index.vue
@@ -1,11 +1,7 @@
 <template>
   <VSkipToContentContainer as="main">
     <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
-      <VBackToSearchResultsLink
-        :id="image.id"
-        :href="backToSearchPath"
-        :media-type="image.frontendMediaType"
-      />
+      <VBackToSearchResultsLink :id="image.id" :href="backToSearchPath" />
     </div>
 
     <figure class="relative mb-4 border-b border-dark-charcoal-20 px-6">

--- a/frontend/src/pages/image/_id/index.vue
+++ b/frontend/src/pages/image/_id/index.vue
@@ -1,7 +1,11 @@
 <template>
   <VSkipToContentContainer as="main">
     <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
-      <VBackToSearchResultsLink :href="backToSearchPath" />
+      <VBackToSearchResultsLink
+        :id="image.id"
+        :href="backToSearchPath"
+        :media-type="image.frontendMediaType"
+      />
     </div>
 
     <figure class="relative mb-4 border-b border-dark-charcoal-20 px-6">

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,4 +1,4 @@
-import type { MediaType } from "~/constants/media"
+import type { MediaType, SearchType } from "~/constants/media"
 import type { ReportReason } from "~/constants/content-report"
 
 /**
@@ -34,8 +34,8 @@ export type Events = {
   BACK_TO_SEARCH: {
     /** The unique ID of the media */
     id: string
-    /** The media type being searched */
-    mediaType: MediaType
+    /** The content type being searched (can include All content) */
+    searchType: SearchType
   }
   /**
    * Description: The user clicks the CTA button to the external source to use the image

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -27,6 +27,17 @@ export type Events = {
     identifier: string
   }
   /**
+   * Click on the 'back to search' link on a single result
+   *
+   * - Are these links used much? Are they necessary?
+   */
+  BACK_TO_SEARCH: {
+    /** The unique ID of the media */
+    id: string
+    /** The media type being searched */
+    mediaType: MediaType
+  }
+  /**
    * Description: The user clicks the CTA button to the external source to use the image
    * Questions:
    *   - How often do users go to the source after viewing a result?

--- a/frontend/test/playwright/e2e/attribution.spec.ts
+++ b/frontend/test/playwright/e2e/attribution.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test"
 
+import { turnOnAnalytics } from "~~/test/playwright/utils/navigation"
+
 test.describe.configure({ mode: "parallel" })
 
 test.beforeEach(async ({ context }) => {
@@ -62,6 +64,8 @@ test("sends analytics event on copy", async ({ page }) => {
   const mediaType = "image"
   const id = "e9d97a98-621b-4ec2-bf70-f47a74380452"
   const format = "rich"
+
+  await turnOnAnalytics(page)
 
   await page.goto(`${mediaType}/${id}?ff_analytics=on`)
   await page.click(`[id="copyattr-${format}"]`)

--- a/frontend/test/playwright/utils/navigation.ts
+++ b/frontend/test/playwright/utils/navigation.ts
@@ -404,3 +404,8 @@ export const closeFiltersUsingCookies = async (page: Page) => {
 export const setBreakpointCookie = async (page: Page, breakpoint: string) => {
   await setCookies(page.context(), { uiBreakpoint: breakpoint })
 }
+
+export const turnOnAnalytics = async (page: Page) => {
+  await page.goto("/preferences")
+  await page.getByLabel("Record custom events and page views.").click()
+}

--- a/frontend/test/unit/setup.js
+++ b/frontend/test/unit/setup.js
@@ -19,7 +19,13 @@ Vue.use(VueI18n)
  */
 config.stubs["nuxt-link"] = Vue.component("NuxtLink", {
   props: ["to"],
-  template: '<a :href="to" v-on="$listeners"><slot /></a>',
+  methods: {
+    handleClick() {
+      this.$emit("mousedown")
+      this.$emit("click", new MouseEvent("click"))
+    },
+  },
+  template: '<a :href="to" v-on="$listeners" @click="handleClick"><slot /></a>',
 })
 
 config.stubs["svg-icon"] = Vue.component("SvgIcon", {

--- a/frontend/test/unit/setup.js
+++ b/frontend/test/unit/setup.js
@@ -21,6 +21,9 @@ config.stubs["nuxt-link"] = Vue.component("NuxtLink", {
   props: ["to"],
   methods: {
     handleClick() {
+      // This is an adaptation to mimic NuxtLink's behavior,
+      // see https://github.com/WordPress/openverse/pull/1118
+      // We should try to remove it after migrating to Nuxt 3.
       this.$emit("mousedown")
       this.$emit("click", new MouseEvent("click"))
     },

--- a/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
+++ b/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
@@ -1,0 +1,45 @@
+import { createLocalVue } from "@vue/test-utils"
+import { fireEvent, render } from "@testing-library/vue"
+
+import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
+
+import { useAnalytics } from "~/composables/use-analytics"
+
+import VBackToSearchResultsLink from "~/components/VBackToSearchResultsLink.vue"
+
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(() => ({
+    sendCustomEvent: jest.fn(),
+  })),
+}))
+
+const localVue = createLocalVue()
+localVue.use(PiniaVuePlugin)
+describe("VBackToSearchResultsLink", () => {
+  it("should send analytics event when clicked", async () => {
+    const sendCustomEventMock = jest.fn()
+
+    useAnalytics.mockImplementation(() => ({
+      sendCustomEvent: sendCustomEventMock,
+    }))
+
+    const propsData = {
+      id: "123",
+      href: "/search",
+    }
+
+    const screen = render(VBackToSearchResultsLink, {
+      localVue,
+      pinia: createPinia(),
+      propsData,
+    })
+    const link = screen.getByText("single-result.back")
+
+    await fireEvent.click(link)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("BACK_TO_SEARCH", {
+      id: propsData.id,
+      searchType: "all",
+    })
+  })
+})

--- a/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
+++ b/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
@@ -8,9 +8,7 @@ import { useAnalytics } from "~/composables/use-analytics"
 import VBackToSearchResultsLink from "~/components/VBackToSearchResultsLink.vue"
 
 jest.mock("~/composables/use-analytics", () => ({
-  useAnalytics: jest.fn(() => ({
-    sendCustomEvent: jest.fn(),
-  })),
+  useAnalytics: jest.fn(),
 }))
 
 const localVue = createLocalVue()


### PR DESCRIPTION
## Fixes

Fixes #1087 by @dhruvkb 

## Description

* Adds `BACK_TO_SEARCH` event to the Events type.
* Fires the event from `VBackToSearchResultsLink.vue` using the `useAnalytics` composable.