### PR TITLE
Prevent non-uniform event names or overwriting default props

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -165,6 +165,7 @@
     "tailwindcss-rtl": "^0.9.0",
     "talkback": "^3.0.1",
     "ts-node": "^10.9.1",
+    "type-fest": "^3.7.2",
     "typescript": "^4.9.5",
     "vue-demi": "^0.13.11",
     "vue-i18n-extract": "^2.0.7",

--- a/frontend/src/composables/use-analytics.ts
+++ b/frontend/src/composables/use-analytics.ts
@@ -1,7 +1,12 @@
 import { computed } from "vue"
 import { useContext } from "@nuxtjs/composition-api"
 
-import type { Events, EventName } from "~/types/analytics"
+import type {
+  Events,
+  EventName,
+  NoPayloadEventName,
+  PayloadEventName,
+} from "~/types/analytics"
 import { useUiStore } from "~/stores/ui"
 
 /**
@@ -54,10 +59,12 @@ export const useAnalytics = () => {
    * @param name - the name of the event being recorded
    * @param payload - the additional information to record about the event
    */
-  const sendCustomEvent = <T extends EventName>(
+  function sendCustomEvent<T extends NoPayloadEventName>(name: T): void
+  function sendCustomEvent<T extends PayloadEventName>(
     name: T,
     payload: Events[T]
-  ) => {
+  ): void
+  function sendCustomEvent<T extends EventName>(name: T, payload?: Events[T]) {
     $plausible.trackEvent(name, {
       props: {
         ...isomorphicProps.value,

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,61 +1,3 @@
-import type { UnionToIntersection } from "type-fest"
-
-type ReservedPropNames =
-  | "timestamp"
-  | "language"
-  | "breakpoint"
-  | "ua"
-  | "os"
-  | "platform"
-  | "browser"
-  | "version"
-  | "origin"
-  | "pathname"
-  | "referrer"
-  | "width"
-  | "height"
-
-type BaseEventsType = Record<string, Record<string, string | number | boolean>>
-
-type MergePayloadTypes<E extends BaseEventsType> = UnionToIntersection<
-  E[keyof E]
->
-type ValidatePayloads<
-  E extends BaseEventsType,
-  Payloads = MergePayloadTypes<E>
-> = Omit<Payloads, ReservedPropNames> extends Payloads
-  ? E
-  : "Payloads include reserved prop names."
-
-type ExtractEventNames<E> = E extends Record<infer K, unknown>
-  ? K extends string
-    ? K
-    : never
-  : never
-
-type ValidateEventNames<E> = ExtractEventNames<E> extends Uppercase<
-  ExtractEventNames<E>
->
-  ? E
-  : "Event names must be in SCREAMING_SNAKE_CASE."
-
-type OnlyErrors<A, B> = A extends string
-  ? B extends string
-    ? A | B
-    : A
-  : B extends string
-  ? B
-  : boolean
-
-type ValidateEvents<
-  E extends BaseEventsType,
-  ValidatedEventNames = ValidateEventNames<E>,
-  ValidatedPayloads = ValidatePayloads<E>,
-  Errors = OnlyErrors<ValidatedEventNames, ValidatedPayloads>
-> = Errors extends string ? Errors : E
-
-type IsRecord<E extends BaseEventsType> = E
-
 /**
  * compound type of all custom events sent from the site; Index with `EventName`
  * to get the type of the payload for a specific event.
@@ -67,7 +9,7 @@ type IsRecord<E extends BaseEventsType> = E
  * - Documentation must be the step to emit the event, followed by a line break.
  * - Questions that are answered by the event must be listed as bullet points.
  */
-export type Events = ValidateEvents<{
+export type Events = {
   /**
    * Click on one of the images in the gallery on the homepage.
    *
@@ -81,16 +23,7 @@ export type Events = ValidateEvents<{
     /** the identifier of the image */
     identifier: string
   }
-}>
-
-/**
- * If `Events` is not a valid type parameter to `IsRecord` then
- * the configuration is invalid. `Events` will be set to string
- * types represnting the specific error case(s) present.
- *
- * Exported to avoid needing to ignore the unused variable error.
- */
-export type IsValid = IsRecord<Events>
+}
 
 /**
  * the name of a custom event sent from the site

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,3 +1,5 @@
+import type { ConditionalKeys } from "type-fest"
+
 /**
  * compound type of all custom events sent from the site; Index with `EventName`
  * to get the type of the payload for a specific event.
@@ -8,6 +10,8 @@
  * - Names should be in past tense for events not associated with user action.
  * - Documentation must be the step to emit the event, followed by a line break.
  * - Questions that are answered by the event must be listed as bullet points.
+ *
+ * Use `never` for the payload type to indicate an event with no payload.
  */
 export type Events = {
   /**
@@ -28,4 +32,6 @@ export type Events = {
 /**
  * the name of a custom event sent from the site
  */
+export type NoPayloadEventName = ConditionalKeys<Events, never>
+export type PayloadEventName = Exclude<keyof Events, NoPayloadEventName>
 export type EventName = keyof Events

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,3 +1,61 @@
+import type { UnionToIntersection } from "type-fest"
+
+type ReservedPropNames =
+  | "timestamp"
+  | "language"
+  | "breakpoint"
+  | "ua"
+  | "os"
+  | "platform"
+  | "browser"
+  | "version"
+  | "origin"
+  | "pathname"
+  | "referrer"
+  | "width"
+  | "height"
+
+type BaseEventsType = Record<string, Record<string, string | number | boolean>>
+
+type MergePayloadTypes<E extends BaseEventsType> = UnionToIntersection<
+  E[keyof E]
+>
+type ValidatePayloads<
+  E extends BaseEventsType,
+  Payloads = MergePayloadTypes<E>
+> = Omit<Payloads, ReservedPropNames> extends Payloads
+  ? E
+  : "Payloads include reserved prop names."
+
+type ExtractEventNames<E> = E extends Record<infer K, unknown>
+  ? K extends string
+    ? K
+    : never
+  : never
+
+type ValidateEventNames<E> = ExtractEventNames<E> extends Uppercase<
+  ExtractEventNames<E>
+>
+  ? E
+  : "Event names must be in SCREAMING_SNAKE_CASE."
+
+type OnlyErrors<A, B> = A extends string
+  ? B extends string
+    ? A | B
+    : A
+  : B extends string
+  ? B
+  : boolean
+
+type ValidateEvents<
+  E extends BaseEventsType,
+  ValidatedEventNames = ValidateEventNames<E>,
+  ValidatedPayloads = ValidatePayloads<E>,
+  Errors = OnlyErrors<ValidatedEventNames, ValidatedPayloads>
+> = Errors extends string ? Errors : E
+
+type IsRecord<E extends BaseEventsType> = E
+
 /**
  * compound type of all custom events sent from the site; Index with `EventName`
  * to get the type of the payload for a specific event.
@@ -9,7 +67,7 @@
  * - Documentation must be the step to emit the event, followed by a line break.
  * - Questions that are answered by the event must be listed as bullet points.
  */
-export type Events = {
+export type Events = ValidateEvents<{
   /**
    * Click on one of the images in the gallery on the homepage.
    *
@@ -23,7 +81,16 @@ export type Events = {
     /** the identifier of the image */
     identifier: string
   }
-}
+}>
+
+/**
+ * If `Events` is not a valid type parameter to `IsRecord` then
+ * the configuration is invalid. `Events` will be set to string
+ * types represnting the specific error case(s) present.
+ *
+ * Exported to avoid needing to ignore the unused variable error.
+ */
+export type IsValid = IsRecord<Events>
 
 /**
  * the name of a custom event sent from the site

--- a/frontend/src/types/validate-analytics.ts
+++ b/frontend/src/types/validate-analytics.ts
@@ -1,0 +1,70 @@
+import type { Events } from "~/types/analytics"
+
+import type { UnionToIntersection } from "type-fest"
+
+type ReservedPropNames =
+  | "timestamp"
+  | "language"
+  | "breakpoint"
+  | "ua"
+  | "os"
+  | "platform"
+  | "browser"
+  | "version"
+  | "origin"
+  | "pathname"
+  | "referrer"
+  | "width"
+  | "height"
+
+type BaseEventsType = Record<string, Record<string, string | number | boolean>>
+
+type MergePayloadTypes<E extends BaseEventsType> = UnionToIntersection<
+  E[keyof E]
+>
+type ValidatePayloads<
+  E extends BaseEventsType,
+  Payloads = MergePayloadTypes<E>
+> = Omit<Payloads, ReservedPropNames> extends Payloads
+  ? E
+  : "Payloads include reserved prop names."
+
+type ExtractEventNames<E> = E extends Record<infer K, unknown>
+  ? K extends string
+    ? K
+    : never
+  : never
+
+type ValidateEventNames<E> = ExtractEventNames<E> extends Uppercase<
+  ExtractEventNames<E>
+>
+  ? E
+  : "Event names must be in SCREAMING_SNAKE_CASE."
+
+type OnlyErrors<A, B> = A extends string
+  ? B extends string
+    ? A | B
+    : A
+  : B extends string
+  ? B
+  : boolean
+
+type ValidateEvents<
+  E extends BaseEventsType,
+  ValidatedEventNames = ValidateEventNames<E>,
+  ValidatedPayloads = ValidatePayloads<E>,
+  Errors = OnlyErrors<ValidatedEventNames, ValidatedPayloads>
+> = Errors extends string ? Errors : E
+
+type IsRecord<E extends BaseEventsType> = E
+
+type EventsOrErrors = ValidateEvents<Events>
+
+/**
+ * If `Events` is not a valid type parameter to `IsRecord` then
+ * the configuration is invalid. `Events` will be set to string
+ * types represnting the specific error case(s) present.
+ *
+ * Exported to avoid needing to ignore the unused variable error.
+ */
+export type IsValid = IsRecord<EventsOrErrors>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,7 @@ importers:
       talkback: ^3.0.1
       throttle-debounce: ^5.0.0
       ts-node: ^10.9.1
+      type-fest: ^3.7.2
       typescript: ^4.9.5
       uuid: ^8.3.2
       vue: ^2.7.14
@@ -240,6 +241,7 @@ importers:
       tailwindcss-rtl: 0.9.0
       talkback: 3.0.1
       ts-node: 10.9.1_ytxlagnlbjxf7pw6smm3knvnbq
+      type-fest: 3.7.2
       typescript: 4.9.5
       vue-demi: 0.13.11_vue@2.7.14
       vue-i18n-extract: 2.0.7
@@ -18716,6 +18718,11 @@ packages:
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /type-fest/3.7.2:
+    resolution: {integrity: sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /type-is/1.6.18:


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

There is no issue for this. I don't think it is absolutely necessary and was mostly motivated by wondering if this was even possible to do. If @dhruvkb or @obulat do not feel this is worthwhile to add or maintain, then we can close the PR, no problem.

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Validates the `Events` type by doing some TypeScript magic to validate the following:

- That all event names are in uppercase. I started adding validation to check that `-` and space were not used as separators, but that felt unnecessary and made things even more complicated.
- That payload types do not include prop names that overlap with the default/reserved prop names.

When either of these things is the case, the `EventsOrErrors` type will be a string that has descriptive content for help identifying the problem. Examples:

![Error message indicating usage of reserved payload prop names](https://user-images.githubusercontent.com/24264157/229423199-3ee939a2-86fb-461d-9ce0-0619980abd52.png)

![Error message indicating both usage of reserved payload prop names and incorrect event names](https://user-images.githubusercontent.com/24264157/229423299-8ee02aa3-7b3a-456a-b393-ca23cc8af99d.png)

![Error message indicating incorrect event names](https://user-images.githubusercontent.com/24264157/229423664-381d27c1-e254-4293-b4a9-031e6276cbd4.png)

These error strings won't show as TS will only be complaining that the string type is not assignable to `BaseEventsType`. The error messages are only visible when inspecting the types in an editor with type help like VSCode. I don't know if WebStorm behaves similarly and would reveal the underlying string.

I've also gone ahead and made it possible to have custom events with zero payload which will be necessary for the `OPEN_PAGES_MENU` event. **This part of the PR I believe we should keep regardless as it is fundamentally necessary for implementing the full list of events.**

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and make changes to the Events configuration object that would cause an invalid configuration.

Try out the changes to the `sendCustomEvent` function after adding some new events, including ones that have `never` payload.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
