### PR TITLE
Modify Renovate to apply appropriate labels to docker PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "gitAuthor": "Openverse Bot <openverse@wordpress.org>",
   "onboarding": false,
   "platform": "github",
-  "repositories": ["WordPress/openverse-frontend"],
+  "repositories": ["WordPress/openverse"],
   "extends": ["config:base", ":preserveSemverRanges", "schedule:monthly"],
   "prCommitsPerRunLimit": 3,
   "labels": [
@@ -13,9 +13,12 @@
     "🧰 goal: internal improvement",
     "🟩 priority: low"
   ],
-  "docker": {
-    "labels": ["🐳 tech: docker"]
-  },
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "labels": ["🐳 tech: docker"]
+    }
+  ],
   "ignorePaths": ["package.json"],
   "includeForks": false
 }


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR changes the Renovate config so that it applies the docker-specific labels appropriately. I noticed in https://github.com/WordPress/openverse/pull/1109 that instead of adding the 4 base labels _and_ the docker label, Renovate instead only added the Docker label. [Based on their documentation](https://docs.renovatebot.com/configuration-options/#labels), it seems like using the `packageRules` directive is the correct way to apply multiple sets of labels rather than using `docker.labels`.

Additionally, the config referenced a repo which is now archived. It's a wonder it was working at all!

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I'm not sure how to test this...open to suggestions :slightly_smiling_face:

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
