### PR TITLE
Update pre-commit deps, pin actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -52,26 +52,26 @@ repos:
           - --lines-after-imports=2
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args:
           - --py310-plus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.257"
+    rev: "v0.0.261"
     hooks:
       - id: ruff
 
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         args:
           - --safe
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.2.2 # 6.2.3 is slightly broken
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         args:
@@ -87,7 +87,7 @@ repos:
           - --add-ignore=D1,D202,D205,D211,D400
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.15.0
+    rev: v8.37.0
     hooks:
       - id: eslint
         files: \.(js|ts|vue)$
@@ -125,12 +125,12 @@ repos:
           - typescript@4.9.3
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/rhysd/actionlint
-    rev: main
+    rev: v1.6.24
     hooks:
       - id: actionlint-docker
 

--- a/automations/python/issues_with_prs.py
+++ b/automations/python/issues_with_prs.py
@@ -247,7 +247,7 @@ def main():
             cards_to_move.append((issue_card, issue))
     log.info(f"Found {len(cards_to_move)} cards to move")
 
-    for (issue_card, issue) in cards_to_move:
+    for issue_card, issue in cards_to_move:
         log.info(f"Moving card for issue {issue.html_url} to {target_column.name}")
         issue_card.move("bottom", target_column)
 

--- a/documentation/_ext/link_issues.py
+++ b/documentation/_ext/link_issues.py
@@ -89,7 +89,6 @@ class PendingIssueXRef(pending_xref):
 
 
 class IssueReferences(SphinxTransform):
-
     default_priority = 999
 
     def apply(self) -> None:

--- a/templates/.pre-commit-config.yaml.jinja
+++ b/templates/.pre-commit-config.yaml.jinja
@@ -11,7 +11,7 @@ repos:
   {% block repos_top %}
   {% endblock %}
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -48,26 +48,26 @@ repos:
           - --lines-after-imports=2
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args:
           - --py310-plus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.257"
+    rev: "v0.0.261"
     hooks:
       - id: ruff
 
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         args:
           - --safe
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.2.2 # 6.2.3 is slightly broken
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         args:
@@ -85,7 +85,7 @@ repos:
   {% endif %}
   {% if contains_js_code | default(true) %}
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.15.0
+    rev: v8.37.0
     hooks:
       - id: eslint
         files: {{ eslint_files | default("^js/.*$") }}
@@ -117,12 +117,12 @@ repos:
 
 {# This comment adds a blank line. #}
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/rhysd/actionlint
-    rev: main
+    rev: v1.6.24
     hooks:
       - id: actionlint-docker
   {% block repos_bottom %}


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Similar to https://github.com/WordPress/openverse-infrastructure/pull/456

Fix based on this warning I observed locally when running just lint:

```
[WARNING] The 'rev' field of repo 'https://github.com/rhysd/actionlint' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
```

I ran pre-commit autoupdate (and applied the changes to the jinja template) and this PR was the result of the changes.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just lint`

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
