### PR TITLE
Use the built-in Tailwind named groups

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -161,7 +161,6 @@
     "rimraf": "^3.0.2",
     "tailwind-config-viewer": "^1.6.3",
     "tailwindcss": "^3.2.4",
-    "tailwindcss-labeled-groups": "^0.0.2",
     "tailwindcss-rtl": "^0.9.0",
     "talkback": "^3.0.1",
     "ts-node": "^10.9.1",

--- a/frontend/src/components/VAudioTrack/VWaveform.vue
+++ b/frontend/src/components/VAudioTrack/VWaveform.vue
@@ -2,7 +2,7 @@
   <div
     v-bind="waveformAttributes"
     ref="el"
-    class="waveform bg-background-var group-waveform relative overflow-hidden text-dark-charcoal focus:outline-none"
+    class="waveform bg-background-var group/waveform relative overflow-hidden text-dark-charcoal focus:outline-none"
     :style="heightProperties"
     :tabIndex="isTabbable && isInteractive ? 0 : -1"
     :aria-disabled="!isInteractive"
@@ -12,7 +12,7 @@
     <!-- Focus ring -->
     <svg
       v-if="isInteractive"
-      class="shadow-ring-1 absolute inset-0 z-20 hidden h-full w-full group-waveform-focus:block"
+      class="shadow-ring-1 absolute inset-0 z-20 hidden h-full w-full group-focus/waveform:block"
       xmlns="http://www.w3.org/2000/svg"
       :viewBox="viewBox"
       preserveAspectRatio="none"
@@ -85,7 +85,7 @@
     <!-- Focus bar -->
     <div
       v-if="isInteractive && isSeeking"
-      class="absolute top-0 z-20 hidden h-full flex-col items-center justify-between bg-black group-focus:flex group-waveform-focus:flex"
+      class="absolute top-0 z-20 hidden h-full flex-col items-center justify-between bg-black group-focus:flex group-focus/waveform:flex"
       :style="{ width: `${barWidth}px`, left: `${progressBarWidth}px` }"
     >
       <div

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -229,7 +229,6 @@ module.exports = {
     require("tailwindcss-rtl"),
     require("@tailwindcss/line-clamp"),
     require("@tailwindcss/typography"),
-    require("tailwindcss-labeled-groups")(["waveform"]),
     // Focus styles
     // This plugin has related stylesheets in `src/styles/tailwind.css`.
     plugin(({ matchUtilities, theme }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,6 @@ importers:
       seeded-rand: ^2.0.1
       tailwind-config-viewer: ^1.6.3
       tailwindcss: ^3.2.4
-      tailwindcss-labeled-groups: ^0.0.2
       tailwindcss-rtl: ^0.9.0
       talkback: ^3.0.1
       throttle-debounce: ^5.0.0
@@ -236,7 +235,6 @@ importers:
       rimraf: 3.0.2
       tailwind-config-viewer: 1.6.3_tailwindcss@3.2.4
       tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
-      tailwindcss-labeled-groups: 0.0.2_tailwindcss@3.2.4
       tailwindcss-rtl: 0.9.0
       talkback: 3.0.1
       ts-node: 10.9.1_ytxlagnlbjxf7pw6smm3knvnbq
@@ -18212,14 +18210,6 @@ packages:
       tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /tailwindcss-labeled-groups/0.0.2_tailwindcss@3.2.4:
-    resolution: {integrity: sha512-leOVv9h2K9WDHoXPXVBOmTJgWECVkpVFc/hjrwuqGUEtNxvRvuOtCjenu9ppY+pJtky5INJUqDCNa8pS3AbYmw==}
-    peerDependencies:
-      tailwindcss: ^3.0.23
-    dependencies:
-      tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
     dev: true
 
   /tailwindcss-rtl/0.9.0:


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We used a separate library, `tailwindcss-labeled-groups`, to be able to use a labeled or named group in tailwind. Now that this functionality is available in Tailwind as a built-in, we can remove the use of this library.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The app should run as it does, normally. The library was used to show the waveform and the played section of it on focus. Check that the waveform displays correctly on focus.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
