### PR TITLE
Analytics event: REPORT_MEDIA

### DIFF
--- a/frontend/src/components/VContentReport/VContentReportForm.vue
+++ b/frontend/src/components/VContentReport/VContentReportForm.vue
@@ -90,6 +90,7 @@
             as="VLink"
             variant="secondary-filled"
             :href="DMCA_FORM_URL"
+            @click="handleDmcaSubmit"
           >
             {{ $t("media-details.content-report.form.dmca.open") }}
             <VIcon :size="4" class="ms-1" :icon-path="icons.externalLink" />
@@ -128,6 +129,7 @@ import {
 } from "~/constants/content-report"
 
 import type { AudioDetail, ImageDetail } from "~/types/media"
+import { useAnalytics } from "~/composables/use-analytics"
 
 import VButton from "~/components/VButton.vue"
 import VIcon from "~/components/VIcon/VIcon.vue"
@@ -183,16 +185,37 @@ export default defineComponent({
     const isSubmitDisabled = computed(
       () => selectedReason.value === OTHER && description.value.length < 20
     )
+
+    const { sendCustomEvent } = useAnalytics()
+
+    const handleDmcaSubmit = () => {
+      sendCustomEvent("REPORT_MEDIA", {
+        id: props.media.id,
+        mediaType: props.media.frontendMediaType,
+        provider: props.media.provider,
+        reason: selectedReason.value,
+      })
+      status.value = SENT
+    }
     const handleSubmit = async (event: Event) => {
       event.preventDefault()
-      if (selectedReason.value === DMCA) return
       // Submit report
       try {
+        const mediaType = props.media.frontendMediaType
+        const reason = selectedReason.value
+
         await ReportService.sendReport({
-          mediaType: props.media.frontendMediaType,
+          mediaType,
+          reason,
           identifier: props.media.id,
-          reason: selectedReason.value,
           description: description.value,
+        })
+
+        sendCustomEvent("REPORT_MEDIA", {
+          mediaType,
+          reason,
+          id: props.media.id,
+          provider: props.media.provider,
         })
         status.value = SENT
       } catch (error) {
@@ -219,6 +242,7 @@ export default defineComponent({
 
       isSubmitDisabled,
       handleSubmit,
+      handleDmcaSubmit,
     }
   },
 })

--- a/frontend/src/components/VContentReport/VContentReportForm.vue
+++ b/frontend/src/components/VContentReport/VContentReportForm.vue
@@ -65,6 +65,7 @@
             v-if="media.foreign_landing_url && selectedReason === DMCA"
             :provider="providerName"
             :foreign-landing-url="media.foreign_landing_url"
+            @click="handleDmcaSubmit"
           />
           <VReportDescForm
             v-if="selectedReason !== DMCA"

--- a/frontend/src/components/VContentReport/VDmcaNotice.vue
+++ b/frontend/src/components/VContentReport/VDmcaNotice.vue
@@ -9,6 +9,7 @@
         :aria-label="$t('media-details.content-report.form.dmca.form')"
         :href="DMCA_FORM_URL"
         class="text-pink hover:underline"
+        @click="$emit('click')"
         >{{ $t("media-details.content-report.form.dmca.form") }}</VLink
       >
     </template>
@@ -24,6 +25,7 @@
 import { defineComponent } from "vue"
 
 import { DMCA_FORM_URL } from "~/constants/content-report"
+import { defineEvent } from "~/types/emits"
 
 import VLink from "~/components/VLink.vue"
 
@@ -45,6 +47,9 @@ export default defineComponent({
       type: String,
       required: true,
     },
+  },
+  emits: {
+    click: defineEvent(),
   },
   setup() {
     return {

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,4 +1,5 @@
 import type { MediaType } from "~/constants/media"
+import type { ReportReason } from "~/constants/content-report"
 
 /**
  * Compound type of all custom events sent from the site; Index with `EventName`
@@ -51,6 +52,27 @@ export type Events = {
     format: "plain" | "rich" | "html"
     /** The media type being searched */
     mediaType: MediaType
+  }
+  /**
+   * Description: The user reports a piece of media through our form
+   * Questions:
+   *   - How often do we get reports?
+   *   - Which types of reports are more common?
+   *   - Do we see an uptick in reports when a certain provider
+   *     is added/updated/refreshed?
+   * Note: Because the DMCA report is sent via a Google form, we send
+   * this event when the form is opened, and not when the report form
+   * is actually sent.
+   */
+  REPORT_MEDIA: {
+    /** the unique ID of the media */
+    id: string
+    /** the slug (not the prettified name) of the provider */
+    provider: string
+    /** the media type being searched */
+    mediaType: MediaType
+    /** the reason for the report */
+    reason: ReportReason
   }
 }
 

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,17 +1,20 @@
-import { fireEvent, render, screen } from "@testing-library/vue"
 import VueI18n from "vue-i18n"
+
+import { fireEvent, render, screen } from "@testing-library/vue"
+import { createLocalVue } from "@vue/test-utils"
+
+import { createPinia } from "~~/test/unit/test-utils/pinia"
+import i18n from "~~/test/unit/test-utils/i18n"
 
 import ReportService from "~/data/report-service"
 
 import VContentReportForm from "~/components/VContentReport/VContentReportForm.vue"
 
-const messages = require("~/locales/en.json")
-
-const i18n = new VueI18n({
-  locale: "en",
-  fallbackLocale: "en",
-  messages: { en: messages },
-})
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(() => ({
+    sendCustomEvent: jest.fn(),
+  })),
+}))
 
 const getDmcaInput = () =>
   screen.getByRole("radio", {
@@ -54,6 +57,8 @@ jest.mock("~/data/report-service", () => ({
 describe("VContentReportForm", () => {
   let props = null
   let options = {}
+  let pinia = null
+  let localVue = null
 
   beforeEach(() => {
     props = {
@@ -66,11 +71,17 @@ describe("VContentReportForm", () => {
       providerName: "Provider",
       closeFn: jest.fn(),
     }
+    pinia = createPinia()
+    localVue = createLocalVue()
+    localVue.use(pinia)
+    localVue.use(VueI18n)
 
     options = {
       propsData: props,
-      i18n,
       stubs: ["VIcon"],
+      localVue,
+      pinia,
+      i18n,
     }
   })
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1082 by @dhruvkb 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds `REPORT_MEDIA` analytics event.

The DMCA report uses an external form, and there is no way of getting the actual "report submitted" event programmatically from the app (we can, of course, create some automation for the Google form submission, but that is outside of scope for this PR).  I decided to send the event when the user clicks on the "Open form" button for the DMCA report.

The RFC did not contain the `reason` property for the event even though it was mentioned in the docstrings. Do we want to update the RFC, @dhruvkb, or is implementing it here enough?

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Set up the analytics by running `just frontend/init`.
Run the app using `just frontend/run dev`.
If you click on "Report content" on the single result page, you should see the event in Plausible: http://0.0.0.0:50288/localhost?goal=REPORT_MEDIA 

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
