### PR TITLE
Remove primary button variant and make variant required

### DIFF
--- a/frontend/src/components/VButton.vue
+++ b/frontend/src/components/VButton.vue
@@ -97,12 +97,10 @@ const VButton = defineComponent({
      *
      * Plain removes all styles except the focus ring.
      * Plain--avoid removes _all_ styles including the focus ring.
-     *
-     * @default 'primary'
      */
     variant: {
       type: String as PropType<ButtonVariant>,
-      default: "primary",
+      required: true,
     },
     /**
      * Allows for programmatically setting the pressed state of a button,
@@ -366,13 +364,6 @@ a.button {
 }
 .transparent-dark {
   @apply border-tx bg-tx text-dark-charcoal hover:bg-dark-charcoal hover:text-white;
-}
-
-.primary {
-  @apply border-tx bg-pink text-white hover:border-tx hover:bg-dark-pink hover:text-white;
-}
-.primary-pressed {
-  @apply bg-dark-pink;
 }
 
 .secondary {

--- a/frontend/src/components/VFilters/VSearchGridFilter.vue
+++ b/frontend/src/components/VFilters/VSearchGridFilter.vue
@@ -27,14 +27,6 @@
         @toggle-filter="toggleFilter"
       />
     </form>
-    <footer
-      v-if="showFilterHeader && isAnyFilterApplied"
-      class="flex justify-between md:hidden"
-    >
-      <VButton variant="primary" @click="$emit('close')">
-        {{ $t("filter-list.show") }}
-      </VButton>
-    </footer>
   </section>
 </template>
 

--- a/frontend/src/components/VHeader/VSearchBar/VSearchButton.vue
+++ b/frontend/src/components/VHeader/VSearchBar/VSearchButton.vue
@@ -2,8 +2,8 @@
   <VButton
     :aria-label="$t('search.search')"
     size="disabled"
-    :variant="route === 'home' ? 'primary' : 'plain'"
-    class="heading-6 h-full flex-shrink-0 rounded-s-none transition-none"
+    :variant="route === 'home' ? 'filled-pink' : 'plain'"
+    class="heading-6 h-full flex-shrink-0 rounded-s-none"
     :class="[
       route === 'home'
         ? 'w-[57px] whitespace-nowrap md:w-auto md:px-10 md:py-6'

--- a/frontend/src/components/VHeader/VSearchBar/VStandaloneSearchBar.vue
+++ b/frontend/src/components/VHeader/VSearchBar/VStandaloneSearchBar.vue
@@ -32,8 +32,8 @@
       type="submit"
       :aria-label="$t('search.search').toString()"
       size="disabled"
-      :variant="isHomeRoute ? 'primary' : 'plain'"
-      class="h-full w-14 flex-shrink-0 rounded-s-none transition-none sm:w-16"
+      :variant="isHomeRoute ? 'filled-pink' : 'plain'"
+      class="h-full w-14 flex-shrink-0 rounded-s-none sm:w-16"
       :class="{
         'search-button border !border-black p-0.5px ps-1.5px hover:bg-pink hover:text-white focus:!border-tx focus-visible:bg-pink focus-visible:text-white group-focus-within:!border-tx group-focus-within:bg-pink group-focus-within:text-white group-focus-within:hover:bg-dark-pink group-hover:!border-tx group-hover:bg-pink group-hover:text-white group-focus:!border-tx':
           !isHomeRoute,

--- a/frontend/src/components/VSkipToContentContainer.vue
+++ b/frontend/src/components/VSkipToContentContainer.vue
@@ -3,6 +3,7 @@
     <slot />
     <VTeleport to="skip-to-content">
       <VButton
+        variant="filled-pink"
         class="z-50 ms-2 mt-2 focus:fixed focus:absolute"
         :class="$style.skipButton"
         @click="skipToContent"

--- a/frontend/src/types/button.ts
+++ b/frontend/src/types/button.ts
@@ -3,7 +3,6 @@ export const buttonForms = ["VLink", "button"] as const
 export type ButtonForm = typeof buttonForms[number]
 
 export const buttonVariants = [
-  "primary",
   "secondary",
   "secondary-bordered",
   "secondary-filled",

--- a/frontend/test/unit/specs/components/v-button.spec.js
+++ b/frontend/test/unit/specs/components/v-button.spec.js
@@ -20,6 +20,7 @@ describe("VButton", () => {
   })
   it('should render a `button` by default with type="button" and no tabindex', async () => {
     render(VButton, {
+      props: { variant: "filled-white" },
       slots: { default: "Code is Poetry" },
     })
 
@@ -32,7 +33,7 @@ describe("VButton", () => {
 
   it("should allow passing an explicit type", async () => {
     render(VButton, {
-      props: { type: "submit" },
+      props: { type: "submit", variant: "filled-white" },
       slots: { default: "Code is Poetry" },
     })
 
@@ -44,7 +45,7 @@ describe("VButton", () => {
   it("should render an anchor with no type attribute", async () => {
     render(VButton, {
       attrs: { href: "http://localhost" },
-      props: { as: "VLink" },
+      props: { as: "VLink", variant: "filled-white" },
       slots: { default: "Code is Poetry" },
     })
     await nextTick()
@@ -57,7 +58,11 @@ describe("VButton", () => {
 
   it("should render the disabled attribute on a button when the element is explicitly unfocusableWhenDisabled and is disabled", async () => {
     render(VButton, {
-      props: { disabled: true, focusableWhenDisabled: false },
+      props: {
+        disabled: true,
+        focusableWhenDisabled: false,
+        variant: "filled-white",
+      },
       slots: { default: "Code is Poetry" },
     })
 
@@ -69,7 +74,11 @@ describe("VButton", () => {
 
   it("should not render the disabled attribute if the element is focusableWhenDisabled", async () => {
     render(VButton, {
-      props: { disabled: true, focusableWhenDisabled: true },
+      props: {
+        disabled: true,
+        focusableWhenDisabled: true,
+        variant: "filled-white",
+      },
       slots: { default: "Code is Poetry" },
     })
 
@@ -86,6 +95,7 @@ describe("VButton", () => {
         disabled: true,
         focusableWhenDisabled: true,
         href: "https://wordpress.org",
+        variant: "filled-white",
       },
       slots: { default: "Code is Poetry" },
     })

--- a/frontend/test/unit/specs/components/v-modal.spec.js
+++ b/frontend/test/unit/specs/components/v-modal.spec.js
@@ -22,7 +22,7 @@ const TestWrapper = Vue.component("TestWrapper", {
     <div>
       <VModal label="modal label" :initial-focus-element="resolvedInitialFocusElement">
         <template #trigger="{ a11yProps, visible }">
-          <VButton v-bind="a11yProps">{{ visible }}</VButton>
+          <VButton variant="filled-white" v-bind="a11yProps">{{ visible }}</VButton>
         </template>
 
         <div>Code is Poetry</div>

--- a/frontend/test/unit/specs/components/v-popover.spec.js
+++ b/frontend/test/unit/specs/components/v-popover.spec.js
@@ -31,7 +31,7 @@ const TestWrapper = Vue.component("TestWrapper", {
       <div>External area</div>
       <VPopover label="Test label" v-bind="popoverProps">
         <template #trigger="{ visible, a11yProps }">
-          <VButton :pressed="visible" v-bind="a11yProps">{{ visible ? 'Close' : 'Open' }}</VButton>
+          <VButton variant="bordered-white" :pressed="visible" v-bind="a11yProps">{{ visible ? 'Close' : 'Open' }}</VButton>
         </template>
         <div :tabindex="popoverContentTabIndex">Code is Poetry</div>
       </VPopover>


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #1187 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes the `primary` button variant that was replaced with `filled-pink`. This was also the default for the button variant prop which I remove in this PR. In general, there are not many pink buttons in the app, and they should probably not be default. And I think it's better to be explicit about the variant to use for the button (by providing the required `variant` prop) than to fall back on a default.

Another change in this PR was the removal of the VFiltersGrid footer which was not actually used because it was set to `hidden` on screens above `md`, but was hidden in JS when the screen was below `md` (after the move to the VContentSwitcherModal for the filters on mobile).

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
