### PR TITLE
Ensure the generated changelog gets linted, fix backticks in log

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -110,11 +110,9 @@ jobs:
 
       - name: Add new changelog file to documentation
         run: |
-          cat << EOF > documentation/changelogs/${{ inputs.app }}/${{ steps.tag.outputs.date }}.md
-          # ${{ steps.tag.outputs.date }}
-
-          ${{ steps.release-drafter.outputs.body }}
-          EOF
+          file="documentation/changelogs/${{ inputs.app }}/${{ steps.tag.outputs.date }}.md"
+          echo -e "# ${{ steps.tag.outputs.date }}\n\n" > "$file"
+          echo -e '${{ steps.release-drafter.outputs.body }}' >> "$file"
 
       - name: Setup CI env
         uses: ./.github/actions/setup-env
@@ -132,8 +130,11 @@ jobs:
 
       - name: Lint the changelog file so that it passes CI
         run: |
+          # Add the new changelog file to git so that pre-commit can lint it.
+          git add documentation/changelogs/${{ inputs.app }}/${{ steps.tag.outputs.date }}.md
           just precommit
-          just lint
+          # Ensure this step passes even if linting has made changes so the workflow can continue
+          just lint || true
 
       - name: Open changelog PR
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1189 by @obulat, also fixes an issue preventing the linting from happening on changelog PRs like #1186

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the `release-app` workflow in two ways:

1. It stages the generated changelog in git to _specifically ensure_ that `just lint` runs on it. For whatever reason, leaving it as an unstaged file prevents `just lint` from running on it, even though I cannot reproduce that behavior locally (i.e. unstaged & untracked files _are_ linted locally).
2. It changes the way the body of the changelog is inserted into a file so that backticks (`) don't get interpolated by bash. I've confirmed that using single quotes should prevent that locally, but I can't test this fully yet until we have a release that includes backticks in the file.

**Successful release run**: https://github.com/WordPress/openverse/actions/runs/4694770892/jobs/8323238328
**Already-linted changelog PR**: https://github.com/WordPress/openverse/pull/1192

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

View the above!

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
