### PR TITLE
Fix typo in github link

### DIFF
--- a/api/catalog/api/docs/README.md
+++ b/api/catalog/api/docs/README.md
@@ -1,6 +1,6 @@
 This documentation is focused towards consumers who are using the Openverse API.
 To contribute to the development of the Openverse API, please refer to the
-[Openverse developer documentation](https://wordpress.githb.io/openverse/).
+[Openverse developer documentation](https://wordpress.github.io/openverse/).
 
 # Introduction
 

--- a/api/catalog/api/docs/README.md
+++ b/api/catalog/api/docs/README.md
@@ -1,6 +1,6 @@
 This documentation is focused towards consumers who are using the Openverse API.
 To contribute to the development of the Openverse API, please refer to the
-[Openverse developer documentation](https://wordpress.github.io/openverse/).
+[Openverse developer documentation](https://docs.openverse.org/).
 
 # Introduction
 


### PR DESCRIPTION
## Fixes

Fixes #1235 by @sarayourfriend 

## Description

Fix typo in github link of the /api/catalog/api/docs README. Now the link redirects to the correct URL (while previous redirects 
to another domain).

![Captura desde 2023-04-17 18-26-08](https://user-images.githubusercontent.com/105130738/232614508-50de0b44-3888-422c-9877-d1053d1253a8.png)

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
