### PR TITLE
Update permissions of deployment steps in the Release workflow

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -162,7 +162,7 @@ jobs:
             -f actor=${{ github.actor }} \
             "Deployment - production-api"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Deploy production frontend
         if: inputs.app == 'frontend'
@@ -172,4 +172,4 @@ jobs:
             -f actor=${{ github.actor }} \
             "Deployment - production-nuxt"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This PR updates the release-app workflow to use the `secrets.ACCESS_TOKEN` key as the GITHUB_TOKEN, which should have sufficient permissions to use the github cli to run the deployment workflows.

To test, we'll just see if it works!