### PR TITLE
Try to prevent additional issues with writing the changelogs to file

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -109,6 +109,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add new changelog file to documentation
+        env:
+          APP: ${{ inputs.app }}
+          DATE: ${{ steps.tag.outputs.date }}
+          RELEASE_BODY: ${{ steps.release-drafter.outputs.body }}
         working-directory: automations/python/workflows
         run: python write_changelog.py
 

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -109,11 +109,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add new changelog file to documentation
-        run: |
-          file="documentation/changelogs/${{ inputs.app }}/${{ steps.tag.outputs.date }}.md"
-          echo -e "# ${{ steps.tag.outputs.date }}\n\n" > "$file"
-          printf -v safe_output '%s' "${{ steps.release-drafter.outputs.body }}"
-          echo "$safe_output" >> "$file"
+        working-directory: automations/python/workflows
+        run: python write_changelog.py
 
       - name: Setup CI env
         uses: ./.github/actions/setup-env

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -112,7 +112,8 @@ jobs:
         run: |
           file="documentation/changelogs/${{ inputs.app }}/${{ steps.tag.outputs.date }}.md"
           echo -e "# ${{ steps.tag.outputs.date }}\n\n" > "$file"
-          echo -e '${{ steps.release-drafter.outputs.body }}' >> "$file"
+          printf -v safe_output '%s' "${{ steps.release-drafter.outputs.body }}"
+          echo "$safe_output" >> "$file"
 
       - name: Setup CI env
         uses: ./.github/actions/setup-env

--- a/automations/python/workflows/write_changelog.py
+++ b/automations/python/workflows/write_changelog.py
@@ -1,9 +1,9 @@
 import os
 
 
-app = os.environ["INPUTS_APP"]
-tag_date = os.environ["STEPS_TAG_OUTPUTS_DATE"]
-release_body = os.environ["STEPS_RELEASE_DRAFTER_OUTPUTS_BODY"]
+app = os.environ["APP"]
+tag_date = os.environ["DATE"]
+release_body = os.environ["RELEASE_BODY"]
 
 file_path = f"documentation/changelogs/{app}/{tag_date}.md"
 

--- a/automations/python/workflows/write_changelog.py
+++ b/automations/python/workflows/write_changelog.py
@@ -1,12 +1,16 @@
 import os
+from pathlib import Path
 
 
 app = os.environ["APP"]
 tag_date = os.environ["DATE"]
 release_body = os.environ["RELEASE_BODY"]
 
-file_path = f"documentation/changelogs/{app}/{tag_date}.md"
+file_path = Path(__file__).parents[3] / f"documentation/changelogs/{app}/{tag_date}.md"
+file_path.write_text(
+    """
+    # {tag_date}
 
-with open(file_path, "w") as f:
-    f.write(f"# {tag_date}\n\n")
-    f.write(f"""{release_body}\n""")
+    {release_body}
+    """
+)

--- a/automations/python/workflows/write_changelog.py
+++ b/automations/python/workflows/write_changelog.py
@@ -1,0 +1,12 @@
+import os
+
+
+app = os.environ["INPUTS_APP"]
+tag_date = os.environ["STEPS_TAG_OUTPUTS_DATE"]
+release_body = os.environ["STEPS_RELEASE_DRAFTER_OUTPUTS_BODY"]
+
+file_path = f"documentation/changelogs/{app}/{tag_date}.md"
+
+with open(file_path, "w") as f:
+    f.write(f"# {tag_date}\n\n")
+    f.write(f"""{release_body}\n""")


### PR DESCRIPTION
I am _not_ a shell script expert but am curious if this might fix issues I'm still seeing with drafting certain release notes. See the [recent run here](https://github.com/WordPress/openverse/actions/runs/4735022950/jobs/8404730500) which errored due to a "syntax error near unexpected token `(".