### PR TITLE
Consolidate all transient dev container dirs for the catalog

### DIFF
--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -15,6 +15,7 @@ ENV AIRFLOW_HOME=/opt/airflow
 ENV DAGS_FOLDER=${AIRFLOW_HOME}/catalog/dags
 ENV PYTHONPATH=${DAGS_FOLDER}
 ENV PATH=${AIRFLOW_HOME}/.local/bin:$PATH
+ENV IPYTHONDIR=/home/airflow/.cache/ipython
 
 # Container optimizations
 ENV PYTHONUNBUFFERED=1
@@ -44,11 +45,11 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Create and set the ownership of directories so airflow user can write to them
+# Create and set the ownership of the cache directory so airflow user can write to them
 # These directories are not needed in production but it's easier to perform
 # this step here while we're doing it for the output directory
-RUN mkdir -p ${OUTPUT_DIR} /home/airflow/.ipython /home/airflow/.cache/pytest && \
-    chown airflow ${OUTPUT_DIR} /home/airflow/.ipython /home/airflow/.cache/pytest
+RUN mkdir -p ${OUTPUT_DIR} /home/airflow/.cache && \
+    chown airflow ${OUTPUT_DIR} /home/airflow/.cache
 
 USER airflow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ x-airflow-common: &airflow-common
       - PROJECT_AIRFLOW_VERSION=${PROJECT_AIRFLOW_VERSION}
   volumes:
     - ./catalog:/opt/airflow/catalog
-    - catalog-ipython:/home/airflow/.ipython
-    - catalog-pytest-cache:/home/airflow/.cache/pytest
+    - catalog-cache:/home/airflow/.cache
 
 services:
   # Database used by the API
@@ -314,5 +313,4 @@ volumes:
   plausible-clickhouse:
   es-data:
   minio:
-  catalog-ipython:
-  catalog-pytest-cache:
+  catalog-cache:


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1820 by @AetherUnbound

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the issue we were seeing with the `tldextract` cache. It does so by creating and owning the `/home/airflow/.cache` directory at image creation time. Previously we were specifically creating `/home/airflow/.ipython` and `/home/airflow/.cache/pytest`; fixing the TLD issue would have required that we add directory creation _and_ a new volume mount for `/home/airflow/.cache/python-tldextract`. That seemed way unnecessary, so I decided to throw everything into `/home/airflow/.cache` (including the `ipython` folder which required changing an environment variable to have it be a subfolder of `~/.cache`).

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Before any steps, check out `main` and run `just down -v` to ensure the old volumes are removed. Then check this branch out and run `just build`.

### TLD Extract issue

1. `just catalog/up`
2. Run a DAG (I chose SMK since it's fast) and ensure the lines referenced in #1820 don't show up in the logs

### Pytest changes

1. `just catalog/test` -> this should not raise any warnings

### ipython changes

1. Run `just ipython`
2. Execute a few commands
3. Exit the session
4. Run `just ipython` and press the up arrow - history from the previous session should be available

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
