### PR TITLE
Dispatch deployment workflows from infrastructure repository

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -830,17 +830,20 @@ jobs:
       - get-image-tag
       - publish-images
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Dispatch workflow
-        run: |
-          gh workflow run \
-            -f tag=${{ needs.get-image-tag.outputs.image_tag }} \
-            -f actor=${{ github.actor }} \
-            "Deployment - staging-nuxt"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Deploy staging frontend
+        uses: felixp8/dispatch-and-wait@v0.1.0
+        with:
+          owner: WordPress
+          repo: openverse-infrastructure
+          token: ${{ secrets.ACCESS_TOKEN }}
+          event_type: deploy_staging_nuxt
+          client_payload: |
+            {
+              "actor": "${{ github.actor }}",
+              "tag": "${{ needs.get-image-tag.outputs.image_tag }}"
+            }
+          wait_time: 60 # check every minute
+          max_time: 1800 # allow up to 30 minutes for a deployment
 
   deploy-api:
     name: Deploy staging API
@@ -855,17 +858,20 @@ jobs:
       - get-image-tag
       - publish-images
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Dispatch workflow
-        run: |
-          gh workflow run \
-            -f tag=${{ needs.get-image-tag.outputs.image_tag }} \
-            -f actor=${{ github.actor }} \
-            "Deployment - staging-api"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Deploy staging API
+        uses: felixp8/dispatch-and-wait@v0.1.0
+        with:
+          owner: WordPress
+          repo: openverse-infrastructure
+          token: ${{ secrets.ACCESS_TOKEN }}
+          event_type: deploy_staging_api
+          client_payload: |
+            {
+              "actor": "${{ github.actor }}",
+              "tag": "${{ needs.get-image-tag.outputs.image_tag }}"
+            }
+          wait_time: 60 # check every minute
+          max_time: 1800 # allow up to 30 minutes for a deployment
 
   ################
   # Notification #

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -156,22 +156,24 @@ jobs:
           body: |
             This changelog PR was automatically generated for @${{ github.actor }} as a result of the ${{ github.workflow }} workflow.
 
-      - name: Deploy production api
-        if: inputs.app == 'api'
-        run: |
-          gh workflow run \
-            -f tag=${{ steps.tag.outputs.image-tag }} \
-            -f actor=${{ github.actor }} \
-            "Deployment - production-api"
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: Deploy production frontend
-        if: inputs.app == 'frontend'
-        run: |
-          gh workflow run \
-            -f tag=${{ steps.tag.outputs.image-tag }} \
-            -f actor=${{ github.actor }} \
-            "Deployment - production-nuxt"
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      - name: Deploy production application
+        if: inputs.app == 'frontend' || inputs.app == 'api'
+        uses: felixp8/dispatch-and-wait@v0.1.0
+        with:
+          owner: WordPress
+          repo: openverse-infrastructure
+          token: ${{ secrets.ACCESS_TOKEN }}
+          event_type: deploy_production_${{ inputs.app == 'frontend' && 'nuxt' || inputs.app }}
+          client_payload: |
+            {
+              "actor": "${{ github.actor }}",
+              "tag": "${{ steps.tag.outputs.image-tag }}"
+            }
+          wait_time: 60 # check every minute
+          max_time: 1800 # allow up to 30 minutes for a deployment
+          # max_time can't easily be configured per application
+          # without duplicating information between our infrastructure
+          # and this workflow. The upstream workflows already have
+          # timeouts appropriately configured and will all fail before 30
+          # minutes is reached. On the other hand, we do want to wait
+          # so that there is a record of the successful deployment.


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse-infrastructure/issues/462 by @sarayourfriend 

I'll open a follow-up PR to remove the deployment workflows from this repository.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Dispatches the deployment workflows from the infrastructure repository using repository dispatch.

@dhruvkb You suggested we should use dispatch and wait, but I want to make sure that doesn't cause issues. Specifically it will block CI/CD from running on `main` while the staging deployments are awaited due to the concurrency setting. The release app workflow doesn't have that issue because the concurrency key includes the app name input. Staging deployments are only ~10 minutes or so but I wonder if we need CI on `main` to wait for them or if we can just rely on the fact that the upstream workflow will correctly handle concurrency and deploy things in order.

What do you think?

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try release app from this branch and confirm it works. For CI/CD I think we just need to merge the PR and see if it works, though the code is almost identical to release app so theoretically there shouldn't be an operational difference.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
