### PR TITLE
Compute search path query parameters for the type passed

### DIFF
--- a/frontend/src/stores/search.ts
+++ b/frontend/src/stores/search.ts
@@ -189,7 +189,16 @@ export const useSearchStore = defineStore("search", {
       query,
     }: { type?: SearchType; query?: ApiQueryParams } = {}): string {
       const searchType = type || this.searchType
-      const queryParams = query || this.searchQueryParams
+      let queryParams
+      if (!query) {
+        if (type && isSearchTypeSupported(type)) {
+          queryParams = computeQueryParams(type, this.filters, this.searchTerm)
+        } else {
+          queryParams = this.searchQueryParams
+        }
+      } else {
+        queryParams = query
+      }
 
       return this.$nuxt.localePath({
         path: searchPath(searchType),

--- a/frontend/test/unit/setup-after-env.js
+++ b/frontend/test/unit/setup-after-env.js
@@ -7,5 +7,6 @@ Vue.prototype.$nuxt = {
       captureException: jest.fn(),
       captureEvent: jest.fn(),
     },
+    localePath: (args) => args,
   },
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1870 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR computes the search path's query parameters if the search type is passed. Otherwise, it uses the query parameters for the currently selected search type.
You can see in the video that the query parameters change based on the search type:

![search_query_change](https://user-images.githubusercontent.com/15233243/233675149-0bb95d0d-a748-4a7e-9854-1c16bf498611.gif)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check the URLs of the search type links in the content switcher. The CI should also pass.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
