### PR TITLE
Simplify report views

### DIFF
--- a/api/catalog/api/models/media.py
+++ b/api/catalog/api/models/media.py
@@ -241,7 +241,10 @@ class AbstractMediaReport(models.Model):
         )
         if self.status != DEINDEXED:
             same_reports = same_reports.filter(reason=self.reason)
-        same_reports.update(status=self.status)
+
+        # Prevent redundant update statement when creating the report
+        if self.status != PENDING:
+            same_reports.update(status=self.status)
 
 
 class AbstractDeletedMedia(OpenLedgerModel):

--- a/api/catalog/api/views/audio_views.py
+++ b/api/catalog/api/views/audio_views.py
@@ -93,5 +93,5 @@ class AudioViewSet(MediaViewSet):
         methods=["post"],
         serializer_class=AudioReportRequestSerializer,
     )
-    def report(self, *args, **kwargs):
-        return super().report(*args, **kwargs)
+    def report(self, request, identifier):
+        return super().report(request, identifier)

--- a/api/catalog/api/views/image_views.py
+++ b/api/catalog/api/views/image_views.py
@@ -179,8 +179,8 @@ class ImageViewSet(MediaViewSet):
         methods=["post"],
         serializer_class=ImageReportRequestSerializer,
     )
-    def report(self, *args, **kwargs):
-        return super().report(*args, **kwargs)
+    def report(self, request, identifier):
+        return super().report(request, identifier)
 
     # Helper functions
 

--- a/api/catalog/api/views/media_views.py
+++ b/api/catalog/api/views/media_views.py
@@ -148,14 +148,11 @@ class MediaViewSet(ReadOnlyModelViewSet):
         serializer = self.get_serializer(results, many=True)
         return self.get_paginated_response(serializer.data)
 
-    def report(self, request, *_, **__):
-        media = self.get_object()
-        identifier = media.identifier
+    def report(self, request, identifier):
         serializer = self.get_serializer(data=request.data | {"identifier": identifier})
         serializer.is_valid(raise_exception=True)
-        report = serializer.save()
+        serializer.save()
 
-        serializer = self.get_serializer(report)
         return Response(data=serializer.data, status=status.HTTP_201_CREATED)
 
     def thumbnail(self, image_url, request, *_, **__):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1037 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Pass the media identifier directly instead of using the method serializer. This update saves two db statements per report. One query and one update were both redundant.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. (optional) On main branch run `just api/recreate`
2. Set `DJANGO_DB_LOGGING=True` on your .env file
3.  Restart the service to apply the change and see the logs
```
just down && just api/up && just logs web
```
4. Report on any image, e.g.:
```
curl --request POST \
  --url http://localhost:50280/v1/images/<uuid>/report/ \
  --header 'Content-Type: application/json' \
  --data '{
	"reason": "mature",
	"description": "Image contains sensitive content"
}'
```
5. Notice there are similar SELECT queries and an UPDATE statement right after the INSERT for the new report
```
openverse-web-1  | [2023-04-27 17:54:56,395 - django.db.backends - 131][DEBUG] [dcca485c44bf4916a23512d241c24379] (0.009) SELECT "image"."id", "image"."created_on", "image"."updated_on", "image"."identifier", "image"."foreign_identifier", "image"."title", "image"."foreign_landing_url", "image"."creator", "image"."creator_url", "image"."thumbnail", "image"."provider", "image"."url", "image"."filesize", "image"."filetype", "image"."watermarked", "image"."license", "image"."license_version", "image"."source", "image"."last_synced_with_source", "image"."removed_from_source", "image"."view_count", "image"."tags", "image"."category", "image"."meta_data", "image"."width", "image"."height", "api_matureimage"."created_on", "api_matureimage"."identifier" FROM "image" LEFT OUTER JOIN "api_matureimage" ON ("image"."identifier" = "api_matureimage"."identifier") WHERE "image"."identifier" = '3d6be27a03b64f138d7c1cdad8f0d9e9'::uuid LIMIT 21; args=(UUID('3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9'),); alias=default
openverse-web-1  | [2023-04-27 17:54:56,397 - django.db.backends - 131][DEBUG] [dcca485c44bf4916a23512d241c24379] (0.001) SELECT "image"."id", "image"."created_on", "image"."updated_on", "image"."identifier", "image"."foreign_identifier", "image"."title", "image"."foreign_landing_url", "image"."creator", "image"."creator_url", "image"."thumbnail", "image"."provider", "image"."url", "image"."filesize", "image"."filetype", "image"."watermarked", "image"."license", "image"."license_version", "image"."source", "image"."last_synced_with_source", "image"."removed_from_source", "image"."view_count", "image"."tags", "image"."category", "image"."meta_data", "image"."width", "image"."height" FROM "image" WHERE "image"."identifier" = '3d6be27a03b64f138d7c1cdad8f0d9e9'::uuid LIMIT 21; args=(UUID('3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9'),); alias=default
openverse-web-1  | [2023-04-27 17:54:56,399 - django.db.backends - 131][DEBUG] [dcca485c44bf4916a23512d241c24379] (0.000) SELECT 1 AS "a" FROM "image" WHERE "image"."identifier" = '3d6be27a03b64f138d7c1cdad8f0d9e9'::uuid LIMIT 1; args=(Int4(1), UUID('3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9')); alias=default
openverse-web-1  | [2023-04-27 17:54:56,403 - django.db.backends - 131][DEBUG] [dcca485c44bf4916a23512d241c24379] (0.004) INSERT INTO "nsfw_reports" ("created_at", "reason", "description", "status", "identifier") VALUES ('2023-04-27 17:54:56.399288+00:00'::timestamptz, 'mature', 'Image contains sensitive content', 'pending_review', '3d6be27a03b64f138d7c1cdad8f0d9e9'::uuid) RETURNING "nsfw_reports"."id"; args=(datetime.datetime(2023, 4, 27, 17, 54, 56, 399288, tzinfo=datetime.timezone.utc), 'mature', 'Image contains sensitive content', 'pending_review', UUID('3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9')); alias=default
openverse-web-1  | [2023-04-27 17:54:56,405 - django.db.backends - 131][DEBUG] [dcca485c44bf4916a23512d241c24379] (0.002) UPDATE "nsfw_reports" SET "status" = 'pending_review' WHERE ("nsfw_reports"."identifier" = '3d6be27a03b64f138d7c1cdad8f0d9e9'::uuid AND "nsfw_reports"."status" = 'pending_review' AND "nsfw_reports"."reason" = 'mature'); args=('pending_review', UUID('3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9'), 'pending_review', 'mature'); alias=default
openverse-web-1  | [2023-04-27 17:54:56,406 - log_request_id.middleware -  55][INFO] [dcca485c44bf4916a23512d241c24379] method=POST path=/v1/images/3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9/report/ status=201
openverse-web-1  | [27/Apr/2023 17:54:56] "POST /v1/images/3d6be27a-03b6-4f13-8d7c-1cdad8f0d9e9/report/ HTTP/1.1" 201 120
```
6. Now check this branch and create another report
7. Look at the logs and observe the DB statements are reduced.
8. Verify on the Django admin that reports are created http://localhost:50280/admin/api/imagereport/

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
