### PR TITLE
Handle more than one value for a url query parameter

### DIFF
--- a/frontend/src/stores/search.ts
+++ b/frontend/src/stores/search.ts
@@ -21,7 +21,7 @@ import {
 import {
   ApiQueryParams,
   filtersToQueryData,
-  qToSearchTerm,
+  queryDictionaryToQueryParams,
   queryStringToSearchType,
   queryToFilterData,
 } from "~/utils/search-query-transform"
@@ -224,8 +224,8 @@ export const useSearchStore = defineStore("search", {
      * use the first one.
      * @param q - The URL `q` query parameter
      */
-    setSearchTerm(q: string | (null | string)[] | null) {
-      const formattedTerm = qToSearchTerm(q)
+    setSearchTerm(q: string | undefined | null) {
+      const formattedTerm = q ? q.trim() : ""
       if (this.searchTerm === formattedTerm) return
       this.searchTerm = formattedTerm
       this.localSearchTerm = formattedTerm
@@ -401,12 +401,13 @@ export const useSearchStore = defineStore("search", {
       path: string
       urlQuery: Context["query"]
     }) {
-      this.setSearchTerm(urlQuery.q)
+      const query = queryDictionaryToQueryParams(urlQuery)
+      this.setSearchTerm(query.q)
       this.searchType = queryStringToSearchType(path)
       if (!isSearchTypeSupported(this.searchType)) return
+
       // When setting filters from URL query, 'mature' has a value of 'true',
       // but we need the 'mature' code. Creating a local shallow copy to prevent mutation.
-      const query: Record<string, string> = { ...urlQuery, q: this.searchTerm }
       if (query.mature === "true") {
         query.mature = "mature"
       } else {

--- a/frontend/src/utils/search-query-transform.ts
+++ b/frontend/src/utils/search-query-transform.ts
@@ -14,6 +14,9 @@ import {
 import { getParameterByName } from "~/utils/url-params"
 import { deepClone } from "~/utils/clone"
 
+import type { Context } from "@nuxt/types"
+import type { Dictionary } from "vue-router/types/router"
+
 export interface ApiQueryParams {
   q?: string
   license?: string
@@ -166,7 +169,7 @@ export const queryToFilterData = ({
   searchType = "image",
   defaultFilters,
 }: {
-  query: Record<string, string>
+  query: Dictionary<string>
   searchType: SupportedSearchType
   defaultFilters: Partial<Filters>
 }) => {
@@ -262,11 +265,23 @@ export const areQueriesEqual = (
 }
 
 /**
- * Converts the API query `q` parameter to a single string that can
- * be used as a search term. Use the first item if `q` is an array.
- * @param q - the URL `q` parameter
+ * The URL query string can contain multiple values for the same parameter.
+ * This function converts the query string to a dictionary where the values
+ * are always strings. If the parameter has multiple values, the first value
+ * is used.
+ * * @param queryDictionary - the query param dictionary provided by Vue router
  */
-export const qToSearchTerm = (q: string | null | (string | null)[]) => {
-  const searchTerm = Array.isArray(q) ? q[0] : q
-  return searchTerm ? searchTerm.trim() : ""
+export const queryDictionaryToQueryParams = (
+  queryDictionary: Context["query"]
+): Dictionary<string> => {
+  const queryParams = {} as Dictionary<string>
+  Object.keys(queryDictionary).forEach((key) => {
+    const value = queryDictionary[key]
+    // If the parameter is an array, use the first value.
+    const parameter = Array.isArray(value) ? value[0] : value
+    if (parameter) {
+      queryParams[key] = parameter
+    }
+  })
+  return queryParams
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1046 by @obulat 
Fixes #453 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Vue router supports having separate values for a single parameter in the URL: `q=cat&q=dog`. This is parsed to `context.query` as `{ q: ["cat", "dog"] }`. Our code, however, expects the values for parameters to be strings, not arrays. This causes a 500 error in Nuxt for such URLs.

This PR pre-processes the `query` received from Nuxt context to leave only the first parameter if an array is given. We can safely discard the other values because normally we do not set such parameters using the UI. If we need to pass several values, we use a comma-separated value: `{ license: "by,sa" }` instead of an array. 


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and go to `localhost:8443/search/?q=cat&q=dog`. You should receive the results for `cat`, and `dog` should be discarded as a search term. If you do the same on main, you would get a Nuxt error screen.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
