### PR TITLE
Raise `UpstreamThumbnailException` for unsuccessful requests

### DIFF
--- a/api/catalog/api/utils/photon.py
+++ b/api/catalog/api/utils/photon.py
@@ -27,15 +27,7 @@ HEADERS = {
 }
 
 
-def get(
-    image_url: str,
-    accept_header: str = "image/*",
-    is_full_size: bool = False,
-    is_compressed: bool = True,
-) -> HttpResponse:
-    logger = parent_logger.getChild("get")
-    # Photon options documented here:
-    # https://developer.wordpress.com/docs/photon/api/
+def _get_photon_params(image_url, is_full_size, is_compressed):
     params = {}
 
     if not is_full_size:
@@ -58,34 +50,38 @@ def get(
         # do not serve over HTTP and do not have a redirect)
         params["ssl"] = "true"
 
-    # Photon excludes the protocol so we need to reconstruct the url + port + path
+    return params, parsed_image_url
+
+
+def get(
+    image_url: str,
+    accept_header: str = "image/*",
+    is_full_size: bool = False,
+    is_compressed: bool = True,
+) -> HttpResponse:
+    logger = parent_logger.getChild("get")
+    # Photon options documented here:
+    # https://developer.wordpress.com/docs/photon/api/
+    params, parsed_image_url = _get_photon_params(
+        image_url, is_full_size, is_compressed
+    )
+
+    # Photon excludes the protocol, so we need to reconstruct the url + port + path
     # to send as the "path" of the Photon request
     domain = parsed_image_url.netloc
     path = parsed_image_url.path
     upstream_url = f"{settings.PHOTON_ENDPOINT}{domain}{path}"
 
-    try:
-        headers = {"Accept": accept_header} | HEADERS
-        if settings.PHOTON_AUTH_KEY:
-            headers["X-Photon-Authentication"] = settings.PHOTON_AUTH_KEY
+    headers = {"Accept": accept_header} | HEADERS
+    if settings.PHOTON_AUTH_KEY:
+        headers["X-Photon-Authentication"] = settings.PHOTON_AUTH_KEY
 
+    try:
         upstream_response = requests.get(
             upstream_url,
             timeout=15,
             params=params,
             headers=headers,
-        )
-        res_status = upstream_response.status_code
-        content_type = upstream_response.headers.get("Content-Type")
-        logger.debug(
-            "Image proxy response "
-            f"status: {res_status}, content-type: {content_type}"
-        )
-
-        return HttpResponse(
-            upstream_response.content,
-            status=res_status,
-            content_type=content_type,
         )
     except requests.ReadTimeout as exc:
         # Count the incident so that we can identify providers with most timeouts.
@@ -102,9 +98,22 @@ def get(
         )
     except requests.RequestException as exc:
         sentry_sdk.capture_exception(exc)
-        raise UpstreamThumbnailException(f"Failed to render thumbnail: {exc}")
+        raise UpstreamThumbnailException(f"Failed to render thumbnail. {exc}")
     except Exception as exc:
         sentry_sdk.capture_exception(exc)
         raise UpstreamThumbnailException(
-            f"Failed to render thumbnail due to unidentified exception: {exc}"
+            f"Failed to render thumbnail due to unidentified exception. {exc}"
+        )
+    else:
+        res_status = upstream_response.status_code
+        content_type = upstream_response.headers.get("Content-Type")
+        logger.debug(
+            "Image proxy response "
+            f"status: {res_status}, content-type: {content_type}"
+        )
+
+        return HttpResponse(
+            upstream_response.content,
+            status=res_status,
+            content_type=content_type,
         )

--- a/api/catalog/api/utils/photon.py
+++ b/api/catalog/api/utils/photon.py
@@ -83,6 +83,7 @@ def get(
             params=params,
             headers=headers,
         )
+        upstream_response.raise_for_status()
     except requests.ReadTimeout as exc:
         # Count the incident so that we can identify providers with most timeouts.
         key = f"{settings.THUMBNAIL_TIMEOUT_PREFIX}{domain}"

--- a/api/catalog/api/utils/photon.py
+++ b/api/catalog/api/utils/photon.py
@@ -28,6 +28,10 @@ HEADERS = {
 
 
 def _get_photon_params(image_url, is_full_size, is_compressed):
+    """
+    Photon options documented here:
+    https://developer.wordpress.com/docs/photon/api/
+    """
     params = {}
 
     if not is_full_size:
@@ -60,8 +64,6 @@ def get(
     is_compressed: bool = True,
 ) -> HttpResponse:
     logger = parent_logger.getChild("get")
-    # Photon options documented here:
-    # https://developer.wordpress.com/docs/photon/api/
     params, parsed_image_url = _get_photon_params(
         image_url, is_full_size, is_compressed
     )

--- a/api/test/unit/utils/photon_test.py
+++ b/api/test/unit/utils/photon_test.py
@@ -284,3 +284,15 @@ def test_get_successful_https_image_url_sends_ssl_parameter(mock_image_data):
     assert res.content == MOCK_BODY.encode()
     assert res.status_code == 200
     assert mock_get.matched
+
+
+@pook.on
+def test_get_unsuccessful_request_raises_exception():
+    mock_get: pook.Mock = pook.get(PHOTON_URL_FOR_TEST_IMAGE).reply(404).mock
+
+    with pytest.raises(
+        UpstreamThumbnailException, match=r"Failed to render thumbnail."
+    ):
+        photon_get(TEST_IMAGE_URL)
+
+    assert mock_get.matched


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #676 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR extracts the params building from the `photon.get` method to reduce it a bit, and also calls `raise_for_status` from the response, as suggested in the issue, to make sure we raise the correct custom exception from unsuccessful HTTP response codes.

The `requests.HTTPError` class inherits from `requests.RequestException`[^1] so there is no need to add it explicitly to the `except` block.

[^1]: https://docs.python-requests.org/en/latest/user/quickstart/#errors-and-exceptions

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. To test this manually, try replacing one DB entry's URL with the sample image URL provided in the issue:
```
https://upload.wikimedia.org/wikipedia/commons/8/89/Flag_of_the_Turkic_Council.svg
```
2. Make sure that image doesn't have a thumbnail URL; in that case, make it null.
3. Go to the image's thumbnail URL (`http://localhost:50280/v1/images/<uuid>/thumb/`) and make sure you see a response like the following:
```
HTTP 424 Failed Dependency
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "detail": "Failed to render thumbnail. 404 Client Error: File Not Found for url: https://i0.wp.com/upload.wikimedia.org/wikipedia/commons/8/89/Flag_of_the_Turkic_Council.svg?w=600&quality=80&ssl=true"
}
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
