### PR TITLE
Add Airflow variable for turning off provider DAG catchup

### DIFF
--- a/catalog/env.template
+++ b/catalog/env.template
@@ -107,6 +107,8 @@ OPENVERSE_BUCKET=openverse-storage
 DATA_REFRESH_POKE_INTERVAL=5
 # Number of Retries if DAG task fails to run
 DEFAULT_RETRY_COUNT = 2
+# Whether to enable catchup for dated DAGs, allowing automatic backfill.
+AIRFLOW_VAR_CATCHUP_ENABLED=false
 
 AIRFLOW_VAR_AIRFLOW_RDS_ARN=unset
 AIRFLOW_VAR_AIRFLOW_RDS_SNAPSHOTS_TO_RETAIN=7

--- a/catalog/utilities/dag_doc_gen/dag_doc_generation.py
+++ b/catalog/utilities/dag_doc_gen/dag_doc_generation.py
@@ -124,7 +124,10 @@ def get_dags_info(dags: DagMapping) -> list[DagInfo]:
         if doc:
             doc = fix_headings(doc)
 
-        dated = dag.catchup
+        provider_workflow = provider_workflows.get(dag_id)
+        dated = (
+            provider_workflow.dated if provider_workflow is not None else dag.catchup
+        )
         # Infer dag type from the first available tag
         type_ = dag.tags[0] if dag.tags else "other"
         dags_info.append(
@@ -134,7 +137,7 @@ def get_dags_info(dags: DagMapping) -> list[DagInfo]:
                 doc=doc,
                 type_=type_,
                 dated=dated,
-                provider_workflow=provider_workflows.get(dag_id),
+                provider_workflow=provider_workflow,
             )
         )
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1284 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds an Airflow variable called `CATCHUP_ENABLED` which can be used to override the default catchup settings for provider DAGs.

In production, `catchup` is enabled for all dated DAGs to allow for backfilling -- but this can be very annoying in local environments, because enabling a dated DAG will automatically kick off a very long backfill which you might not want.

Using an Airflow variable allows devs to easily toggle this on and off in local testing, and even allows us to do so in production should the need ever arise. If you want to persist the setting across `recreate`s of the environment, you can set `AIRFLOW_VAR_CATCHUP_ENABLED=false` in your `.env`. 


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

### Test default
* Make no changes to the Variables to begin with
* Select a few dated DAGs (eg metropolitan, flickr) and ensure that `catchup` is `True` by checking the Dag Details tab in the UI

### Test Airflow UI
* Create a variable through the Admin > Variables UI called "CATCHUP_ENABLED", and set it to 'false'
* Ensure that the dated DAGs now have catchup disabled
* Set the variable to 'true' and ensure catchup is enabled again

### Test env variable
* Add `AIRFLOW_VAR_CATCHUP_ENABLED=false` to your `catalog/.env` and run `just catalog/up`
* Ensure that the dated DAGs now have catchup disabled


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
