### PR TITLE
Respect the task timeout in recreate popularity constants task

### DIFF
--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -236,10 +236,11 @@ def create_media_popularity_constants_view(
     popularity_constants_idx=IMAGE_POP_CONSTANTS_IDX,
     popularity_metrics=IMAGE_POPULARITY_METRICS_TABLE_NAME,
     popularity_percentile=IMAGE_POPULARITY_PERCENTILE_FUNCTION,
-    pg_timeout: float = timedelta(hours=6).total_seconds(),
+    task: AbstractOperator = None,
 ):
     postgres = PostgresHook(
-        postgres_conn_id=postgres_conn_id, default_statement_timeout=pg_timeout
+        postgres_conn_id=postgres_conn_id,
+        default_statement_timeout=PostgresHook.get_execution_timeout(task),
     )
     if media_type == AUDIO:
         popularity_constants = AUDIO_POPULARITY_CONSTANTS_VIEW


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The postgres statement timeout for the `create_popularity_constants_view` task in the `recreate_<media>_popularity_calculation` DAGs was not being pulled correctly from the task timeout. As a consequence, when the task's timeout was extended, the actual SQL was not and it still timed out at 6 hours.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Pull this branch, and locally trigger the `recreate_image_popularity_calculation` DAG. Open up the logs for the `create_popularity_constants_view` and you should see a log like this showing the correct timeout:

```
2023-04-28, 00:13:37 UTC] {sql.py:375} INFO - Running statement: SET statement_timeout TO '28800.0s'; 
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
