### PR TITLE
Run `awk` before `grep` in the `attach` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -194,9 +194,9 @@ recreate:
 logs services="" args=(if IS_CI != "" { "" } else { "-f" }):
     just dc logs {{ args }} {{ services }}
 
-# Attach to the specificed `service`. Enables interacting with the TTY of the running service.
+# Attach to the specificed service to interacting with its TTY
 attach service:
-    docker attach $(docker-compose ps | grep {{ service }} | awk '{print $1}')
+    docker attach $(just dc ps | awk '{print $1}' | grep {{ service }})
 
 # Execute statement in service containers using Docker Compose
 exec +args:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #1910 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the order of operations in the `attach` recipe to prevent confusion.

Earlier the `attach` recipe would grep in the list of running containers based on in the given service name. However when querying the full tabular output, the query name can match in the image column as well.

<img width="1809" alt="Screenshot 2023-04-29 at 10 08 14 AM" src="https://user-images.githubusercontent.com/16580576/235286879-1782cc4c-b5a5-4148-b1ea-69470d9da764.png">

By running `awk` first, we reduce the output to its first column i.e. the names of the services. Then running `grep` only matches the right service.

<img width="1091" alt="Screenshot 2023-04-29 at 10 09 37 AM" src="https://user-images.githubusercontent.com/16580576/235286933-675f8574-895f-4039-99d7-57e6979169d8.png">


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just attach ingestion_server` before and after this change.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
