### PR TITLE
Correctly pass `maxDiffPixelRatio` to add tolerance for pages-single-result VR test

### DIFF
--- a/frontend/test/playwright/utils/breakpoints.ts
+++ b/frontend/test/playwright/utils/breakpoints.ts
@@ -51,17 +51,10 @@ interface Options {
    * @defaultValue true
    */
   uaMocking?: boolean
-  /**
-   * Adjust the error tolerance for a single test to avoid
-   * flakiness.
-   * Do not set to a value higher than 0.02.
-   */
-  maxDiffPixelRatio?: number
 }
 
 const defaultOptions = Object.freeze({
   uaMocking: true,
-  maxDiffPixelRatio: 0,
 })
 
 const makeBreakpointDescribe =

--- a/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
@@ -18,29 +18,27 @@ test.describe.configure({ mode: "parallel" })
 for (const mediaType of supportedMediaTypes) {
   for (const dir of languageDirections) {
     test.describe(`${mediaType} ${dir} single-result page snapshots`, () => {
-      breakpoints.describeEvery(
-        { maxDiffPixelRatio: 0.02 },
-        ({ breakpoint, expectSnapshot }) => {
-          test.beforeEach(async ({ page }) => {
-            await closeFiltersUsingCookies(page)
-            await dismissBannersUsingCookies(page)
-            await setBreakpointCookie(page, breakpoint)
+      breakpoints.describeEvery(({ breakpoint, expectSnapshot }) => {
+        test.beforeEach(async ({ page }) => {
+          await closeFiltersUsingCookies(page)
+          await dismissBannersUsingCookies(page)
+          await setBreakpointCookie(page, breakpoint)
 
-            await goToSearchTerm(page, "birds", { dir })
-          })
+          await goToSearchTerm(page, "birds", { dir })
+        })
 
-          test(`from search results`, async ({ page }) => {
-            // This will include the "Back to results" link.
-            await openFirstResult(page, mediaType)
+        test(`from search results`, async ({ page }) => {
+          // This will include the "Back to results" link.
+          await openFirstResult(page, mediaType)
 
-            await expectSnapshot(
-              `${mediaType}-${dir}-from-search-results`,
-              page,
-              { fullPage: true }
-            )
-          })
-        }
-      )
+          await expectSnapshot(
+            `${mediaType}-${dir}-from-search-results`,
+            page,
+            { fullPage: true },
+            { maxDiffPixelRatio: 0.02 }
+          )
+        })
+      })
     })
   }
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #1959 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In https://github.com/WordPress/openverse/pull/1132, I've added `maxDiffPixelRatio` screenshot parameter set to 0.02 to fix the flakiness of the `pages-single-result` test. However, I passed it incorrectly, so it wasn't actually used. This PR passes it using the last parameter of `expectSnapshot` function.

I've also added this change to all of the failing PRs from #1959 description, and they all pass now.
This does not fully fix the root cause of the VR failure, however, I think test is still useful even if the license icons section is off. I would welcome any solution for the root cause, too.

@sarayourfriend, considering that this seems to fix all of the `pages-single-result` flakiness, do you think we should still `skip` the failing test, or would merging this PR as is be fine?

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass. However, because the test is flaky, it could pass even though the flakiness is fixed. I will re-run the CI a couple of times to make sure it doesn't fail.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
