### PR TITLE
Simplify and reorder parameters to `catalog/pgcli` recipe

### DIFF
--- a/api/justfile
+++ b/api/justfile
@@ -79,8 +79,8 @@ stats media="images" host="localhost:50280":
     just _curl-get "{{ media }}/stats/" {{ host }}
 
 # Launch a `pgcli` shell in the web container
-pgcli db_host="db" db_port="5432" db_name="openledger" db_user="deploy" db_password="deploy": up
-    env DC_USER="opener" just ../exec web pgcli postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/{{ db_name }}
+pgcli db_user_pass="deploy" db_name="openledger": up
+    env DC_USER="opener" just ../_pgcli web {{ db_user_pass }} {{ db_name }} db
 
 #########################
 # Django administration #

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -85,8 +85,8 @@ ipython: up-deps
         bash -c \'ipython\'
 
 # Launch a `pgcli` shell in the PostgreSQL container
-pgcli db_host="upstream_db" db_port="5432" db_name="openledger" db_user="airflow" db_password="airflow": up
-    just ../exec upstream_db pgcli postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/{{ db_name }}
+pgcli db_user_pass="deploy" db_name="openledger" db_host="upstream_db" db_port="5432": up
+    just ../exec upstream_db pgcli postgresql://{{ db_user_pass }}:{{ db_user_pass }}@{{ db_host }}:{{ db_port }}/{{ db_name }}
 
 #########
 # Tests #

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -85,8 +85,8 @@ ipython: up-deps
         bash -c \'ipython\'
 
 # Launch a `pgcli` shell in the PostgreSQL container
-pgcli db_user_pass="deploy" db_name="openledger" db_host="upstream_db" db_port="5432": up
-    just ../exec upstream_db pgcli postgresql://{{ db_user_pass }}:{{ db_user_pass }}@{{ db_host }}:{{ db_port }}/{{ db_name }}
+pgcli db_user_pass="deploy" db_name="openledger": up
+    just ../_pgcli upstream_db {{ db_user_pass }} {{ db_name }} upstream_db
 
 #########
 # Tests #

--- a/justfile
+++ b/justfile
@@ -206,6 +206,10 @@ exec +args:
 run +args:
     just dc run -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "{{ args }}"
 
+# Execute pgcli against one of the database instances
+_pgcli container db_user_pass db_name db_host db_port="5432":
+    just exec {{ container }} pgcli postgresql://{{ db_user_pass }}:{{ db_user_pass }}@{{ db_host }}:{{ db_port }}/{{ db_name }}
+
 ########
 # Misc #
 ########


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adjust the recipe for `catalog/pgcli` to reduce the number of overrides necessary to define when switching between the Airflow and upstream databases. Additionally, I've reordered the parameters (since with `just` you have to override _all_ parameters in order if you want to change one) so that the fewest need to be changed. Our username and passwords are the same for both databases so I just combined the field.

Lastly, the current config actually didn't work because it was using the airflow creds to connect to the upstream database (which it didn't have access to). I can only speak from personal experience, but almost every time I use the `pgcli` command for the catalog it's to access the upstream database, so I changed the default to be that.

Update: Based on feedback below, I've combined the recipes into a `_pgcli` recipe at the root level, which both the API and catalog now call. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. On `main`, running `j catalog/pgcli` and then `select * from image limit 10` should raise an error
1. Repeating the above on this branch should return results (if they exist)!
1. Try running `j catalog/pgcli airflow airflow` and run `\d` and various selects to ensure you can see the airflow schema
2. Run `j api/pgcli` and confirm that this correctly connects to the API's database and can be used to query the API as well.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
