### PR TITLE
Disallow unexpect console output during tests and fix all errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -150,6 +150,7 @@
     "eslint-plugin-vue": "^9.9.0",
     "eslint-plugin-vuejs-accessibility": "^1.1.1",
     "jest": "^26.6.3",
+    "jest-fail-on-console": "^3.1.1",
     "jest-transform-stub": "^2.0.0",
     "module-alias": "^2.2.2",
     "npm-run-all": "^4.1.5",

--- a/frontend/src/components/VContentLink/VContentLink.vue
+++ b/frontend/src/components/VContentLink/VContentLink.vue
@@ -32,10 +32,11 @@ import type { SupportedMediaType } from "~/constants/media"
 import { defineEvent } from "~/types/emits"
 
 import VLink from "~/components/VLink.vue"
+import VIcon from "~/components/VIcon/VIcon.vue"
 
 export default defineComponent({
   name: "VContentLink",
-  components: { VLink },
+  components: { VLink, VIcon },
   props: {
     /**
      * One of the media types supported.

--- a/frontend/test/unit/setup-after-env.js
+++ b/frontend/test/unit/setup-after-env.js
@@ -1,5 +1,8 @@
 import Vue from "vue"
 import "@testing-library/jest-dom"
+import failOnConsole from "jest-fail-on-console"
+
+failOnConsole()
 
 Vue.prototype.$nuxt = {
   context: {

--- a/frontend/test/unit/specs/components/AudioTrack/v-full-layout.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-full-layout.spec.js
@@ -1,5 +1,8 @@
 import { createLocalVue } from "@vue/test-utils"
 import { fireEvent, render, screen } from "@testing-library/vue"
+import VueI18n from "vue-i18n"
+
+import i18n from "~~/test/unit/test-utils/i18n"
 
 import { getAudioObj } from "~~/test/unit/fixtures/audio"
 import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
@@ -17,6 +20,7 @@ jest.mock("~/composables/use-analytics", () => ({
 
 const localVue = createLocalVue()
 localVue.use(PiniaVuePlugin)
+localVue.use(VueI18n)
 
 describe("VFullLayout", () => {
   it("should render the weblink button with the foreign landing url", () => {
@@ -25,6 +29,7 @@ describe("VFullLayout", () => {
     render(VFullLayout, {
       localVue,
       pinia: createPinia(),
+      i18n,
       propsData: {
         audio,
         size: "s",
@@ -47,6 +52,7 @@ describe("VFullLayout", () => {
     render(VFullLayout, {
       localVue,
       pinia: createPinia(),
+      i18n,
       propsData: {
         audio,
         size: "s",

--- a/frontend/test/unit/specs/pages/browse-page.spec.js
+++ b/frontend/test/unit/specs/pages/browse-page.spec.js
@@ -4,6 +4,8 @@ import { ref } from "vue"
 
 import { createPinia, PiniaVuePlugin } from "~~/test/unit/test-utils/pinia"
 
+import { IsHeaderScrolledKey, IsSidebarVisibleKey } from "~/types/provides"
+
 import SearchIndex from "~/pages/search.vue"
 import { IMAGE } from "~/constants/media"
 
@@ -24,6 +26,12 @@ describe("SearchIndex", () => {
     searchStore.setSearchType(IMAGE)
     options = {
       localVue,
+      provide: {
+        showScrollButton: ref(false),
+        isHeaderScrolled: ref(false),
+        [IsHeaderScrolledKey]: ref(false),
+        [IsSidebarVisibleKey]: ref(false),
+      },
       pinia,
       mocks: {
         $router: { path: { name: "search-image" } },
@@ -38,7 +46,7 @@ describe("SearchIndex", () => {
   })
 
   it("hides the scroll button when injected value is false", () => {
-    options.provide = { showScrollButton: ref(false) }
+    options.provide.showScrollButton = ref(false)
 
     render(SearchIndex, options)
 
@@ -46,7 +54,7 @@ describe("SearchIndex", () => {
   })
 
   it("shows the scroll button when injected value is false", () => {
-    options.provide = { showScrollButton: ref(true) }
+    options.provide.showScrollButton = ref(true)
 
     render(SearchIndex, options)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
       focus-visible: ^5.2.0
       glob: ^8.0.1
       jest: ^26.6.3
+      jest-fail-on-console: ^3.1.1
       jest-transform-stub: ^2.0.0
       module-alias: ^2.2.2
       node-html-parser: ^5.3.3
@@ -222,6 +223,7 @@ importers:
       eslint-plugin-vue: 9.9.0_eslint@8.28.0
       eslint-plugin-vuejs-accessibility: 1.1.1_eslint@8.28.0
       jest: 26.6.3_ts-node@10.9.1
+      jest-fail-on-console: 3.1.1
       jest-transform-stub: 2.0.0
       module-alias: 2.2.2
       npm-run-all: 4.1.5
@@ -12907,6 +12909,12 @@ packages:
       '@types/node': 17.0.32
       jest-mock: 26.6.2
       jest-util: 26.6.2
+    dev: true
+
+  /jest-fail-on-console/3.1.1:
+    resolution: {integrity: sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==}
+    dependencies:
+      chalk: 4.1.2
     dev: true
 
   /jest-get-type/26.3.0:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Similar to #2041 (which this PR builds upon), this PR prevents any unexpected console errors from appearing in tests via the `jest-fail-on-console` utility. This prevents people observing test runs from being confused as to why errors are appearing in the test logs. It also forces us to actually fix these errors instead of glossing over them or ignoring them.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Introduce `jest-fail-on-console` to prevent unexpected console logging in tests. Please note that with this utility you can still enabled _expected_ console logging of any level and the utility gives clear instructions for how to do so when tests fail due to unexpected console logs.

This PR also then fixes all the instances where tests were logging errors. Mostly this was through fixing a variety of fixtures and test configurations.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the unit tests and confirm that they pass (you can rely on CI for this). Also check the CI output to confirm that there are no logged warnings or errors of any kind in the tests (indeed, they should fail if there are).

Check out the branch and add a console error to a test locally to test that the `jest-fail-on-console` utility is configured correctly.

Finally, because I had to make changes to the focus trap, test some dialogues in the running application to make sure they still work as expected. Specifically test that when opening them via keyboard navigation that the correct element is focused when the dialogue is opened.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
