### PR TITLE
Fix i18n setup in the unit tests

### DIFF
--- a/frontend/src/components/VFilters/VSearchGridFilter.vue
+++ b/frontend/src/components/VFilters/VSearchGridFilter.vue
@@ -33,7 +33,7 @@
 <script lang="ts">
 import { computed, defineComponent, ref } from "vue"
 
-import { useContext, useRouter } from "@nuxtjs/composition-api"
+import { useRouter } from "@nuxtjs/composition-api"
 import { kebab } from "case"
 
 import { watchDebounced } from "@vueuse/core"
@@ -42,6 +42,7 @@ import { useSearchStore } from "~/stores/search"
 import { areQueriesEqual, ApiQueryParams } from "~/utils/search-query-transform"
 import type { NonMatureFilterCategory } from "~/constants/filters"
 import { defineEvent } from "~/types/emits"
+import { useI18n } from "~/composables/use-i18n"
 
 import VFilterChecklist from "~/components/VFilters/VFilterChecklist.vue"
 import VButton from "~/components/VButton.vue"
@@ -77,7 +78,7 @@ export default defineComponent({
   setup() {
     const searchStore = useSearchStore()
 
-    const { i18n } = useContext()
+    const i18n = useI18n()
     const router = useRouter()
 
     const filtersFormRef = ref<HTMLFormElement | null>(null)

--- a/frontend/src/composables/use-analytics.ts
+++ b/frontend/src/composables/use-analytics.ts
@@ -4,13 +4,15 @@ import { useContext } from "@nuxtjs/composition-api"
 import type { Events, EventName } from "~/types/analytics"
 import { useUiStore } from "~/stores/ui"
 import { useFeatureFlagStore } from "~/stores/feature-flag"
+import { useI18n } from "~/composables/use-i18n"
 
 /**
  * The `ctx` parameter must be supplied if using this composable outside the
  * bounds of the composition API.
  */
 export const useAnalytics = () => {
-  const { $plausible, $ua, i18n } = useContext()
+  const { $plausible, $ua } = useContext()
+  const i18n = useI18n()
   const uiStore = useUiStore()
   const featureFlagStore = useFeatureFlagStore()
 

--- a/frontend/src/composables/use-get-locale-formatted-number.ts
+++ b/frontend/src/composables/use-get-locale-formatted-number.ts
@@ -1,5 +1,7 @@
 import { useI18n } from "~/composables/use-i18n"
 
+import type { Locale } from "@nuxtjs/i18n"
+
 const WESTERN_ARABIC_NUMERALS = [
   "0",
   "1",
@@ -18,11 +20,13 @@ const WESTERN_ARABIC_NUMERALS = [
  * instead always using Western Arabic Numerals but still respecting
  * the locale preferences for delimiters.
  */
-export const useGetLocaleFormattedNumber = () => {
+export const useGetLocaleFormattedNumber = (
+  locale: Locale | undefined = undefined
+) => {
   const i18n = useI18n()
 
   return (n: number) => {
-    const testFormat = n.toLocaleString(i18n.locale)
+    const testFormat = n.toLocaleString(locale ?? i18n.locale)
 
     if (
       WESTERN_ARABIC_NUMERALS.some((numeral) => testFormat.includes(numeral))

--- a/frontend/src/constants/filters.ts
+++ b/frontend/src/constants/filters.ts
@@ -113,7 +113,7 @@ const filterCodesPerCategory = deepFreeze<Record<FilterCategory, string[]>>({
  *   "audioCategories": [
  *     {
  *       "code": "music",
- *       "name": "filters.audioCategories.music",
+ *       "name": "filters['audio-categories'].music",
  *       "checked": false
  *     }, ...
  *   ],

--- a/frontend/src/types/provides.ts
+++ b/frontend/src/types/provides.ts
@@ -1,4 +1,10 @@
 import type { InjectionKey, Ref } from "vue"
 
-export const IsHeaderScrolledKey = Symbol() as InjectionKey<Ref<boolean>>
-export const IsSidebarVisibleKey = Symbol() as InjectionKey<Ref<boolean>>
+export const IsHeaderScrolledKey =
+  process.env.NODE_ENV === "test"
+    ? "IsHeaderScrolledKey"
+    : (Symbol() as InjectionKey<Ref<boolean>>)
+export const IsSidebarVisibleKey =
+  process.env.NODE_ENV === "test"
+    ? "IsHeaderScrolledKey"
+    : (Symbol() as InjectionKey<Ref<boolean>>)

--- a/frontend/src/types/provides.ts
+++ b/frontend/src/types/provides.ts
@@ -1,10 +1,4 @@
 import type { InjectionKey, Ref } from "vue"
 
-export const IsHeaderScrolledKey =
-  process.env.NODE_ENV === "test"
-    ? "IsHeaderScrolledKey"
-    : (Symbol() as InjectionKey<Ref<boolean>>)
-export const IsSidebarVisibleKey =
-  process.env.NODE_ENV === "test"
-    ? "IsHeaderScrolledKey"
-    : (Symbol() as InjectionKey<Ref<boolean>>)
+export const IsHeaderScrolledKey = Symbol() as InjectionKey<Ref<boolean>>
+export const IsSidebarVisibleKey = Symbol() as InjectionKey<Ref<boolean>>

--- a/frontend/test/unit/setup-after-env.js
+++ b/frontend/test/unit/setup-after-env.js
@@ -1,6 +1,9 @@
 import Vue from "vue"
+
 import "@testing-library/jest-dom"
 import failOnConsole from "jest-fail-on-console"
+
+import { i18n } from "~~/test/unit/test-utils/i18n"
 
 failOnConsole()
 
@@ -10,7 +13,7 @@ Vue.prototype.$nuxt = {
       captureException: jest.fn(),
       captureEvent: jest.fn(),
     },
-    localePath: (args) => args,
-    i18n: { t: (val) => val, tc: (val) => val },
+    // i18n returned by `useI18n` composable (`useContext().i18n`)
+    i18n,
   },
 }

--- a/frontend/test/unit/setup.js
+++ b/frontend/test/unit/setup.js
@@ -1,6 +1,7 @@
 import Vue from "vue"
-import VueI18n from "vue-i18n"
 import { config } from "@vue/test-utils"
+
+import VueI18n from "vue-i18n"
 
 import { env } from "~/utils/env"
 
@@ -37,8 +38,6 @@ config.stubs["svg-icon"] = Vue.component("SvgIcon", {
 })
 /* eslint-enable vue/one-component-per-file */
 
-config.mocks.$t = (key) => key
-config.mocks.localePath = (i) => i
 global.matchMedia =
   global.matchMedia ||
   function () {

--- a/frontend/test/unit/specs/components/AudioTrack/v-box-layout.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-box-layout.spec.js
@@ -1,35 +1,18 @@
-import { render } from "@testing-library/vue"
-import Vuei18n from "vue-i18n"
-import { createLocalVue } from "@vue/test-utils"
-
 import { getAudioObj } from "~~/test/unit/fixtures/audio"
+import { render } from "~~/test/unit/test-utils/render"
 
 import VBoxLayout from "~/components/VAudioTrack/layouts/VBoxLayout.vue"
 
-const enMessages = require("~/locales/en.json")
-
-const i18n = new Vuei18n({
-  locale: "en",
-  fallbackLocale: "en",
-  messages: { en: enMessages },
-})
-
 describe("VBoxLayout", () => {
   let options = null
-  let localVue
   let props = {
     audio: getAudioObj(),
     size: "m",
   }
 
   beforeEach(() => {
-    localVue = createLocalVue()
-    localVue.use(Vuei18n)
     options = {
       propsData: props,
-      mocks: { $nuxt: { context: { i18n } } },
-      localVue,
-      i18n,
     }
   })
 

--- a/frontend/test/unit/specs/components/AudioTrack/v-full-layout.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-full-layout.spec.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/vue"
+import { fireEvent } from "@testing-library/vue"
 
 import { getAudioObj } from "~~/test/unit/fixtures/audio"
 import { render } from "~~/test/unit/test-utils/render"
@@ -8,17 +8,20 @@ import { AUDIO } from "~/constants/media"
 
 import VFullLayout from "~/components/VAudioTrack/layouts/VFullLayout.vue"
 
-jest.mock("~/composables/use-analytics", () => ({
-  useAnalytics: jest.fn(() => ({
-    sendCustomEvent: jest.fn(),
-  })),
-}))
+jest.mock("~/composables/use-analytics")
 
 describe("VFullLayout", () => {
+  const sendCustomEventMock = jest.fn()
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
+  beforeEach(() => {
+    sendCustomEventMock.mockClear()
+  })
   it("should render the weblink button with the foreign landing url", () => {
     const audio = getAudioObj()
 
-    render(VFullLayout, {
+    const { getByText } = render(VFullLayout, {
       propsData: {
         audio,
         size: "s",
@@ -27,18 +30,14 @@ describe("VFullLayout", () => {
       },
     })
 
-    const downloadButton = screen.getByText("audio-details.weblink")
+    const downloadButton = getByText(/Get this audio/i)
     expect(downloadButton).toHaveAttribute("href", audio.foreign_landing_url)
   })
 
   it("should send GET_MEDIA analytics event on button click", async () => {
-    const sendCustomEventMock = jest.fn()
-    useAnalytics.mockImplementation(() => ({
-      sendCustomEvent: sendCustomEventMock,
-    }))
     const audio = getAudioObj()
 
-    render(VFullLayout, {
+    const { getByText } = render(VFullLayout, {
       propsData: {
         audio,
         size: "s",
@@ -47,7 +46,7 @@ describe("VFullLayout", () => {
       },
     })
 
-    const downloadButton = screen.getByText("audio-details.weblink")
+    const downloadButton = getByText(/Get this audio/i)
     await fireEvent.click(downloadButton)
 
     expect(sendCustomEventMock).toHaveBeenCalledWith("GET_MEDIA", {

--- a/frontend/test/unit/specs/components/AudioTrack/waveform.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/waveform.spec.js
@@ -1,12 +1,6 @@
-import { mount } from "@vue/test-utils"
-
-import { useI18n } from "~/composables/use-i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
 import VWaveform from "~/components/VAudioTrack/VWaveform.vue"
-
-jest.mock("~/composables/use-i18n", () => ({
-  useI18n: jest.fn(),
-}))
 
 jest.mock("~/utils/resampling", () => {
   return {
@@ -20,7 +14,6 @@ describe("VWaveform", () => {
   let props = null
 
   beforeEach(() => {
-    useI18n.mockImplementation(() => ({ t: (v) => v, tc: (v) => v }))
     props = {
       peaks: [],
       audioId: "test",
@@ -30,24 +23,25 @@ describe("VWaveform", () => {
       propsData: props,
     }
   })
-  afterEach(() => {
-    useI18n.mockReset()
-  })
 
   it("should use given peaks when peaks array is provided", () => {
-    props.peaks = Array.from({ length: 5 }, () => 0)
-    const wrapper = mount(VWaveform, options)
-    expect(wrapper.vm.normalizedPeaks.length).toBe(5)
+    const peaksCount = 5
+    props.peaks = Array.from({ length: peaksCount }, () => 0)
+    const { container } = render(VWaveform, options)
+    // There is also a yellow "played" rectangle
+    expect(container.querySelectorAll("rect").length).toBe(peaksCount + 1)
   })
 
   it("should use random peaks when peaks not set", () => {
-    const wrapper = mount(VWaveform, options)
-    expect(wrapper.vm.normalizedPeaks.length).toBe(100)
+    const peaksCount = 100
+    const { container } = render(VWaveform, options)
+    expect(container.querySelectorAll("rect")).toHaveLength(peaksCount + 1)
   })
 
   it("should use random peaks when peaks array is blank", () => {
+    const peaksCount = 100
     props.peaks = null
-    const wrapper = mount(VWaveform, options)
-    expect(wrapper.vm.normalizedPeaks.length).toBe(100)
+    const { container } = render(VWaveform, options)
+    expect(container.querySelectorAll("rect")).toHaveLength(peaksCount + 1)
   })
 })

--- a/frontend/test/unit/specs/components/ExternalSources/v-external-source-list.spec.js
+++ b/frontend/test/unit/specs/components/ExternalSources/v-external-source-list.spec.js
@@ -1,11 +1,7 @@
-import VueI18n from "vue-i18n"
-
-import { createLocalVue } from "@vue/test-utils"
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 import userEvent from "@testing-library/user-event"
 
-import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
-import i18n from "~~/test/unit/test-utils/i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useAnalytics } from "~/composables/use-analytics"
 import { IMAGE } from "~/constants/media"
@@ -18,13 +14,9 @@ jest.mock("~/composables/use-analytics", () => ({
 
 describe("VExternalSourceList", () => {
   let propsData
-  let localVue
   let sendCustomEventMock
 
   beforeEach(() => {
-    localVue = createLocalVue()
-    localVue.use(PiniaVuePlugin)
-    localVue.use(VueI18n)
     sendCustomEventMock = jest.fn()
     useAnalytics.mockImplementation(() => ({
       sendCustomEvent: sendCustomEventMock,
@@ -38,9 +30,6 @@ describe("VExternalSourceList", () => {
       ],
     }
     render(VExternalSourceList, {
-      localVue,
-      pinia: createPinia(),
-      i18n,
       props: propsData,
     })
   })

--- a/frontend/test/unit/specs/components/ImageDetails/v-copy-license.spec.js
+++ b/frontend/test/unit/specs/components/ImageDetails/v-copy-license.spec.js
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/vue"
-
 import { render } from "~~/test/unit/test-utils/render"
 
 import VCopyLicense from "~/components/VMediaInfo/VCopyLicense.vue"
@@ -32,9 +30,7 @@ describe("VCopyLicense", () => {
   })
 
   it("should contain the correct contents", () => {
-    render(VCopyLicense, options)
-    expect(
-      screen.queryAllByText("media-details.reuse.copy-license.copy-text")
-    ).toHaveLength(3)
+    const { queryAllByText } = render(VCopyLicense, options)
+    expect(queryAllByText(/Copy text/i)).toHaveLength(3)
   })
 })

--- a/frontend/test/unit/specs/components/ImageDetails/v-image-details-page.spec.js
+++ b/frontend/test/unit/specs/components/ImageDetails/v-image-details-page.spec.js
@@ -1,10 +1,6 @@
-import VueI18n from "vue-i18n"
+import { fireEvent, screen } from "@testing-library/vue"
 
-import { createLocalVue } from "@vue/test-utils"
-import { fireEvent, render, screen } from "@testing-library/vue"
-
-import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
-import i18n from "~~/test/unit/test-utils/i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useAnalytics } from "~/composables/use-analytics"
 import { IMAGE } from "~/constants/media"
@@ -31,10 +27,6 @@ const imageObject = {
   frontendMediaType: "image",
 }
 
-const localVue = createLocalVue()
-localVue.use(PiniaVuePlugin)
-localVue.use(VueI18n)
-
 describe("VImageDetailsPage", () => {
   it("should send GET_MEDIA analytics event on CTA button click", async () => {
     const sendCustomEventMock = jest.fn()
@@ -43,9 +35,6 @@ describe("VImageDetailsPage", () => {
     }))
 
     render(VImageDetailsPage, {
-      localVue,
-      pinia: createPinia(),
-      i18n,
       mocks: {
         $route: {
           params: {
@@ -55,7 +44,7 @@ describe("VImageDetailsPage", () => {
       },
     })
 
-    const downloadButton = screen.getByText("image-details.weblink")
+    const downloadButton = screen.getByText(/get this image/i)
     await fireEvent.click(downloadButton)
 
     expect(sendCustomEventMock).toHaveBeenCalledWith("GET_MEDIA", {

--- a/frontend/test/unit/specs/components/InputField/input-field.spec.js
+++ b/frontend/test/unit/specs/components/InputField/input-field.spec.js
@@ -1,4 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VInputField from "~/components/VInputField/VInputField.vue"
 

--- a/frontend/test/unit/specs/components/VAudioDetails/v-audio-details.spec.js
+++ b/frontend/test/unit/specs/components/VAudioDetails/v-audio-details.spec.js
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 
 import { getAudioObj } from "~~/test/unit/fixtures/audio"
+import { render } from "~~/test/unit/test-utils/render"
 
 import VAudioDetails from "~/components/VAudioDetails/VAudioDetails.vue"
 
@@ -30,7 +31,7 @@ describe("VAudioDetails", () => {
 
   it("renders the album title", () => {
     render(VAudioDetails, options)
-    screen.getByText("audio-details.table.album")
+    screen.getByText(/Test Album/i)
     const album = screen.getByText(overrides.audio_set.title)
     expect(album).toHaveAttribute(
       "href",

--- a/frontend/test/unit/specs/components/VHeader/SearchBar/search-bar.spec.js
+++ b/frontend/test/unit/specs/components/VHeader/SearchBar/search-bar.spec.js
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 
-import { createPinia, PiniaVuePlugin } from "~~/test/unit/test-utils/pinia"
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useMatchHomeRoute } from "~/composables/use-match-routes"
 
@@ -12,13 +12,6 @@ jest.mock("~/composables/use-match-routes", () => ({
 
 const sizes = ["small", "medium", "large", "standalone"]
 const defaultPlaceholder = "Enter search query"
-
-const configureVue = (vue) => {
-  vue.use(PiniaVuePlugin)
-  return {
-    pinia: createPinia(),
-  }
-}
 
 describe("VSearchBar", () => {
   let options
@@ -41,7 +34,7 @@ describe("VSearchBar", () => {
     (size) => {
       useMatchHomeRoute.mockImplementation(() => false)
       options.props.size = size
-      render(VSearchBar, options, configureVue)
+      render(VSearchBar, options)
 
       const inputElement = screen.getByPlaceholderText(defaultPlaceholder)
 
@@ -56,13 +49,13 @@ describe("VSearchBar", () => {
     (size) => {
       useMatchHomeRoute.mockImplementation(() => false)
       options.props.size = size
-      render(VSearchBar, options, configureVue)
+      render(VSearchBar, options)
 
-      const btnElement = screen.getByLabelText("search.search")
+      const btnElement = screen.getByRole("button", { name: /search/i })
 
       expect(btnElement.tagName).toBe("BUTTON")
       expect(btnElement).toHaveAttribute("type", "submit")
-      expect(btnElement).toHaveAttribute("aria-label", "search.search")
+      expect(btnElement).toHaveAttribute("aria-label", "Search")
     }
   )
 
@@ -70,16 +63,16 @@ describe("VSearchBar", () => {
     it("should default to hero.search.placeholder", () => {
       delete options.props.placeholder
 
-      render(VSearchBar, options, configureVue)
+      render(VSearchBar, options)
       expect(
-        screen.queryByPlaceholderText("hero.search.placeholder")
+        screen.queryByPlaceholderText(/Search for content/i)
       ).not.toBeNull()
     })
 
     it("should use the prop when provided", () => {
       const placeholder = "This is a different placeholder from the default"
       options.props.placeholder = placeholder
-      render(VSearchBar, options, configureVue)
+      render(VSearchBar, options)
       expect(screen.queryByPlaceholderText(placeholder)).not.toBeNull()
     })
   })

--- a/frontend/test/unit/specs/components/scroll-button.spec.js
+++ b/frontend/test/unit/specs/components/scroll-button.spec.js
@@ -1,4 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VScrollButton from "~/components/VScrollButton.vue"
 

--- a/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
+++ b/frontend/test/unit/specs/components/v-back-to-search-results-link.spec.js
@@ -1,7 +1,6 @@
-import { createLocalVue } from "@vue/test-utils"
-import { fireEvent, render } from "@testing-library/vue"
+import { fireEvent } from "@testing-library/vue"
 
-import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useAnalytics } from "~/composables/use-analytics"
 
@@ -11,8 +10,6 @@ jest.mock("~/composables/use-analytics", () => ({
   useAnalytics: jest.fn(),
 }))
 
-const localVue = createLocalVue()
-localVue.use(PiniaVuePlugin)
 describe("VBackToSearchResultsLink", () => {
   it("should send analytics event when clicked", async () => {
     const sendCustomEventMock = jest.fn()
@@ -27,11 +24,9 @@ describe("VBackToSearchResultsLink", () => {
     }
 
     const screen = render(VBackToSearchResultsLink, {
-      localVue,
-      pinia: createPinia(),
       propsData,
     })
-    const link = screen.getByText("single-result.back")
+    const link = screen.getByText(/back to results/i)
 
     await fireEvent.click(link)
 

--- a/frontend/test/unit/specs/components/v-button.spec.js
+++ b/frontend/test/unit/specs/components/v-button.spec.js
@@ -1,4 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import { warn } from "~/utils/console"
 

--- a/frontend/test/unit/specs/components/v-checkbox.spec.js
+++ b/frontend/test/unit/specs/components/v-checkbox.spec.js
@@ -1,5 +1,7 @@
 import Vue from "vue"
-import { fireEvent, render, screen } from "@testing-library/vue"
+import { fireEvent, screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VCheckbox from "~/components/VCheckbox/VCheckbox.vue"
 

--- a/frontend/test/unit/specs/components/v-content-link.spec.js
+++ b/frontend/test/unit/specs/components/v-content-link.spec.js
@@ -1,15 +1,8 @@
-import { render, screen } from "@testing-library/vue"
-import VueI18n from "vue-i18n"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VContentLink from "~/components/VContentLink/VContentLink.vue"
-
-const enMessages = require("~/locales/en.json")
-
-const i18n = new VueI18n({
-  locale: "en",
-  fallbackLocale: "en",
-  messages: { en: enMessages },
-})
 
 describe("VContentLink", () => {
   let options = {}
@@ -17,13 +10,6 @@ describe("VContentLink", () => {
   beforeEach(() => {
     options = {
       props: { mediaType: "image", resultsCount: 123, to: "/images" },
-      mocks: {
-        $nuxt: {
-          context: {
-            i18n,
-          },
-        },
-      },
     }
   })
 

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,10 +1,6 @@
-import VueI18n from "vue-i18n"
+import { fireEvent, screen } from "@testing-library/vue"
 
-import { fireEvent, render, screen } from "@testing-library/vue"
-import { createLocalVue } from "@vue/test-utils"
-
-import { createPinia } from "~~/test/unit/test-utils/pinia"
-import i18n from "~~/test/unit/test-utils/i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
 import ReportService from "~/data/report-service"
 
@@ -18,7 +14,7 @@ jest.mock("~/composables/use-analytics", () => ({
 
 const getDmcaInput = () =>
   screen.getByRole("radio", {
-    name: /dmca/i,
+    name: /Infringes copyright/i,
   })
 const getMatureInput = () =>
   screen.getByRole("radio", {
@@ -34,18 +30,18 @@ const getCancelButton = () =>
   })
 const getReportButton = () =>
   screen.getByRole("button", {
-    name: /submit/i,
+    name: /report/i,
   })
 
 // When DMCA selected
 const getReportLink = () =>
   screen.getByRole("link", {
-    name: /dmca\.open/i,
+    name: /DMCA form/i,
   })
 // When other selected
 const getDescriptionTextarea = () =>
   screen.getByRole("textbox", {
-    name: /other\.note/i,
+    name: /Describe the issue. Required/i,
   })
 
 const mockImplementation = () => Promise.resolve()
@@ -57,8 +53,6 @@ jest.mock("~/data/report-service", () => ({
 describe("VContentReportForm", () => {
   let props = null
   let options = {}
-  let pinia = null
-  let localVue = null
 
   beforeEach(() => {
     props = {
@@ -71,17 +65,10 @@ describe("VContentReportForm", () => {
       providerName: "Provider",
       closeFn: jest.fn(),
     }
-    pinia = createPinia()
-    localVue = createLocalVue()
-    localVue.use(pinia)
-    localVue.use(VueI18n)
 
     options = {
       propsData: props,
       stubs: ["VIcon"],
-      localVue,
-      pinia,
-      i18n,
     }
   })
 
@@ -111,7 +98,7 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getReportButton())
 
     // Submission error message
-    getByText("media-details.content-report.failure.note")
+    getByText(/Something went wrong, please try again after some time./i)
   })
 
   it("should render DMCA notice", async () => {
@@ -130,7 +117,7 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getOtherInput())
 
     // Report form with a submit button
-    getByText("media-details.content-report.form.other.note")
+    getByText(/Describe the issue./i)
     getDescriptionTextarea()
   })
 

--- a/frontend/test/unit/specs/components/v-copy-button.spec.js
+++ b/frontend/test/unit/specs/components/v-copy-button.spec.js
@@ -3,7 +3,7 @@
  * Actual copying is being tested by the e2e tests:
  * test/playwright/e2e/attribution.spec.ts
  */
-import { render } from "@testing-library/vue"
+import { render } from "~~/test/unit/test-utils/render"
 
 import VCopyButton from "~/components/VCopyButton.vue"
 
@@ -15,8 +15,6 @@ describe("VCopyButton", () => {
         id: "foo",
       },
     })
-    expect(screen.getByRole("button")).toHaveTextContent(
-      "media-details.reuse.copy-license.copy-text"
-    )
+    expect(screen.getByRole("button")).toHaveTextContent("Copy text")
   })
 })

--- a/frontend/test/unit/specs/components/v-filter-checklist.spec.js
+++ b/frontend/test/unit/specs/components/v-filter-checklist.spec.js
@@ -1,37 +1,28 @@
-import { createLocalVue } from "@vue/test-utils"
-import { fireEvent, render, screen } from "@testing-library/vue"
+import { fireEvent, screen } from "@testing-library/vue"
 
-import { PiniaVuePlugin, createPinia } from "~~/test/unit/test-utils/pinia"
-
-import { useI18n } from "~/composables/use-i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
 import FilterChecklist from "~/components/VFilters/VFilterChecklist.vue"
-
-jest.mock("~/composables/use-i18n", () => ({
-  useI18n: jest.fn(),
-}))
 
 describe("FilterChecklist", () => {
   let options = {}
   let props = null
-  let localVue = null
-  let pinia
 
   beforeEach(() => {
-    localVue = createLocalVue()
-    localVue.use(PiniaVuePlugin)
-    pinia = createPinia()
-    useI18n.mockImplementation(() => ({ t: (v) => v }))
-
     props = {
-      options: [{ code: "foo", name: "bar", checked: false }],
-      title: "Foo",
-      filterType: "bar",
+      // Using real values to avoid i18n warnings
+      options: [
+        {
+          code: "music",
+          name: "filters.audio-categories.music",
+          checked: false,
+        },
+      ],
+      title: "Music",
+      filterType: "audioCategories",
       disabled: false,
     }
     options = {
-      localVue,
-      pinia,
       propsData: props,
     }
   })

--- a/frontend/test/unit/specs/components/v-item-group.spec.js
+++ b/frontend/test/unit/specs/components/v-item-group.spec.js
@@ -1,6 +1,8 @@
 import Vue, { ref } from "vue"
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 import userEvent from "@testing-library/user-event"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useI18n } from "~/composables/use-i18n"
 

--- a/frontend/test/unit/specs/components/v-license.spec.js
+++ b/frontend/test/unit/specs/components/v-license.spec.js
@@ -1,4 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VLicense from "~/components/VLicense/VLicense.vue"
 
@@ -7,18 +9,11 @@ describe("VLicense", () => {
     props: {
       license: "by",
     },
-    mocks: {
-      $nuxt: {
-        context: {
-          i18n: { t: (val) => val },
-        },
-      },
-    },
   }
 
   it("should render the license name and icons", () => {
     const { container } = render(VLicense, options)
-    const licenseName = screen.getByLabelText("license-readable-names.by")
+    const licenseName = screen.getByLabelText("Attribution")
     expect(licenseName).toBeInTheDocument()
     const licenseIcons = container.querySelectorAll("svg")
     expect(licenseIcons).toHaveLength(2) // 'CC' and 'BY' icons
@@ -27,7 +22,7 @@ describe("VLicense", () => {
   it("should render only the license icons", () => {
     options.props.hideName = true
     const { container } = render(VLicense, options)
-    const licenseName = screen.queryByLabelText("license-readable-names.by")
+    const licenseName = screen.queryByText("CC BY")
     expect(licenseName).not.toBeVisible()
     const licenseIcons = container.querySelectorAll("svg")
     expect(licenseIcons).toHaveLength(2)

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -1,11 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/vue"
+import { fireEvent, screen } from "@testing-library/vue"
 import Vue from "vue"
 
-import VLink from "~/components/VLink.vue"
+import { render } from "~~/test/unit/test-utils/render"
 
-const nuxtContextMock = {
-  $nuxt: { context: { app: { localePath: jest.fn((v) => v) } } },
-}
+import VLink from "~/components/VLink.vue"
 
 describe("VLink", () => {
   it.each`
@@ -18,7 +16,6 @@ describe("VLink", () => {
       render(VLink, {
         props: { href },
         slots: { default: "Code is Poetry" },
-        mocks: nuxtContextMock,
       })
       const link = screen.getByRole("link")
       const expectedHref = href.startsWith("/")
@@ -37,6 +34,7 @@ describe("VLink", () => {
     const createVLinkWrapper = (href) =>
       // eslint-disable-next-line vue/one-component-per-file
       Vue.component("VLinkWrapper", {
+        components: { VLink },
         data: () => ({ text: "Link Text" }),
         methods: {
           handleClick(e) {
@@ -47,7 +45,7 @@ describe("VLink", () => {
         template: `<div><VLink href="${href}" @click="handleClick">{{ text }}</VLink></div>`,
       })
     const WrapperComponent = createVLinkWrapper(href)
-    render(WrapperComponent, { mocks: nuxtContextMock }, (localVue) => {
+    render(WrapperComponent, {}, (localVue) => {
       localVue.component("VLink", VLink)
     })
     const linkBefore = await screen.getByRole("link")

--- a/frontend/test/unit/specs/components/v-logo-loader.spec.js
+++ b/frontend/test/unit/specs/components/v-logo-loader.spec.js
@@ -1,4 +1,6 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useReducedMotion } from "~/composables/use-media-query"
 

--- a/frontend/test/unit/specs/components/v-modal.spec.js
+++ b/frontend/test/unit/specs/components/v-modal.spec.js
@@ -1,6 +1,8 @@
 import Vue, { ref, computed } from "vue"
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 import userEvent from "@testing-library/user-event"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VModal from "~/components/VModal/VModal.vue"
 import VModalTarget from "~/components/VModal/VModalTarget.vue"
@@ -37,7 +39,7 @@ const TestWrapper = Vue.component("TestWrapper", {
 const nextTick = async () =>
   await new Promise((resolve) => setTimeout(resolve, 1))
 
-const getCloseButton = () => screen.getByText("modal.close")
+const getCloseButton = () => screen.getByText(/close/i)
 const getDialog = () => screen.getByRole("dialog")
 const queryDialog = () => screen.queryByRole("dialog")
 const getTrigger = () => screen.getByRole("button")
@@ -89,7 +91,7 @@ describe("VModal", () => {
     expect(container.ownerDocument.body.style.position).toBe("fixed")
     expect(container.ownerDocument.body.style.top).toBe(`-${scrollY}px`)
 
-    await userEvent.click(screen.getByText("modal.close"))
+    await userEvent.click(screen.getByText(/close/i))
     await nextTick()
 
     expect(window.scrollTo).toHaveBeenCalledWith(0, scrollY)

--- a/frontend/test/unit/specs/components/v-popover.spec.js
+++ b/frontend/test/unit/specs/components/v-popover.spec.js
@@ -1,6 +1,8 @@
 import Vue from "vue"
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 import userEvent from "@testing-library/user-event"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import { noFocusableElementWarning } from "~/composables/use-focus-on-show"
 

--- a/frontend/test/unit/specs/components/v-related-audios.spec.js
+++ b/frontend/test/unit/specs/components/v-related-audios.spec.js
@@ -17,9 +17,9 @@ describe("RelatedAudios", () => {
       stubs: { LoadingIcon: true, VAudioThumbnail: true },
     })
 
-    expect(screen.findByText("audio-details.related-audios"))
+    screen.getByText(/related audio/i)
 
-    expect(screen.queryAllByLabelText("play-pause.play")).toHaveLength(
+    expect(screen.queryAllByLabelText("Play")).toHaveLength(
       // Two for each as the "row" layout rendered by VRelatedAudio
       // renders a "large" and "small" version that are visually hidden by a parent
       // depending on the breakpoint (but critically still rendered in the

--- a/frontend/test/unit/specs/components/v-related-images.spec.js
+++ b/frontend/test/unit/specs/components/v-related-images.spec.js
@@ -22,9 +22,9 @@ describe("RelatedImage", () => {
   it("should render an image grid", () => {
     render(VRelatedImages, options)
 
-    expect(screen.getAllByRole("heading")[0].textContent).toContain(
-      "image-details.related-images"
-    )
+    expect(
+      screen.getAllByRole("heading", { name: /related images/i })
+    ).toHaveLength(1)
     expect(screen.queryAllByRole("heading").length).toEqual(3)
     expect(screen.queryAllByRole("img").length).toEqual(2)
     expect(screen.queryAllByRole("figure").length).toEqual(2)
@@ -33,9 +33,7 @@ describe("RelatedImage", () => {
   it("should not render data when media array is empty", () => {
     options.propsData.media = []
     render(VRelatedImages, options)
-    expect(screen.getByRole("heading").textContent).toContain(
-      "image-details.related-images"
-    )
+    expect(screen.getByRole("heading").textContent).toContain("Related images")
     expect(screen.queryAllByRole("img").length).toEqual(0)
   })
 })

--- a/frontend/test/unit/specs/components/v-search-results-title.spec.js
+++ b/frontend/test/unit/specs/components/v-search-results-title.spec.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/vue"
+import { render } from "~~/test/unit/test-utils/render"
 
 import VSearchResultsTitle from "~/components/VSearchResultsTitle.vue"
 
@@ -13,8 +13,8 @@ describe("VSearchResultsTitle", () => {
   }
 
   it("should render an h1 tag containing the correct text", async () => {
-    render(VSearchResultsTitle, options)
-    const button = await screen.findByText("zack")
+    const { findByText } = render(VSearchResultsTitle, options)
+    const button = await findByText("zack")
     expect(button.tagName).toBe("H1")
   })
 })

--- a/frontend/test/unit/specs/components/v-sources-table.spec.js
+++ b/frontend/test/unit/specs/components/v-sources-table.spec.js
@@ -1,63 +1,35 @@
-import { render, screen } from "@testing-library/vue"
+import { screen } from "@testing-library/vue"
 import userEvent from "@testing-library/user-event"
 
-import { createTestingPinia } from "@pinia/testing"
-import VueI18n from "vue-i18n"
+import { render } from "~~/test/unit/test-utils/render"
 
-import { PiniaVuePlugin } from "~~/test/unit/test-utils/pinia"
+import { useProviderStore } from "~/stores/provider"
 
 import VSourcesTableVue from "~/components/VSourcesTable.vue"
 
-const enMessages = require("~/locales/en.json")
-
-const i18n = new VueI18n({
-  locale: "en",
-  fallbackLocale: "en",
-  messages: { en: enMessages },
-})
-
-const useMockStore = (vue) => {
-  vue.use(PiniaVuePlugin)
-  const pinia = createTestingPinia({
-    initialState: {
-      provider: {
-        providers: {
-          image: [
-            {
-              source_name: "Provider_B",
-              display_name: "Provider B",
-              source_url: "http://yyy.com",
-              media_count: 1111,
-            },
-            {
-              source_name: "Provider_C",
-              display_name: "Provider C",
-              source_url: "www.xxx.com",
-              media_count: 2222,
-            },
-            {
-              source_name: "Provider_A",
-              display_name: "Provider A",
-              source_url: "https://zzz.com",
-              media_count: 3333,
-            },
-          ],
-        },
+const initialProviderStoreState = {
+  providers: {
+    image: [
+      {
+        source_name: "Provider_B",
+        display_name: "Provider B",
+        source_url: "http://yyy.com",
+        media_count: 1111,
       },
-    },
-  })
-  return { pinia }
-}
-
-const configureVue = (vue) => {
-  const { pinia } = useMockStore(vue)
-  vue.use(VueI18n)
-
-  return {
-    i18n,
-    pinia,
-    /** @todo Create a better mock that can be configured to test this behavior.  */
-  }
+      {
+        source_name: "Provider_C",
+        display_name: "Provider C",
+        source_url: "www.xxx.com",
+        media_count: 2222,
+      },
+      {
+        source_name: "Provider_A",
+        display_name: "Provider A",
+        source_url: "https://zzz.com",
+        media_count: 3333,
+      },
+    ],
+  },
 }
 
 const getTableData = (table) => {
@@ -71,20 +43,23 @@ const getTableData = (table) => {
 
 describe("VSourcesTable", () => {
   let options
+  let configureStoreCb
+  let providerStore
 
   beforeEach(() => {
     options = {
       propsData: { media: "image" },
       stubs: ["TableSortIcon", "VLink"],
-      mocks: {
-        $nuxt: { context: { i18n } },
-      },
+    }
+    configureStoreCb = (localVue, options) => {
+      providerStore = useProviderStore(options?.pinia)
+      providerStore.$patch(initialProviderStoreState)
     }
   })
 
   it('should be sorted by display_name ("Source") by default', () => {
-    render(VSourcesTableVue, options, configureVue)
-    const table = getTableData(screen.getByLabelText("sources.aria.table"))
+    render(VSourcesTableVue, options, configureStoreCb)
+    const table = getTableData(screen.getByLabelText(/source/i))
     const expectedTable = [
       ["Provider A", "zzz.com", "3,333"],
       ["Provider B", "yyy.com", "1,111"],
@@ -94,12 +69,12 @@ describe("VSourcesTable", () => {
   })
 
   it('should be sorted by clean url when click on "Domain" header', async () => {
-    render(VSourcesTableVue, options, configureVue)
+    render(VSourcesTableVue, options, configureStoreCb)
     const domainCell = screen.getByRole("columnheader", {
-      name: "sources.providers.domain",
+      name: /domain/i,
     })
     await userEvent.click(domainCell)
-    const table = getTableData(screen.getByLabelText("sources.aria.table"))
+    const table = getTableData(screen.getByLabelText("sources table"))
     const expectedTable = [
       ["Provider C", "xxx.com", "2,222"],
       ["Provider B", "yyy.com", "1,111"],
@@ -109,12 +84,12 @@ describe("VSourcesTable", () => {
   })
 
   it('should be sorted by media_count when click on "Total items" header', async () => {
-    render(VSourcesTableVue, options, configureVue)
+    render(VSourcesTableVue, options, configureStoreCb)
     const domainCell = screen.getByRole("columnheader", {
-      name: "sources.providers.item",
+      name: /total items/i,
     })
     await userEvent.click(domainCell)
-    const table = getTableData(screen.getByLabelText("sources.aria.table"))
+    const table = getTableData(screen.getByLabelText("sources table"))
     const expectedTable = [
       ["Provider B", "yyy.com", "1,111"],
       ["Provider C", "xxx.com", "2,222"],

--- a/frontend/test/unit/specs/components/v-tabs.spec.js
+++ b/frontend/test/unit/specs/components/v-tabs.spec.js
@@ -1,8 +1,8 @@
-import { render } from "@testing-library/vue"
-
 import Vue from "vue"
 
 import userEvent from "@testing-library/user-event"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import VTabs from "~/components/VTabs/VTabs.vue"
 import VTab from "~/components/VTabs/VTab.vue"

--- a/frontend/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
+++ b/frontend/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
@@ -1,14 +1,13 @@
 import Vue from "vue"
-import { render } from "@testing-library/vue"
-import VueI18n from "vue-i18n"
 
-import messages from "~/locales/en.json"
+import { render } from "~~/test/unit/test-utils/render"
+
 import { useGetLocaleFormattedNumber } from "~/composables/use-get-locale-formatted-number"
 
 const TestWrapper = Vue.component("TestWrapper", {
-  props: ["n"],
-  setup() {
-    const getLocaleFormattedNumber = useGetLocaleFormattedNumber()
+  props: ["n", "locale"],
+  setup(props) {
+    const getLocaleFormattedNumber = useGetLocaleFormattedNumber(props.locale)
 
     return { getLocaleFormattedNumber }
   },
@@ -16,24 +15,11 @@ const TestWrapper = Vue.component("TestWrapper", {
 })
 
 describe("use-get-locale-formatted-number", () => {
-  const getMockedI18n = (locale) => ({
-    $nuxt: {
-      context: {
-        i18n: new VueI18n({
-          locale,
-          fallbackLocale: "en",
-          messages: { en: messages },
-        }),
-      },
-    },
-  })
-
   it.each(["ar", "fa", "ckb", "ps"])(
     "should use en formatting for locales like %s that use Eastern Arabic Numerals",
     (locale) => {
       const { container } = render(TestWrapper, {
-        mocks: getMockedI18n(locale),
-        props: { n: 1000.01 },
+        props: { n: 1000.01, locale },
       })
 
       expect(container.firstChild.textContent).toEqual(
@@ -49,8 +35,7 @@ describe("use-get-locale-formatted-number", () => {
     "should use the default formatting for locales not matching eastern arabic numeral locales like %s",
     (locale) => {
       const { container } = render(TestWrapper, {
-        mocks: getMockedI18n(locale),
-        props: { n: 1000.01 },
+        props: { n: 1000.01, locale },
       })
 
       expect(container.firstChild.textContent).toEqual(

--- a/frontend/test/unit/specs/composables/use-window-scroll.spec.js
+++ b/frontend/test/unit/specs/composables/use-window-scroll.spec.js
@@ -1,14 +1,14 @@
 import Vue, { ref } from "vue"
-import { render } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
 
 import { useWindowScroll } from "~/composables/use-window-scroll"
 
-const getMockWindow = <T>(props: T) =>
-  ({
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    ...props,
-  } as unknown as typeof window)
+const getMockWindow = (props) => ({
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  ...props,
+})
 
 const UseWindowScrollTestContainer = Vue.component(
   "UseWindowScrollTestContainer",
@@ -20,7 +20,7 @@ const UseWindowScrollTestContainer = Vue.component(
           scrollX: props.initX,
           scrollY: props.initY,
         }),
-        throttleMs: props.throttleMs as number | undefined,
+        throttleMs: props.throttleMs,
       })
     },
     template: "<div>x={{x}} y={{y}} isScrolled={{isScrolled}}</div>",

--- a/frontend/test/unit/test-utils/i18n.js
+++ b/frontend/test/unit/test-utils/i18n.js
@@ -2,12 +2,10 @@ import VueI18n from "vue-i18n"
 
 const messages = require("~/locales/en.json")
 
-const i18n = new VueI18n({
+export const i18n = new VueI18n({
   locale: "en",
   fallbackLocale: "en",
   messages: {
     en: messages,
   },
 })
-
-export default i18n

--- a/frontend/test/unit/test-utils/render.js
+++ b/frontend/test/unit/test-utils/render.js
@@ -3,16 +3,7 @@ import VueI18n from "vue-i18n"
 import { render as testingLibraryRender } from "@testing-library/vue"
 
 import { createPinia, PiniaVuePlugin } from "~~/test/unit/test-utils/pinia"
-
-import messages from "~/locales/en.json"
-
-const i18n = new VueI18n({
-  locale: "en",
-  fallbackLocale: "en",
-  messages: { en: messages },
-  missingWarn: false,
-  silentTranslationWarn: true,
-})
+import { i18n } from "~~/test/unit/test-utils/i18n"
 
 export const render = (Component, options = {}, configureCb = null) => {
   if (!options?.i18n) {
@@ -26,10 +17,9 @@ export const render = (Component, options = {}, configureCb = null) => {
     localVue.use(VueI18n)
     localVue.use(PiniaVuePlugin)
 
+    // This callback can be used to set up the store
     if (configureCb) {
       configureCb(localVue, options)
     }
   })
 }
-
-export default render


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2050 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR correctly sets up i18n in unit tests so that the keys are actually translated, both in the `setup` function that uses `useContext().i18n` from `Nuxt`, and in the templates' `$t` function.

Over the time, we have used several ways of mocking i18n in unit tests, and i18n is  set up slightly differently for different tests. This PR simplifies the set up by moving all of it into 3 points:
- `i18n` instance is set up in `test-utils/i18n.js`, and imported from there
- this instance is used in the `$nuxt` context mock - to be used everywhere where we use `useI18n()` in the components' `setup` functions.
- this instance is also used in the `render` function that mounts the component for tests. This is passed to `Vue` and is used in the templates' `$t` function.

All of the `i18n` set up and mocking from the components was removed.
This PR also uses `test-utils/render` for all components to correctly pass the `i18n` to all of the components. Using `render` from `testing-library` would require us to set up `i18n` separately (which is not necessary, and would needlessly complicate the set up).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
All the unit tests should pass. They should use the translated strings instead of the keys for selecting elements (see how the element selectors in the component tests have changed from e.g. "audio-details.related-audios" key to the value we can see in the UI ("Related audio")).


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
