### PR TITLE
Add a dev container supporting docs and frontend

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+  "name": "Openverse",
+
+  "image": "mcr.microsoft.com/devcontainers/base:0-debian",
+
+  // Features to add to the dev container.
+  // More info: https://containers.dev/features
+  // List of features and their default options: https://github.com/devcontainers/features/tree/main/src
+  "features": {
+    // Openverse development environment requirement matrix: https://docs.openverse.org/general/general_setup.html#requirement-matrix
+    "ghcr.io/guiyomh/features/just:0": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      // Match the Python version defined in `*/Pipfile`.
+      // TODO: Automatically populate this.
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      // Match the Node.js version defined in `package.json`.
+      // TODO: Automatically populate this.
+      "version": "16"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    50230, // documentation
+    8443 // frontend
+  ],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "./.devcontainer/post_create.sh"
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# ABOUT
+# =====
+# This Bash script runs inside the dev container when it is created for the
+# time. Use this space to prepare the dev environment.
+
+# The Node.js feature installs the latest version of pnpm, not the one we want.
+# So we enable Corepack to provision the right pnpm version.
+corepack enable
+
+# Install dependencies for projects that run outside of the Docker context. This
+# includes Node.js packages, Python automations and documentation.
+just install
+
+# Running lint installs and prepares the hook environments. This saves time when
+# the developer needs to run lint.
+just lint

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@ templates/                  @WordPress/openverse-maintainers
 .gitattributes              @WordPress/openverse-maintainers
 .gitignore                  @WordPress/openverse-maintainers
 .github/                    @WordPress/openverse-maintainers
+.devcontainer/              @WordPress/openverse-maintainers
 .pre-commit-config.yaml     @WordPress/openverse-maintainers
 CODE_OF_CONDUCT.md          @WordPress/openverse-maintainers
 CONTRIBUTING.md             @WordPress/openverse-maintainers

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -44,6 +44,7 @@ lint:
   - .pre-commit-config.yaml
 mgmt:
   - .github/**
+  - .devcontainer/**
   - automations/**
 ci_cd:
   - .github/actions/**

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__/
 node_modules/
 npm-debug.log*
 .pnpm-debug.log
+.pnpm-store/
 
 # Nuxt
 .nuxt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
       - id: check-executables-have-shebangs
       - id: check-json
-        exclude: tsconfig.json # contains comments
+        exclude: tsconfig.json|.devcontainer/devcontainer.json # contains comments
       - id: check-case-conflict
       - id: check-toml
       - id: check-merge-conflict


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1022 by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR sets up a dev container that can be used locally (which is awesome) or as a GitHub codespace (not as awesome but still usable).

This container contains everything you need to be immediately productive in two stacks (for now, others maybe later), the documentation and the frontend.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

- Navigate to `WordPress/openverse`.
- Click on the "<> Code" button.
- Switch to the Codespaces tab.
- Click on the "..." dropdown button.
- Choose "New with options".
- Change branch to this one `dev_container`. This should automatically apply the "Openverse" dev container configuration.
- Customise any other options to your liking.
- Create the codespace.

The codespace can take quite some time to build and initialise. Grab a coffee or snack in the meantime. Or go for a walk. Whatever floats your boat. During this step the container will set up all pnpm dependencies, install Python projects that run outside Docker and set up linting with pre-commit.

### Documentation

- Run `just documentation/live` in the attached terminal.
- Switch to the ports tab (adjacent to the terminal).
- Click on the "🌐" icon next to the 50230 port. That should open the forwarded port in a new tab. 
- Make some changes to the documentation. Your changes should reflect in the preview in real time.

<img width="1392" alt="Screenshot 2023-05-07 at 6 19 07 PM" src="https://user-images.githubusercontent.com/16580576/236683143-f89e1192-4da6-42f8-9f94-c805b6da8183.png">

### Frontend

- Run `just frontend/run dev` in the attached terminal.
- Switch to the ports tab (adjacent to the terminal).
- Click on the "🌐" icon next to the 8443 port. That should open the forwarded port in a new tab. 
- Make some changes to the frontend. Your changes should reflect in the preview in real time.

<img width="1392" alt="Screenshot 2023-05-07 at 6 44 55 PM" src="https://user-images.githubusercontent.com/16580576/236684484-be1dc5b7-dd75-4bdc-a5af-a7a0e20cd32b.png">

## Caveats

The dev container is frustratingly slow and pretty limited in what it can do, considering it's all running _inside_ a Docker container. Additionally it's currently limited to the documentation and the frontend (only if you opt for a higher RAM codespace). Dockerised applications like the API will run with Docker-in-Docker and as I understand, will be even slower 😢.

But for a lot of contributors who struggle with setting up an environment complete will all the pre-requisites, this is amazing. It has all you need to be productive and make a quick PR to two stacks!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
