### PR TITLE
Derive document sensitivity markings from filtered index

### DIFF
--- a/api/api/constants/media_types.py
+++ b/api/api/constants/media_types.py
@@ -1,4 +1,6 @@
 """Also see `ingestion_server/constants/media_types.py`."""
+from typing import Literal
+
 
 AUDIO_TYPE = "audio"
 IMAGE_TYPE = "image"
@@ -6,3 +8,5 @@ IMAGE_TYPE = "image"
 MEDIA_TYPES = [AUDIO_TYPE, IMAGE_TYPE]
 
 MEDIA_TYPE_CHOICES = [(AUDIO_TYPE, "Audio"), (IMAGE_TYPE, "Image")]
+
+OriginIndex = Literal["image", "audio"]

--- a/api/api/constants/sensitivity.py
+++ b/api/api/constants/sensitivity.py
@@ -1,3 +1,12 @@
+"""
+Sensitivity tokens denoting what made a given result "sensitive".
+
+``PROVIDER_SUPPLIED`` is currently unused because we do not actually
+ingest sensitive content from providers (knowingly). It is included
+here to cover the gamut of potential use-cases and to provide an
+opportunity to document it as an exceptional case.
+"""
+
 TEXT = "sensitive_text"
 PROVIDER_SUPPLIED = "provider_supplied_sensitivity"
 USER_REPORTED = "user_reported_sensitivity"

--- a/api/api/constants/sensitivity.py
+++ b/api/api/constants/sensitivity.py
@@ -1,0 +1,3 @@
+TEXT = "sensitive_text"
+PROVIDER_SUPPLIED = "provider_supplied_sensitivity"
+USER_REPORTED = "user_reported_sensitivity"

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -475,7 +475,7 @@ def search(
     return results or [], page_count, result_count, search_context.asdict()
 
 
-def related_media(uuid, index, request, filter_dead):
+def related_media(uuid, index, filter_dead):
     """Given a UUID, find related search results."""
 
     search_client = Search(index=index)
@@ -502,13 +502,12 @@ def related_media(uuid, index, request, filter_dead):
     start, end = _get_query_slice(s, page_size, page, filter_dead)
     s = s[start:end]
     response = s.execute()
-    results = _post_process_results(
-        s, start, end, page_size, response, request, filter_dead
-    )
+    results = _post_process_results(s, start, end, page_size, response, filter_dead)
 
     result_count, _ = _get_result_and_page_count(response, results, page_size, page)
 
-    return results or [], result_count
+    search_context = SearchContext.build(results, index)
+    return results or [], result_count, search_context.asdict()
 
 
 def get_sources(index):

--- a/api/api/examples/audio_responses.py
+++ b/api/api/examples/audio_responses.py
@@ -54,6 +54,7 @@ base_audio = {
     "detail_url": f"{origin}/v1/audio/{identifier}/",
     "related_url": f"{origin}/v1/audio/{identifier}/related/",
     "waveform": f"{origin}/v1/audio/{identifier}/waveform/",
+    "unstable__sensitivity": [],
 }
 
 audio_search_200_example = {

--- a/api/api/examples/image_responses.py
+++ b/api/api/examples/image_responses.py
@@ -56,6 +56,7 @@ base_image = {
     "thumbnail": f"{origin}/v1/images/{identifier}/thumb/",
     "detail_url": f"{origin}/v1/images/{identifier}/",
     "related_url": f"{origin}/v1/images/{identifier}/related/",
+    "unstable__sensitivity": [],
 }
 
 detailed_image = base_image | {

--- a/api/api/serializers/media_serializers.py
+++ b/api/api/serializers/media_serializers.py
@@ -489,7 +489,11 @@ class MediaSerializer(BaseModelSerializer):
     def get_unstable__sensitivity(self, obj: Hit | AbstractMedia) -> list[str]:
         result = []
 
-        if obj.identifier in self.context.get(
+        # obj.identifier needs to be cast to a string because
+        # Django UUID fields return UUID objects by default
+        # and UUID comparison fails against _any_ string object,
+        # even if the string matches the UUID.
+        if str(obj.identifier) in self.context.get(
             "sensitive_text_result_identifiers", set()
         ):
             result.append(sensitivity.TEXT)

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -1,0 +1,78 @@
+from dataclasses import asdict, dataclass
+from typing import Self
+
+from django.db.models import CharField
+from django.db.models.functions import Cast
+
+from elasticsearch_dsl import Q, Search
+from elasticsearch_dsl.response import Hit
+
+from api import models
+from api.constants.media_types import OriginIndex
+
+
+@dataclass
+class SearchContext:
+    all_result_identifiers: set[str]
+    """All the result identifiers gathered for the search."""
+
+    user_reported_sensitive_result_identifiers: set[str]
+    """Subset of result identifiers for results with confirmed sensitive reports."""
+
+    sensitive_text_result_identifiers: set[str]
+    """Subset of result identifiers for results with sensitive textual content."""
+
+    @classmethod
+    def get_mature_media_class_for_index(
+        cls, origin_index: OriginIndex
+    ) -> models.MatureImage | models.MatureAudio:
+        match origin_index:
+            case "image":
+                return models.MatureImage
+            case "audio":
+                return models.MatureAudio
+            case _:
+                raise ValueError(f"Unknown `origin_index` value '{origin_index}'")
+
+    @classmethod
+    def build(cls, results: list[Hit], origin_index: OriginIndex) -> Self:
+        if not results:
+            return cls(set(), set(), set())
+
+        all_result_identifiers = {r.identifier for r in results}
+
+        filtered_index_search = Search(index=f"{origin_index}-filtered")
+        filtered_index_search = filtered_index_search.query(
+            Q("terms", id=[result.id for result in results])
+        )
+
+        results_in_filtered_index = filtered_index_search.execute()
+        filtered_index_identifiers = {
+            result.identifier for result in results_in_filtered_index
+        }
+        sensitive_text_result_identifiers = {
+            identifier
+            for identifier in all_result_identifiers
+            if identifier not in filtered_index_identifiers
+        }
+
+        mature_media_class = cls.get_mature_media_class_for_index(origin_index)
+
+        user_reported_sensitive_result_identifiers = set(
+            mature_media_class.objects
+            # ``identifier`` comes back as a UUID by default, so it needs to be
+            # cast to string to match the interface of the sets expected
+            # by ``SearchContext``
+            .annotate(identifier_string=Cast("media_obj_id", output_field=CharField()))
+            .filter(media_obj_id__in=list(all_result_identifiers))
+            .values_list("identifier_string", flat=True)
+        )
+
+        return cls(
+            all_result_identifiers=all_result_identifiers,
+            sensitive_text_result_identifiers=sensitive_text_result_identifiers,
+            user_reported_sensitive_result_identifiers=user_reported_sensitive_result_identifiers,
+        )
+
+    def asdict(self):
+        return asdict(self)

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -1,43 +1,28 @@
 from dataclasses import asdict, dataclass
 from typing import Self
 
-from django.db.models import CharField
-from django.db.models.functions import Cast
-
 from elasticsearch_dsl import Q, Search
 from elasticsearch_dsl.response import Hit
 
-from api import models
 from api.constants.media_types import OriginIndex
 
 
 @dataclass
 class SearchContext:
+    # Note: These sets use "identifiers" very explicitly
+    # to convey that it is the Openverse result identifier and
+    # not the document _id
+
     all_result_identifiers: set[str]
     """All the result identifiers gathered for the search."""
-
-    user_reported_sensitive_result_identifiers: set[str]
-    """Subset of result identifiers for results with confirmed sensitive reports."""
 
     sensitive_text_result_identifiers: set[str]
     """Subset of result identifiers for results with sensitive textual content."""
 
     @classmethod
-    def get_mature_media_class_for_index(
-        cls, origin_index: OriginIndex
-    ) -> models.MatureImage | models.MatureAudio:
-        match origin_index:
-            case "image":
-                return models.MatureImage
-            case "audio":
-                return models.MatureAudio
-            case _:
-                raise ValueError(f"Unknown `origin_index` value '{origin_index}'")
-
-    @classmethod
     def build(cls, results: list[Hit], origin_index: OriginIndex) -> Self:
         if not results:
-            return cls(set(), set(), set())
+            return cls(set(), set())
 
         all_result_identifiers = {r.identifier for r in results}
 
@@ -46,7 +31,10 @@ class SearchContext:
             Q("terms", id=[result.id for result in results])
         )
 
-        results_in_filtered_index = filtered_index_search.execute()
+        # The default query size is 10, so we need to slice the query
+        # to change the size to be big enough to encompass all the
+        # results.
+        results_in_filtered_index = filtered_index_search[: len(results)].execute()
         filtered_index_identifiers = {
             result.identifier for result in results_in_filtered_index
         }
@@ -56,22 +44,9 @@ class SearchContext:
             if identifier not in filtered_index_identifiers
         }
 
-        mature_media_class = cls.get_mature_media_class_for_index(origin_index)
-
-        user_reported_sensitive_result_identifiers = set(
-            mature_media_class.objects
-            # ``identifier`` comes back as a UUID by default, so it needs to be
-            # cast to string to match the interface of the sets expected
-            # by ``SearchContext``
-            .annotate(identifier_string=Cast("media_obj_id", output_field=CharField()))
-            .filter(media_obj_id__in=list(all_result_identifiers))
-            .values_list("identifier_string", flat=True)
-        )
-
         return cls(
             all_result_identifiers=all_result_identifiers,
             sensitive_text_result_identifiers=sensitive_text_result_identifiers,
-            user_reported_sensitive_result_identifiers=user_reported_sensitive_result_identifiers,
         )
 
     def asdict(self):

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -50,4 +50,10 @@ class SearchContext:
         )
 
     def asdict(self):
+        """
+        Cast the object to a dict.
+
+        This is a convenience method to avoid leaking dataclass
+        implementation details elsewhere in the code.
+        """
         return asdict(self)

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -115,7 +115,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
 
         serializer_context = search_context | self.get_serializer_context()
 
-        serializer_class = self.get_serializer_class()
+        serializer_class = self.get_serializer()
         if params.needs_db or serializer_class.needs_db:
             results = self.get_db_results(results)
 

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -140,10 +140,9 @@ class MediaViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def related(self, request, identifier=None, *_, **__):
         try:
-            results, num_results = search_controller.related_media(
+            results, num_results, search_context = search_controller.related_media(
                 uuid=identifier,
                 index=self.default_index,
-                request=request,
                 filter_dead=True,
             )
             self.paginator.result_count = num_results
@@ -156,7 +155,9 @@ class MediaViewSet(ReadOnlyModelViewSet):
         except IndexError:
             raise APIException("Could not find items.", 404)
 
-        serializer = self.get_serializer(results, many=True)
+        serializer_context = search_context | self.get_serializer_context()
+
+        serializer = self.get_serializer(results, many=True, context=serializer_context)
         return self.get_paginated_response(serializer.data)
 
     def report(self, request, identifier):

--- a/api/test/factory/models/__init__.py
+++ b/api/test/factory/models/__init__.py
@@ -1,0 +1,8 @@
+from test.factory.models.audio import AudioAddOnFactory, AudioFactory
+from test.factory.models.image import ImageFactory
+from test.factory.models.oauth2 import (
+    AccessTokenFactory,
+    OAuth2RegistrationFactory,
+    OAuth2VerificationFactory,
+    ThrottledApplicationFactory,
+)

--- a/api/test/factory/models/__init__.py
+++ b/api/test/factory/models/__init__.py
@@ -1,5 +1,9 @@
-from test.factory.models.audio import AudioAddOnFactory, AudioFactory
-from test.factory.models.image import ImageFactory
+from test.factory.models.audio import (
+    AudioAddOnFactory,
+    AudioFactory,
+    MatureAudioFactory,
+)
+from test.factory.models.image import ImageFactory, MatureImageFactory
 from test.factory.models.oauth2 import (
     AccessTokenFactory,
     OAuth2RegistrationFactory,

--- a/api/test/factory/models/audio.py
+++ b/api/test/factory/models/audio.py
@@ -1,12 +1,22 @@
 from test.factory.faker import Faker
 from test.factory.models.media import IdentifierFactory, MediaFactory
 
+import factory
 from factory.django import DjangoModelFactory
 
-from api.models.audio import Audio, AudioAddOn
+from api.models.audio import Audio, AudioAddOn, MatureAudio
+
+
+class MatureAudioFactory(DjangoModelFactory):
+    class Meta:
+        model = MatureAudio
+
+    media_obj = factory.SubFactory("test.factory.models.audio.AudioFactory")
 
 
 class AudioFactory(MediaFactory):
+    _mature_factory = MatureAudioFactory
+
     class Meta:
         model = Audio
 

--- a/api/test/factory/models/image.py
+++ b/api/test/factory/models/image.py
@@ -1,8 +1,20 @@
 from test.factory.models.media import MediaFactory
 
-from api.models.image import Image
+import factory
+from factory.django import DjangoModelFactory
+
+from api.models.image import Image, MatureImage
+
+
+class MatureImageFactory(DjangoModelFactory):
+    class Meta:
+        model = MatureImage
+
+    media_obj = factory.SubFactory("test.factory.models.image.ImageFactory")
 
 
 class ImageFactory(MediaFactory):
+    _mature_factory = MatureImageFactory
+
     class Meta:
         model = Image

--- a/api/test/factory/models/media.py
+++ b/api/test/factory/models/media.py
@@ -1,21 +1,52 @@
 from test.factory.faker import Faker
 from uuid import uuid4
 
+from django.conf import settings
+
 import factory
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl.response import Hit
 from factory.django import DjangoModelFactory
 
 from api.constants.licenses import ALL_LICENSES
+from api.models.media import AbstractMedia
+
+
+CREATED_BY_FIXTURE_MARKER = "__created_by_test_fixture"
+
+
+_highest_pre_existing_pk = {}
 
 
 class MediaFactory(DjangoModelFactory):
     """Base factory for models that extend from the AbstractMedia class."""
+
+    # Sub-factories can extend this with media-specific fields
+    _document_fields = (
+        "id",
+        "identifier",
+        "foreign_identifier",
+        "license",
+        "foreign_landing_url",
+        "url",
+        "thumbnail",
+        "mature",
+        "title",
+        "tags",
+    )
+
+    # Sub-factories must set this to their corresponding
+    # ``AbstractMatureMedia`` subclass
+    _mature_factory = None
+
+    _highest_pre_existing_pk = None
 
     class Meta:
         abstract = True
 
     id = factory.sequence(lambda n: n)
 
-    identifier = factory.sequence(lambda _: uuid4())
+    identifier = factory.sequence(lambda _: str(uuid4()))
 
     foreign_identifier = factory.sequence(lambda _: uuid4())
     """The foreign identifier isn't necessarily a UUID but for test purposes it's fine if it looks like one"""
@@ -25,6 +56,113 @@ class MediaFactory(DjangoModelFactory):
     foreign_landing_url = Faker("globally_unique_url")
     url = Faker("globally_unique_url")
     thumbnail = Faker("image_url")
+    title = Faker("sentence", nb_words=4)
+    tags = factory.List(
+        [
+            {
+                "name": CREATED_BY_FIXTURE_MARKER,
+            }
+        ]
+    )
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Create the media instance.
+
+        If ``mature_reported`` kwarg is passed, this is understood to mean
+        a document identified as mature as a result of a user report.
+
+        Provider-supplied maturity is only recorded in the ES
+        index and should be tested via the ``create_es_document``
+        helper method or mocking.
+        """
+        mature_reported = kwargs.pop("mature_reported", False)
+
+        model_class = cls._meta.get_model_class()
+        if cls._highest_pre_existing_pk is None:
+            response = settings.ES.search(
+                index=model_class._meta.db_table, sort={"id": "desc"}, size=1
+            )
+
+            cls._highest_pre_existing_pk = int(response["hits"]["hits"][0]["_id"])
+
+        kwargs.setdefault(
+            "id", cls._meta.next_sequence() + cls._highest_pre_existing_pk + 1
+        )
+
+        model = super().create(*args, **kwargs)
+        if mature_reported:
+            cls._mature_factory.create(media_obj=model)
+
+        return model
+
+    @classmethod
+    def _create_es_source_document(
+        cls,
+        media: AbstractMedia,
+        # If ``None`` this will default to the ``media.mature``
+        # property value. Otherwise it will force the document
+        # value.
+        mature: bool | None,
+    ) -> dict:
+        mature = media.mature if mature is None else mature
+        return {"mature": mature} | {
+            field: getattr(media, field) for field in cls._document_fields
+        }
+
+    @classmethod
+    def save_model_to_es(
+        cls,
+        media: AbstractMedia,
+        *,
+        filtered: bool = True,
+        mature: bool | None = None,
+    ):
+        """
+        Persist a media model to Elasticsearch.
+
+        ``test.unit.conftest::cleanup_test_documents_elasticsearch`` is
+        responsible for cleaning up documents created in tests.
+        """
+        es: Elasticsearch = settings.ES
+
+        origin_index = media._meta.db_table
+        source_document = cls._create_es_source_document(media, mature)
+        es.create(
+            index=origin_index,
+            id=media.pk,
+            document=source_document,
+            refresh=True,
+        )
+        if filtered:
+            es.create(
+                index=f"{origin_index}-filtered",
+                id=media.pk,
+                document=source_document,
+                refresh=True,
+            )
+
+    @classmethod
+    def create_hit(
+        cls, media: AbstractMedia, *, _score: float = 1.0, mature: bool | None = None
+    ) -> Hit:
+        # ``document`` should match the dictionary returned
+        # by Elasticsearch. ``_source`` only contains the
+        # fields that are defined in the ``MediaFactory``,
+        # not all the fields for a
+        document = {
+            "_index": media._meta.db_table,
+            "_type": "doc",
+            "_id": media.pk,
+            "_score": _score,
+            "_source": cls._create_es_source_document(
+                media,
+                mature,
+            ),
+        }
+
+        return Hit(document)
 
 
 class IdentifierFactory(factory.SubFactory):

--- a/api/test/unit/conftest.py
+++ b/api/test/unit/conftest.py
@@ -45,6 +45,7 @@ def request_factory() -> APIRequestFactory():
 @dataclass
 class MediaTypeConfig:
     media_type: str
+    url_prefix: str
     origin_index: str
     filtered_index: str
     model_factory: MediaFactory
@@ -56,6 +57,7 @@ class MediaTypeConfig:
 MEDIA_TYPE_CONFIGS = (
     MediaTypeConfig(
         media_type="image",
+        url_prefix="images",
         origin_index="image",
         filtered_index="image-filtered",
         model_factory=model_factories.ImageFactory,
@@ -65,6 +67,7 @@ MEDIA_TYPE_CONFIGS = (
     ),
     MediaTypeConfig(
         media_type="audio",
+        url_prefix="audio",
         origin_index="audio",
         filtered_index="audio-filtered",
         model_factory=model_factories.AudioFactory,

--- a/api/test/unit/conftest.py
+++ b/api/test/unit/conftest.py
@@ -1,8 +1,11 @@
+from test.factory.models import AudioFactory, ImageFactory
+from test.factory.models.media import CREATED_BY_FIXTURE_MARKER
 from unittest.mock import MagicMock
 
 from rest_framework.test import APIClient, APIRequestFactory
 
 import pytest
+from elasticsearch import Elasticsearch
 
 
 @pytest.fixture
@@ -23,3 +26,41 @@ def request_factory() -> APIRequestFactory():
     request_factory = APIRequestFactory(defaults={"REMOTE_ADDR": "192.0.2.1"})
 
     return request_factory
+
+
+@pytest.fixture(params=["image", "audio"])
+def origin_index(request):
+    return request.param
+
+
+@pytest.fixture
+def model_factory(request: pytest.FixtureRequest):
+    match request.getfixturevalue("origin_index"):
+        case "audio":
+            return AudioFactory
+        case "image":
+            return ImageFactory
+        case unknown:
+            raise ValueError(f"Unknown origin_index '{unknown}'")
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_documents_elasticsearch(
+    request, origin_index, model_factory, settings
+):
+    yield None
+    # This fixture only matters after tests are finished
+
+    if not request.node.get_closest_marker("django_db"):
+        # If the test isn't configured to access the database
+        # then it couldn't have created any new documents,
+        # so we can skip cleanup
+        return
+
+    es: Elasticsearch = settings.ES
+
+    es.delete_by_query(
+        index="*",
+        body={"query": {"match": {"tags.name": CREATED_BY_FIXTURE_MARKER}}},
+        refresh=True,
+    )

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -459,7 +459,7 @@ def test_search_tallies_pages_less_than_5(
     search_controller.search(
         search_params=serializer,
         ip=0,
-        index=index,
+        origin_index=index,
         exact_index=False,
         page=page,
         page_size=page_size,
@@ -499,7 +499,7 @@ def test_search_tallies_handles_empty_page(
     search_controller.search(
         search_params=serializer,
         ip=0,
-        index=index,
+        origin_index=index,
         exact_index=False,
         # Force calculated result depth length to include results within 80th position and above
         # to force edge case where retrieved results are only partially tallied.
@@ -545,7 +545,7 @@ def test_resolves_index(
     search_controller.search(
         search_params=serializer,
         ip=0,
-        index=origin_index,
+        origin_index=origin_index,
         exact_index=False,
         page=1,
         page_size=20,

--- a/api/test/unit/serializers/test_media_serializers.py
+++ b/api/test/unit/serializers/test_media_serializers.py
@@ -10,18 +10,9 @@ from rest_framework.views import APIView
 
 import pytest
 
-<<<<<<< HEAD
-from api.serializers.audio_serializers import (
-    AudioSearchRequestSerializer,
-    AudioSerializer,
-)
-from api.serializers.image_serializers import (
-    ImageSearchRequestSerializer,
-    ImageSerializer,
-)
-=======
 from api.constants import sensitivity
->>>>>>> 9274ff532 (Remove provider-supplied sensitivity handling)
+from api.serializers.audio_serializers import AudioSearchRequestSerializer
+from api.serializers.image_serializers import ImageSearchRequestSerializer
 from api.serializers.media_serializers import MediaSearchRequestSerializer
 
 

--- a/api/test/unit/serializers/test_media_serializers.py
+++ b/api/test/unit/serializers/test_media_serializers.py
@@ -120,14 +120,13 @@ def test_media_serializer_adds_license_url_if_missing(
 def test_media_serializer_sensitivity(
     has_sensitive_text,
     has_confirmed_report,
-    provider_marked_mature,
     media_type_config,
     anon_request,
 ):
     model, hit = media_type_config.model_factory.create(
         sensitive_text=has_sensitive_text,
         mature_reported=has_confirmed_report,
-        with_es=True,
+        with_hit=True,
     )
 
     other_result_ids = [str(uuid.uuid4()) for _ in range(6)]
@@ -145,6 +144,8 @@ def test_media_serializer_sensitivity(
     expected_sensitivity = set()
     if has_sensitive_text:
         expected_sensitivity.add(sensitivity.TEXT)
+    if has_confirmed_report:
+        expected_sensitivity.add(sensitivity.USER_REPORTED)
 
     assert set(serializer.data["unstable__sensitivity"]) == expected_sensitivity
 

--- a/api/test/unit/serializers/test_media_serializers.py
+++ b/api/test/unit/serializers/test_media_serializers.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 import pytest
 
+<<<<<<< HEAD
 from api.serializers.audio_serializers import (
     AudioSearchRequestSerializer,
     AudioSerializer,
@@ -18,6 +19,9 @@ from api.serializers.image_serializers import (
     ImageSearchRequestSerializer,
     ImageSerializer,
 )
+=======
+from api.constants import sensitivity
+>>>>>>> 9274ff532 (Remove provider-supplied sensitivity handling)
 from api.serializers.media_serializers import MediaSearchRequestSerializer
 
 
@@ -32,7 +36,7 @@ def access_token():
 @pytest.fixture
 def hit():
     hit = MagicMock(
-        identifier=uuid.uuid4(),
+        identifier=str(uuid.uuid4()),
         license="cc0",
         license_version="1.0",
     )
@@ -91,71 +95,56 @@ def test_page_size_validation(page_size, authenticated, anon_request, authed_req
     assert serializer.is_valid(raise_exception=True)
 
 
-parametrize_media_serializer_classes = pytest.mark.parametrize(
-    "serializer_class",
-    [
-        AudioSerializer,
-        ImageSerializer,
-    ],
-)
-
-
-@parametrize_media_serializer_classes
 def test_media_serializer_adds_license_url_if_missing(
-    anon_request, hit, serializer_class
+    anon_request, hit, media_type_config
 ):
     # Note that this behaviour is inherited from the parent `MediaSerializer` class, but
     # it cannot be tested without a concrete model to test with.
-
+    serializer_class = media_type_config.model_serializer
     del hit.license_url  # without the ``del``, the property is dynamically generated
     repr = serializer_class(hit, context={"request": anon_request}).data
     assert repr["license_url"] == "https://creativecommons.org/publicdomain/zero/1.0/"
 
 
-@parametrize_media_serializer_classes
 @pytest.mark.parametrize(
-    ("identifier_in_context_sets", "mature_hit", "expected_sensitivity"),
-    (
-        (
-            ("user_reported_sensitive_result_ids", "sensitive_text_result_ids"),
-            True,
-            {"user_reported_sensitive", "sensitive_text"},
-        ),
-        (
-            ("sensitive_text_result_ids",),
-            True,
-            {"provider_supplied_sensitive", "sensitive_text"},
-        ),
-        (("sensitive_text_result_ids",), False, {"sensitive_text"}),
-        (tuple(), True, {"provider_supplied_sensitive"}),
-        (("user_reported_sensitive_result_ids",), True, {"user_reported_sensitive"}),
-        (tuple(), False, set()),
-        # user_reported_sensitive_result_ids with mature ``False`` isn't a real
-        # configuration our data can have so it is ignored here in the tests.
-    ),
+    "has_sensitive_text",
+    (True, False),
+    ids=lambda x: "has_sensitive_text" if x else "no_sensitive_text",
 )
+@pytest.mark.parametrize(
+    "has_confirmed_report",
+    (True, False),
+    ids=lambda x: "has_confirmed_report" if x else "no_confirmed_report",
+)
+@pytest.mark.django_db
 def test_media_serializer_sensitivity(
-    serializer_class,
-    identifier_in_context_sets,
-    mature_hit,
-    expected_sensitivity,
-    hit,
+    has_sensitive_text,
+    has_confirmed_report,
+    provider_marked_mature,
+    media_type_config,
     anon_request,
 ):
-    hit.mature = mature_hit
-    other_result_ids = [uuid.uuid4() for _ in range(6)]
+    model, hit = media_type_config.model_factory.create(
+        sensitive_text=has_sensitive_text,
+        mature_reported=has_confirmed_report,
+        with_es=True,
+    )
+
+    other_result_ids = [str(uuid.uuid4()) for _ in range(6)]
     context = {
         "request": anon_request,
-        "result_ids": {hit.identifier} | set(other_result_ids),
-        "user_reported_sensitive_result_ids": set(
-            random.choices(other_result_ids, k=3)
-        ),
-        "sensitive_text_result_ids": set(random.choices(other_result_ids, k=3)),
+        "all_result_identifiers": {hit.identifier} | set(other_result_ids),
+        "sensitive_text_result_identifiers": set(random.choices(other_result_ids, k=3)),
     }
-    for context_set in identifier_in_context_sets:
-        context[context_set].add(hit.identifier)
 
-    serializer = serializer_class(hit, context=context)
+    if has_sensitive_text:
+        context["sensitive_text_result_identifiers"] |= {hit.identifier}
+
+    serializer = media_type_config.model_serializer(model, context=context)
+
+    expected_sensitivity = set()
+    if has_sensitive_text:
+        expected_sensitivity.add(sensitivity.TEXT)
 
     assert set(serializer.data["unstable__sensitivity"]) == expected_sensitivity
 

--- a/api/test/unit/utils/test_search_context.py
+++ b/api/test/unit/utils/test_search_context.py
@@ -1,0 +1,80 @@
+import pytest
+
+from api.utils.search_context import SearchContext
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_no_results(origin_index):
+    search_context = SearchContext.build([], origin_index)
+
+    assert search_context == SearchContext(set(), set(), set())
+
+
+def test_clear_result(origin_index, model_factory):
+    media = model_factory.create(mature_reported=False)
+    model_factory.save_model_to_es(
+        media,
+        # Include in the filtered index to represent
+        # a document without sensitive terms
+        filtered=True,
+        mature=False,
+    )
+    results = [model_factory.create_hit(media)]
+
+    search_context = SearchContext.build(results, origin_index)
+
+    assert search_context == SearchContext(
+        {r.identifier for r in results},
+        set(),
+        set(),
+    )
+
+
+parametrize_filtered = pytest.mark.parametrize(
+    "filtered",
+    (True, False),
+    ids=lambda x: "no_sensitive_text" if x else "sensitive_text",
+)
+
+
+@parametrize_filtered
+def test_user_reported_mature_result(origin_index, model_factory, filtered):
+    media = model_factory.create(mature_reported=True)
+    model_factory.save_model_to_es(
+        media,
+        filtered=filtered,
+    )
+    results = [model_factory.create_hit(media)]
+
+    search_context = SearchContext.build(results, origin_index)
+
+    identifiers = {r.identifier for r in results}
+
+    assert search_context == SearchContext(
+        all_result_identifiers=identifiers,
+        user_reported_sensitive_result_identifiers=identifiers,
+        sensitive_text_result_identifiers=identifiers if not filtered else set(),
+    )
+
+
+@parametrize_filtered
+def test_provider_mature_result(origin_index, model_factory, filtered):
+    media = model_factory.create(mature_reported=False)
+    model_factory.save_model_to_es(
+        media,
+        filtered=filtered,
+        mature=True,
+    )
+    results = [model_factory.create_hit(media)]
+
+    search_context = SearchContext.build(results, origin_index)
+
+    identifiers = {r.identifier for r in results}
+
+    assert search_context == SearchContext(
+        all_result_identifiers=identifiers,
+        user_reported_sensitive_result_identifiers=set(),
+        sensitive_text_result_identifiers=identifiers if not filtered else set(),
+    )

--- a/api/test/unit/utils/test_search_context.py
+++ b/api/test/unit/utils/test_search_context.py
@@ -6,75 +6,42 @@ from api.utils.search_context import SearchContext
 pytestmark = pytest.mark.django_db
 
 
-def test_no_results(origin_index):
-    search_context = SearchContext.build([], origin_index)
+def test_no_results(media_type_config):
+    search_context = SearchContext.build([], media_type_config.origin_index)
 
-    assert search_context == SearchContext(set(), set(), set())
+    assert search_context == SearchContext(set(), set())
 
 
-def test_clear_result(origin_index, model_factory):
-    media = model_factory.create(mature_reported=False)
-    model_factory.save_model_to_es(
-        media,
-        # Include in the filtered index to represent
-        # a document without sensitive terms
-        filtered=True,
-        mature=False,
+@pytest.mark.parametrize(
+    "has_sensitive_text",
+    (True, False),
+    ids=lambda x: "has_sensitive_text" if x else "no_sensitive_text",
+)
+def test_sensitive_text(media_type_config, has_sensitive_text):
+    clear_results = media_type_config.model_factory.create_batch(
+        # Use size 10 to force result size beyond the default ES query window
+        size=10,
+        mature_reported=False,
+        provider_marked_mature=False,
+        sensitive_text=False,
+        with_hit=True,
     )
-    results = [model_factory.create_hit(media)]
 
-    search_context = SearchContext.build(results, origin_index)
+    (
+        maybe_sensitive_text_model,
+        maybe_sensitive_text_hit,
+    ) = media_type_config.model_factory.create(
+        mature_reported=False,
+        provider_marked_mature=False,
+        sensitive_text=has_sensitive_text,
+        with_hit=True,
+    )
+
+    results = [maybe_sensitive_text_hit] + [hit for _, hit in clear_results]
+
+    search_context = SearchContext.build(results, media_type_config.origin_index)
 
     assert search_context == SearchContext(
         {r.identifier for r in results},
-        set(),
-        set(),
-    )
-
-
-parametrize_filtered = pytest.mark.parametrize(
-    "filtered",
-    (True, False),
-    ids=lambda x: "no_sensitive_text" if x else "sensitive_text",
-)
-
-
-@parametrize_filtered
-def test_user_reported_mature_result(origin_index, model_factory, filtered):
-    media = model_factory.create(mature_reported=True)
-    model_factory.save_model_to_es(
-        media,
-        filtered=filtered,
-    )
-    results = [model_factory.create_hit(media)]
-
-    search_context = SearchContext.build(results, origin_index)
-
-    identifiers = {r.identifier for r in results}
-
-    assert search_context == SearchContext(
-        all_result_identifiers=identifiers,
-        user_reported_sensitive_result_identifiers=identifiers,
-        sensitive_text_result_identifiers=identifiers if not filtered else set(),
-    )
-
-
-@parametrize_filtered
-def test_provider_mature_result(origin_index, model_factory, filtered):
-    media = model_factory.create(mature_reported=False)
-    model_factory.save_model_to_es(
-        media,
-        filtered=filtered,
-        mature=True,
-    )
-    results = [model_factory.create_hit(media)]
-
-    search_context = SearchContext.build(results, origin_index)
-
-    identifiers = {r.identifier for r in results}
-
-    assert search_context == SearchContext(
-        all_result_identifiers=identifiers,
-        user_reported_sensitive_result_identifiers=set(),
-        sensitive_text_result_identifiers=identifiers if not filtered else set(),
+        {maybe_sensitive_text_model.identifier} if has_sensitive_text else set(),
     )

--- a/api/test/unit/views/test_media_views.py
+++ b/api/test/unit/views/test_media_views.py
@@ -1,5 +1,3 @@
-from test.factory.models.audio import AudioFactory
-from test.factory.models.image import ImageFactory
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,22 +5,13 @@ import pytest_django.asserts
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "media_type, media_factory",
-    [
-        ("images", ImageFactory),
-        ("audio", AudioFactory),
-    ],
-)
-def test_list_query_count(api_client, media_type, media_factory):
+def test_list_query_count(api_client, media_type_config):
     num_results = 20
     controller_ret = (
-        [
-            MagicMock(identifier=str(media_factory.create().identifier))
-            for _ in range(num_results)
-        ],  # results
+        media_type_config.model_factory.create_batch(size=num_results),  # results
         1,  # num_pages
         num_results,
+        {},  # search_context
     )
     with patch(
         "api.views.media_views.search_controller",
@@ -33,24 +22,17 @@ def test_list_query_count(api_client, media_type, media_factory):
     ), pytest_django.asserts.assertNumQueries(
         1
     ):
-        res = api_client.get(f"/v1/{media_type}/")
+        res = api_client.get(f"/v1/{media_type_config.media_type}/")
 
     assert res.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    ("media_type", "media_factory"),
-    (
-        ("images", ImageFactory),
-        ("audio", AudioFactory),
-    ),
-)
-def test_retrieve_query_count(api_client, media_type, media_factory):
-    media = media_factory.create()
+def test_retrieve_query_count(api_client, media_type_config):
+    media = media_type_config.model_factory.create()
 
     # This number goes up without `select_related` in the viewset queryset.
     with pytest_django.asserts.assertNumQueries(1):
-        res = api_client.get(f"/v1/{media_type}/{media.identifier}/")
+        res = api_client.get(f"/v1/{media_type_config.media_type}/{media.identifier}/")
 
     assert res.status_code == 200

--- a/api/test/unit/views/test_media_views.py
+++ b/api/test/unit/views/test_media_views.py
@@ -22,7 +22,7 @@ def test_list_query_count(api_client, media_type_config):
     ), pytest_django.asserts.assertNumQueries(
         1
     ):
-        res = api_client.get(f"/v1/{media_type_config.media_type}/")
+        res = api_client.get(f"/v1/{media_type_config.url_prefix}/")
 
     assert res.status_code == 200
 
@@ -33,6 +33,6 @@ def test_retrieve_query_count(api_client, media_type_config):
 
     # This number goes up without `select_related` in the viewset queryset.
     with pytest_django.asserts.assertNumQueries(1):
-        res = api_client.get(f"/v1/{media_type_config.media_type}/{media.identifier}/")
+        res = api_client.get(f"/v1/{media_type_config.url_prefix}/{media.identifier}/")
 
     assert res.status_code == 200


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1199 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR includes significant additions to the test factories and fixtures in order to facilitate Elasticsearch document creation. I chose this approach over ElasticMock for the following reasons:

1. It allows us to avoid mocking altogether (great for tests generally)
2. It exercises our _actual_ indexes, not fake ones
3. It still follows the general test-data hygiene rules of removing test data after each test case

The last one is the source of some abstraction that is not necessarily easy to follow (in that the parts aren't explicitly connected), but at least somewhat tied together via the `CREATED_BY_FIXTURE_MARKER`. The usage of pytest's `request` fixture is also potentially obscure but is quite common in pytest plugins of any significant complexity. I learned that specific usage (how to look for a specific mark) reading `pytest-django`'s code.

I also added a new `media_type_config` fixture that provides a dataclass containing most of the relevant disparate bits for different media types necessary for many of our tests. This made it easier to update tests that were previously using _very_ naive and shallow stubs which broke due to the new requirements. Luckily, the changes to those tests are easier to understand and will continue to benefit from additional improvements to the fixture classes. We'll be able to continue cleaning up tests with this fixture in the future in separate PRs, but not this one. In this one I tried to touch only the tests that actually needed changes.

Anyway, with that in mind, here is a summary of the significant changes:

- Enable Elasticsearch document creation in model factories
  - I needed to fix the Postgres ID creation for this because it is also used to set the document ID in Elasticsearch. The query for the latest ID needs to go to Elasticsearch because in tests the models are not able to query the existing data (it seems).
- Add `unstable__sensitivity` to the result serializer
  - This is marked as `unstable` and will be stabilised alongside the new query parameter after testing
- Remove ``request`` parameter from `search_controller.search` and `search_controller.related_media`. This parameter was not being used and made tests slightly more annoying to write as you had to either pass a real request or `None`. The first requires calling a new fixture and the other is obscure and unclear.
- Update many unit tests to accommodate the new `search_controller.search` interface (made easier by the improved fixtures and factories).

This PR includes a deviation from the original plan. Specifically, in the course of writing this PR and testing it, I discovered that we do not actually have _any_ documents marked mature in our production dataset that are not marked mature due to confirmed user reports. That's to say: we have no provider-supplied maturity. I left the constant in there along with a big comment in the new serializer method explaining why that is. Trying to accommodate that in this PR would significantly increase the complexity because we need to be able to efficiently (read: no duplicate queries) read from the database _and_ ES, regardless of the serialization context. It turns out that's not that hard for our actual runtime, but many many many many many tests assume the ability to bypass Elasticsearch (probably because we did not have easy Elasticsearch fixture creation). We need to put off that feature and luckily we don't need it because simply put, there are no results that fall into that case.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Review the new unit tests. There are significant changes to the test factories to support these tests and they integrate directly with the live Elasticsearch instance.

Additionally, test by making queries. You must enable `ENABLE_FILTERED_INDEX_QUERIES` for the new parameter to work. Refer to `ingestion_server/static/mock_sensitive_terms.txt` for the terms used to generate the local filtered indexes (these terms are _not_ sensitive and are only for testing).

You should observe that requests that do not include sensitive results should always have `[]` for `unstable__sensitivity`.

You must create a confirmed mature report for results to test the "user reported sensitive" results.

You should query for one of the mock sensitive terms directly while including sensitive results and confirm that the documents appropriately include the sensitive text marking in `unstable__sensitivity`. Try a combination of the two as well, (i.e., create a confirmed report for a "bird" result locally). The new field should have both text and user-reported sensitivity indications.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
