### PR TITLE
Always run `clean` before `build` for the documentation

### DIFF
--- a/documentation/justfile
+++ b/documentation/justfile
@@ -33,3 +33,7 @@ serve port="50231":
 # Delete the live server and build output directories
 clean:
     rm -rf _serve/ _build
+
+# Clean & build the documentation, raising warnings as errors
+recreate: clean
+    just build -W

--- a/documentation/justfile
+++ b/documentation/justfile
@@ -23,7 +23,7 @@ live port="50230": clean
     pipenv run sphinx-autobuild -b html . _serve/ --port {{ port }}
 
 # Compile the documentation into a static site
-build *args:
+build *args: clean
     pipenv run sphinx-build {{ args }} -b html . _build/
 
 # Serve the compiled docs using a simple HTTP server
@@ -33,7 +33,3 @@ serve port="50231":
 # Delete the live server and build output directories
 clean:
     rm -rf _serve/ _build
-
-# Clean & build the documentation, raising warnings as errors
-recreate: clean
-    just build -W


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

~~This PR adds a `recreate` recipe for the documentation which can be used to easily clean & rebuild the documentation. This is useful for testing whether changes to the documentation would raise warnings on the CI, since only running `just documentation/build -W` doesn't always expose those errors.~~

~~I also needed to call `just build -W` within the recipe explicitly because I don't think it's possible to add arguments to a recipe's dependencies.~~

Per @dhruvkb's comment below, this has been change to instead just add `clean` as a dependency for `build` (similar to the `live` recipe).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just documentation/build` should run `just documentation/clean` first.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
