### PR TITLE
Improve error handling and pipe flow for `just ps`

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,7 +149,9 @@ build *args:
     just dc build {{ args }}
 
 # List all services and their URLs and ports
-ps:
+@ps:
+    # ps is a helper command & intermediate dependency, so it should not fail the whole
+    # command if it fails
     python3 utilities/ps.py || true
 
 # Also see `up` recipe in sub-justfiles

--- a/justfile
+++ b/justfile
@@ -150,7 +150,7 @@ build *args:
 
 # List all services and their URLs and ports
 ps:
-    python3 utilities/ps.py
+    python3 utilities/ps.py || true
 
 # Also see `up` recipe in sub-justfiles
 # Bring all Docker services up, in all profiles

--- a/utilities/ps.py
+++ b/utilities/ps.py
@@ -1,4 +1,5 @@
 import subprocess
+import traceback
 from dataclasses import dataclass
 
 
@@ -103,6 +104,8 @@ def print_ps():
         for service in parse_ps():
             service.print()
     except Exception as err:
+        print(traceback.format_exc())
+        print("=" * 80)
         print(f"Failed to get service info ({err.__class__.__name__}): \n{err}")
     print("=" * 80)
 

--- a/utilities/ps.py
+++ b/utilities/ps.py
@@ -63,7 +63,10 @@ def parse_ps() -> list[Service]:
     lines = get_ps()
     lines = [stripped for line in lines if (stripped := line.strip())]
     for line in lines:
-        service, image, ports = line.split("\t")
+        parts = line.split("\t")
+        if len(parts) != 3:
+            raise ValueError(f"Unexpected line format from `docker ps`: {line}")
+        service, image, ports = parts
         # Services are usually of the form openverse-<name>-1 or openverse_<name>_1,
         # but we can't always tell which one is used.
         strip_char = service.removeprefix("openverse")[0]
@@ -96,8 +99,11 @@ def print_ps():
     print("=" * 80)
     print(f"{'Service Ports':^80}")
     print("=" * 80)
-    for service in parse_ps():
-        service.print()
+    try:
+        for service in parse_ps():
+            service.print()
+    except Exception as err:
+        print(f"Failed to get service info ({err.__class__.__name__}): \n{err}")
     print("=" * 80)
 
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1899 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes two changes to the `just ps` recipe:

1. It changes the recipe itself so that it never reports a failing exit code, meaning it doesn't fail any subsequent jobs
2. It adds some additional error handling to the `ps.py` script so that errors are more clearly reported. 

Here's an example of a failing run:

```
$ j catalog/up "s3 upstream_db"
env COMPOSE_PROFILES="catalog" just ../up s3 upstream_db
env COMPOSE_PROFILES="catalog" docker-compose -f docker-compose.yml -f docker-compose.overrides.yml up -d s3 upstream_db
[+] Running 3/3
 ⠿ Network openverse_default          Created                                                                                                                                                                  0.1s
 ⠿ Container openverse-upstream_db-1  Started                                                                                                                                                                  0.5s
 ⠿ Container openverse-s3-1           Started                                                                                                                                                                  0.6s

python3 utilities/ps.py || true
================================================================================
                                 Service Ports                                  
================================================================================
Traceback (most recent call last):
  File "/home/madison/git-a8c/openverse/utilities/ps.py", line 104, in print_ps
    for service in parse_ps():
  File "/home/madison/git-a8c/openverse/utilities/ps.py", line 69, in parse_ps
    raise ValueError(f"Unexpected line format from `docker ps`: {line}")
ValueError: Unexpected line format from `docker ps`: openverse-upstream_db-1	openverse-upstream_db	5432/tcp

================================================================================
Failed to get service info (ValueError): 
Unexpected line format from `docker ps`: openverse-upstream_db-1	openverse-upstream_db	5432/tcp
================================================================================
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Make the following change to `ps.py`:

```diff
diff --git a/utilities/ps.py b/utilities/ps.py
index cdf1d7a66..30ca50f1c 100644
--- a/utilities/ps.py
+++ b/utilities/ps.py
@@ -64,7 +64,7 @@ def parse_ps() -> list[Service]:
     lines = get_ps()
     lines = [stripped for line in lines if (stripped := line.strip())]
     for line in lines:
-        parts = line.split("\t")
+        parts = line.split("\t")[:1]
         if len(parts) != 3:
             raise ValueError(f"Unexpected line format from `docker ps`: {line}")
         service, image, ports = parts
```

Then run `just up` and observe an error similar to the above.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
