### PR TITLE
Add a run name to staging deployment workflows

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -892,7 +892,8 @@ jobs:
           client_payload: |
             {
               "actor": "${{ github.actor }}",
-              "tag": "${{ needs.get-image-tag.outputs.image_tag }}"
+              "tag": "${{ needs.get-image-tag.outputs.image_tag }}",
+              "run_name": "${{ github.event.head_commit.message }}"
             }
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment
@@ -920,7 +921,8 @@ jobs:
           client_payload: |
             {
               "actor": "${{ github.actor }}",
-              "tag": "${{ needs.get-image-tag.outputs.image_tag }}"
+              "tag": "${{ needs.get-image-tag.outputs.image_tag }}",
+              "run_name": "${{ github.event.head_commit.message }}"
             }
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Companion piece to https://github.com/WordPress/openverse-infrastructure/pull/506

This PR adds a `run_name` to the set of parameters sent for staging deployments. The run name is based on the git commit message of the head commit from the branch that is being deployed. Here's an example of what that should look like:

![image](https://github.com/WordPress/openverse-infrastructure/assets/10214785/5a275f46-9103-4725-b2a2-dcc7386d9a53)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I'm not sure I can test this even if I run a CI/CD build from this branch, since it won't trigger any deployments. So I think we might just need to merge and see.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
