### PR TITLE
Paginate GitHub events query for PR reminders

### DIFF
--- a/catalog/dags/common/github.py
+++ b/catalog/dags/common/github.py
@@ -55,10 +55,19 @@ class GitHubAPI:
         )
 
     def get_issue_events(self, repo: str, issue_number: int, owner: str = "WordPress"):
-        return self._make_request(
+        # GitHub by default returns only 30 results, so we need to paginate over
+        # all of them to get the full list of events
+        # https://docs.github.com/en/rest/issues/events?apiVersion=2022-11-28#list-issue-events
+        page = 1
+        all_events = []
+        while events := self._make_request(
             "GET",
             f"repos/{owner}/{repo}/issues/{issue_number}/events",
-        )
+            params={"page": page},
+        ):
+            all_events.extend(events)
+            page += 1
+        return all_events
 
     def delete_issue_comment(
         self, repo: str, comment_id: int, owner: str = "WordPress"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This fixes an issue we found after merging #2027 - an undrafted PR was pinged for review only a day after being ready for review, but the PR message said it was 12 days since the PR was ready (see #1891). After some investigation, we found that this is because the GitHub API defaults to 30 events per page in the events endpoint: https://docs.github.com/en/rest/issues/events?apiVersion=2022-11-28#list-issue-events

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds some very simple pagination to the `get_issue_events` function to enable querying all of the events for a PR prior to determining whether it should be pinged.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Follow the testing instructions outlined in #2027, but note that #1891 _should not_ be included in the list of PRs to ping.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
