### PR TITLE
Add the data & python automation folders as sync for the infra repo

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -6,6 +6,11 @@ group:
   - repos: |
       WordPress/openverse-infrastructure
     files:
+      # Dependencies for some workflows
+      - source: automations/python/
+        dest: automations/python/
+      - source: automations/data/
+        dest: automations/data/
       # Synced workflows
       - source: .github/workflows/new_issues.yml
         dest: .github/workflows/new_issues.yml


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This fixes an issue that came about by #2046 wherein some of the python automation scripts are now necessary on the infrastructure repo in order for those checks to run (see the discussion in https://github.com/WordPress/openverse-infrastructure/pull/503).

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the `automations/python/` and `automations/data/` folders as sync targets for the infrastructure repo so the actions which require those dependencies can be run there as well. This is significantly easier and less to manage than trying to dispatch the checks from the infra repo to run on this repo.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

~~We'll see with https://github.com/WordPress/openverse-infrastructure/pull/503 once these files are synced!~~

I was able to kick off the action here: https://github.com/WordPress/openverse/actions/runs/4952494677/jobs/8858874012

It looks like https://github.com/WordPress/openverse-infrastructure/pull/503 is now passing on the label check steps! 😄 It's failing on the linting though, I think we might need to add the `automations/` directory as an exclusion in the pre-commit check.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
