### PR TITLE
Fix issues with label automations, update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_alert.md
+++ b/.github/ISSUE_TEMPLATE/airflow_alert.md
@@ -1,7 +1,7 @@
 ---
 name: Airflow Alert
 about: Report an alert raised by Airflow
-labels: "🛠 goal: fix, 🚦 status: awaiting triage, 🌬️ tooling: airflow"
+labels: "🛠 goal: fix, 🚦 status: awaiting triage, 🌬️ tooling: airflow, 🧱 stack: catalog"
 title: "<Replace this with actual title>"
 ---
 

--- a/.github/ISSUE_TEMPLATE/image_provider_api_integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/image_provider_api_integration_request.yml
@@ -3,9 +3,12 @@ description: Tell us about an API providing CC-licensed images
 title: "<Provider name here>"
 labels:
   - "🚦 status: awaiting triage"
-  - "✨ goal: improvement"
   - "🧹 status: ticket work required"
   - "☁️ provider: images"
+  - "💻 aspect: code"
+  - "🌟 goal: addition"
+  - "🧱 stack: catalog"
+  - "🟩 priority: low"
 body:
   - type: input
     id: provider

--- a/.github/ISSUE_TEMPLATE/new_source_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/new_source_suggestion.yml
@@ -5,6 +5,10 @@ labels:
   - "🚦 status: awaiting triage"
   - "🧹 status: ticket work required"
   - "☁️ provider: any"
+  - "💻 aspect: code"
+  - "🌟 goal: addition"
+  - "🧱 stack: catalog"
+  - "🟩 priority: low"
 body:
   - type: input
     id: source

--- a/.github/ISSUE_TEMPLATE/project_thread.md
+++ b/.github/ISSUE_TEMPLATE/project_thread.md
@@ -1,7 +1,7 @@
 ---
 name: Project Thread
 about: An issue to track and outline a new project
-labels: "project"
+labels: "🧭 project: thread"
 title: "<Replace this with actual title>"
 ---
 

--- a/automations/python/print_labels.py
+++ b/automations/python/print_labels.py
@@ -1,0 +1,8 @@
+"""Simple utility for printing all the labels from labels.yml."""
+from shared.labels import get_labels
+
+
+if __name__ == "__main__":
+    labels = get_labels()
+    for label in labels:
+        print(label)

--- a/automations/python/shared/labels.py
+++ b/automations/python/shared/labels.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from itertools import chain
 
 from models.label import Label
 from models.label_group import LabelGroup
@@ -29,7 +28,9 @@ def get_labels() -> list[Label]:
     """
     labels_file = deepcopy(get_data("labels.yml"))
     grouped_labels = get_labels_by_group(labels_file)
-    standard_labels = list(chain(group.labels for group in grouped_labels.values()))
+    standard_labels = [
+        label for group in grouped_labels.values() for label in group.labels
+    ]
     # Also grab standard labels
     for label_info in labels_file["standalone"]:
         label = Label(**label_info)

--- a/automations/python/sync_labels.py
+++ b/automations/python/sync_labels.py
@@ -23,7 +23,7 @@ def set_labels(repo: Repository, labels: list[Label]):
     """
 
     log.info(f"Fetching existing labels from {repo.full_name}")
-    existing_labels = {label.name.casefold(): label for label in get_labels()}
+    existing_labels = {label.name.casefold(): label for label in repo.get_labels()}
     log.info(f"Found {len(existing_labels)} existing labels")
 
     for label in labels:
@@ -58,7 +58,7 @@ def main():
         log.info(f"• {label.qualified_name}")
     repos = [org.get_repo(repo_name) for repo_name in repo_names]
     for repo in repos:
-        set_labels(repo, get_labels())
+        set_labels(repo, labels)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This issue was originally intended to only update the issue template labels, but in writing a quick utility to actually print out the labels defined in `labels.yml`, I found that there were some serious issues with the logic changes I made in #2046, namely:

- The logic to unspool the list of list of labels wasn't working, and was still producing a list of lists
- The sync label script wasn't actually pulling existing labels from repos

Example failing workflow: https://github.com/WordPress/openverse/actions/runs/4953650953/jobs/8861350311

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes the following changes to label-related aspects:
- Adds a simple script for printing out the labels (very useful for me since typing emojis is hard on linux)
- Correctly collapses the labels into a single list
- Correctly queries the repos for their existing labels
- Updates issue templates where relevant to include more appropriate labels

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You should be able to go to `automations/python` and run `pipenv run python print_labels.py` to see the full list of labels. I've also run the `sync_labels.py` script locally to ensure it works.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
