### PR TITLE
Check the file type of the thumbnail before passing it to Photon

### DIFF
--- a/api/api/utils/photon.py
+++ b/api/api/utils/photon.py
@@ -144,9 +144,9 @@ def get(
             f"Failed to render thumbnail due to timeout: {exc}"
         )
     except requests.HTTPError as exc:
-        # Save number of occurrences to redis. Only raise a Sentry error when the number of
-        # occurrences reaches the configured threshold, to prevent provider API downtime from
-        # causing excessive Sentry events.
+        # Save number of occurrences to redis. Only raise a Sentry error when
+        # the number of occurrences reaches the configured threshold, to
+        # prevent provider API downtime from causing excessive Sentry events.
         key = f"{settings.THUMBNAIL_HTTP_ERROR_PREFIX}{domain}"
         errors = 1
         try:

--- a/api/api/utils/photon.py
+++ b/api/api/utils/photon.py
@@ -144,9 +144,9 @@ def get(
             f"Failed to render thumbnail due to timeout: {exc}"
         )
     except requests.HTTPError as exc:
-        # Save occurrences to redis and only sent to Sentry when reached a
-        # threshold to prevent providers downtime consuming all the events
-        # quota.
+        # Save number of occurrences to redis. Only raise a Sentry error when the number of
+        # occurrences reaches the configured threshold, to prevent provider API downtime from
+        # causing excessive Sentry events.
         key = f"{settings.THUMBNAIL_HTTP_ERROR_PREFIX}{domain}"
         errors = 1
         try:

--- a/api/api/utils/photon.py
+++ b/api/api/utils/photon.py
@@ -30,7 +30,7 @@ HEADERS = {
 }
 
 
-def _get_extension_from_url(image_url: str) -> str:
+def _get_file_extension_from_url(image_url: str) -> str:
     """Return the image extension if present in the URL."""
     parsed = urlparse(image_url)
     _, ext = splitext(parsed.path)
@@ -41,7 +41,7 @@ def check_image_type(image_url: str, media_obj) -> None:
     key = f"media:{media_obj.identifier}:thumb_type"
     cache = django_redis.get_redis_connection("default")
 
-    ext = _get_extension_from_url(image_url)
+    ext = _get_file_extension_from_url(image_url)
 
     if not ext:
         # If the extension is not present in the URL, try to get it from the redis cache

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -66,14 +66,14 @@ class AudioViewSet(MediaViewSet):
         audio = self.get_object()
 
         image_url = None
-        if thumbnail := audio.thumbnail:
-            image_url = thumbnail
-        elif audio.audio_set and (thumbnail := audio.audio_set.thumbnail):
-            image_url = thumbnail
+        if audio_thumbnail := audio.thumbnail:
+            image_url = audio_thumbnail
+        elif audio.audio_set and (audio_thumbnail := audio.audio_set.thumbnail):
+            image_url = audio_thumbnail
         if not image_url:
             raise NotFound("Could not find artwork.")
 
-        return super().thumbnail(image_url, request)
+        return super().thumbnail(request, audio, image_url)
 
     @waveform
     @action(

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -118,7 +118,7 @@ class ImageViewSet(MediaViewSet):
         if "iip.smk.dk" in image_url and image.thumbnail:
             image_url = image.thumbnail
 
-        return super().thumbnail(image_url, request)
+        return super().thumbnail(request, image, image_url)
 
     @watermark_doc
     @action(detail=True, url_path="watermark", url_name="watermark")

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -152,9 +152,12 @@ class MediaViewSet(ReadOnlyModelViewSet):
 
         return Response(data=serializer.data, status=status.HTTP_201_CREATED)
 
-    def thumbnail(self, image_url, request, *_, **__):
+    def thumbnail(self, request, media_obj, image_url):
         serializer = self.get_serializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
+
+        photon.check_image_type(image_url, media_obj)
+
         return photon.get(
             image_url,
             accept_header=request.headers.get("Accept", "image/*"),

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -19,3 +19,11 @@ THUMBNAIL_QUALITY = config("THUMBNAIL_JPG_QUALITY", default="80")
 THUMBNAIL_TIMEOUT_PREFIX = config(
     "THUMBNAIL_TIMEOUT_PREFIX", default="thumbnail_timeout:"
 )
+
+THUMBNAIL_HTTP_ERROR_PREFIX = config(
+    "THUMBNAIL_HTTP_ERROR_PREFIX", default="thumbnail_http_error:"
+)
+
+THUMBNAIL_HTTP_ERROR_THRESHOLD_TO_NOTIFY = config(
+    "THUMBNAIL_HTTP_ERROR_THRESHOLD_TO_NOTIFY", default=1000, cast=int
+)

--- a/api/test/unit/utils/test_photon.py
+++ b/api/test/unit/utils/test_photon.py
@@ -1,6 +1,9 @@
+from test.factory.models.image import ImageFactory
+from unittest import mock
 from urllib.parse import urlencode
 
 from django.conf import settings
+from rest_framework.exceptions import UnsupportedMediaType
 
 import pook
 import pytest
@@ -10,6 +13,7 @@ from api.utils.photon import (
     HEADERS,
     UpstreamThumbnailException,
     _get_file_extension_from_url,
+    check_image_type,
 )
 from api.utils.photon import get as photon_get
 
@@ -243,6 +247,24 @@ def test_get_timeout_existing_cache_key(
     assert redis.get(key) == b"6"
 
 
+def test_get_http_error_pass_threshold(
+    capture_exception, setup_requests_get_exception, redis
+):
+    exc = requests.HTTPError()
+    setup_requests_get_exception(exc)
+    key = f"{settings.THUMBNAIL_HTTP_ERROR_PREFIX}subdomain.example.com"
+    redis.set(key, settings.THUMBNAIL_HTTP_ERROR_THRESHOLD_TO_NOTIFY - 1)
+
+    with pytest.raises(
+        UpstreamThumbnailException, match=r"Failed to render thumbnail."
+    ):
+        photon_get(TEST_IMAGE_URL)
+
+    capture_exception.assert_called_once_with(exc)
+
+    assert redis.get(key) == b"1000"
+
+
 @pytest.mark.parametrize(
     "exception, expected_message",
     [
@@ -318,3 +340,26 @@ def test_get_unsuccessful_request_raises_custom_exception():
 )
 def test__get_extension_from_url(image_url, expected_ext):
     assert _get_file_extension_from_url(image_url) == expected_ext
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("image_type", ["apng", "svg", "bmp"])
+def test_check_image_type_raises_by_not_allowed_types(image_type):
+    image_url = TEST_IMAGE_URL.replace(".jpg", f".{image_type}")
+    image = ImageFactory.create(url=image_url)
+
+    with pytest.raises(UnsupportedMediaType):
+        check_image_type(image_url, image)
+
+
+@pytest.mark.django_db
+def test_check_image_type_saves_image_type_to_cache(redis):
+    image_url = TEST_IMAGE_URL.replace(".jpg", "")
+    image = ImageFactory.create(url=image_url)
+
+    with mock.patch("requests.head") as mock_head, pytest.raises(UnsupportedMediaType):
+        mock_head.return_value.headers = {"Content-Type": "image/svg+xml"}
+        check_image_type(image_url, image)
+
+    key = f"media:{image.identifier}:thumb_type"
+    assert redis.get(key) == b"svg+xml"

--- a/api/test/unit/views/test_image_views.py
+++ b/api/test/unit/views/test_image_views.py
@@ -78,4 +78,4 @@ def test_thumbnail_uses_upstream_thumb_for_smk(
         mock_response = HttpResponse("mock_response")
         thumb_call.return_value = mock_response
         api_client.get(f"/v1/images/{image.identifier}/thumb/")
-    thumb_call.assert_called_once_with(expected_thumb_url, ANY)
+    thumb_call.assert_called_once_with(ANY, image, expected_thumb_url)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2067 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
To prevent known errors from Photon due to unsupported file types, this PR adds the following check before making the call to Photon:
1. Get the thumbnail extension from the URL. We can't assume it'd be the same of the main image (in the case of `images/`), so try to guess it first from the URL. I believe it is worth trying this route, since this is where most of the cases will fall.
2. If can't guess the extension from the URL then make a HEAD request to get the content-type of the file, caching the result
3. If the media type is not supported by Photon then raise an exception: [415 Unsupported Media Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
If you want to manually check, try replacing the first row (after the header) of the `sample_data/sample_image.csv` file with the following:

```
0e3315c5-3328-4a99-80ab-567ac32f685f,2022-12-21 17:29:54.000000+00,2022-12-21 17:29:54.000000+00,provider_api,wikimedia,wikimedia,,https://www.flickr.com/photos/54633257@N04/51745822704,https://upload.wikimedia.org/wikipedia/commons/9/92/Flower_sewing_pattern_outline.svg,,433,1024,97150,by-sa,2.0,Jooja,https://commons.wikimedia.org/wiki/User:Jooja,Flower sewing pattern outline,"{""views"": ""5991"", ""pub_date"": ""1639443671"", ""date_taken"": ""2021-07-20 18:19:25"", ""description"": ""dressed"", ""license_url"": ""https://creativecommons.org/licenses/by-sa/3.0/"", ""raw_license_url"": null}",,f,2021-12-15 20:49:19.976193+00,f,svg,illustration
```

The run `just api/recreate` and visit http://localhost:50280/v1/images/0e3315c5-3328-4a99-80ab-567ac32f685f/thumb/

You should see the new response message 'Unsupported media type \"svg\" in request.'

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
