### PR TITLE
Skip the create filtered index steps that expect an index to already exist

### DIFF
--- a/catalog/dags/common/ingestion_server.py
+++ b/catalog/dags/common/ingestion_server.py
@@ -3,7 +3,7 @@ import os
 from datetime import timedelta
 from urllib.parse import urlparse
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowSkipException
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 from requests import Response
@@ -24,7 +24,10 @@ def response_filter_stat(response: Response) -> str:
     This is used to extract the name of the current index that the concerned alias
     points to. This index name will be available via XCom in the downstream tasks.
     """
-    index_name = response.json()["alt_names"]
+    data = response.json()
+    if not (data["exists"]):
+        raise AirflowSkipException("Index does not exist.")
+    index_name = data["alt_names"]
     # Indices are named as '<media type>-<suffix>', so everything after the first
     # hyphen '-' is the suffix.
     _, index_suffix = index_name.split("-", maxsplit=1)

--- a/catalog/dags/common/ingestion_server.py
+++ b/catalog/dags/common/ingestion_server.py
@@ -56,9 +56,7 @@ def response_check_wait_for_completion(response: Response) -> bool:
         return False
 
     if data["error"]:
-        raise AirflowException(
-            "Ingestion server encountered an error during data refresh."
-        )
+        raise ValueError("Ingestion server encountered an error during data refresh.")
 
     logger.info(f"Data refresh done with {data['progress']}% completed.")
     return True

--- a/catalog/tests/dags/common/test_ingestion_server.py
+++ b/catalog/tests/dags/common/test_ingestion_server.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+import pytest
+from airflow.exceptions import AirflowSkipException
+
+from common import ingestion_server
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ({"exists": True, "is_alias": False, "alt_names": "asdf-1234"}, "1234"),
+        pytest.param(
+            {"exists": False, "is_alias": None, "alt_names": None},
+            None,
+            marks=pytest.mark.raises(exception=AirflowSkipException),
+        ),
+        pytest.param({}, None, marks=pytest.mark.raises(exception=KeyError)),
+    ],
+)
+def test_response_filter_stat(data, expected):
+    response = MagicMock()
+    response.json.return_value = data
+    actual = ingestion_server.response_filter_stat(response)
+    assert actual == expected


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2105 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes an issue with the `create_filtered_<media>_index` DAG wherein it expects that the filtered index will already exist when it is first run. I've changed the configuration of the DAG so that the `get_current_index` step can skip (along with skipping the `trigger_delete_index` step) without skipping any of the rest of the DAG. I did this by using an `EmptyOperator` to manage the control flow - due to the way this DAG is constructed and how the functions are reused elsewhere, I didn't want to have to add `trigger_rule` at every level within the various function calls.

I also made a slight tweak to one of the `ingestion_server.py` logic to raise a `ValueError` instead of an `AirflowException`, since the latter has some airflow-specific meaning that we want to avoid overloading.

**Before**
![image](https://github.com/WordPress/openverse/assets/10214785/43dc9d0b-8c8e-4b0e-86c8-122096f6c1ef)

**After**

![image](https://github.com/WordPress/openverse/assets/10214785/32929903-585e-4655-afce-cdd7a70ec68f)


<details> <summary> Previous iteration </summary>

![image](https://github.com/WordPress/openverse/assets/10214785/82a99dde-790a-4ce1-b258-66bd89c56538)

</details>

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. `just down -v`
2. Apply the following diff to simulate the lack of a filtered audio index:

```diff
diff --git a/load_sample_data.sh b/load_sample_data.sh
index 07a157382..60c74faa5 100755
--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -74,10 +74,10 @@ just ingestion_server/ingest-upstream "audio" "init"
 just docker/es/wait-for-index "audio-init"
 just ingestion_server/promote "audio" "init" "audio"
 just docker/es/wait-for-index "audio"
-just ingestion_server/create-and-populate-filtered-index "audio" "init"
-just docker/es/wait-for-index "audio-init-filtered"
-just ingestion_server/point-alias "audio" "init-filtered" "audio-filtered"
-just docker/es/wait-for-index "audio-filtered" "audio-init-filtered"
+#just ingestion_server/create-and-populate-filtered-index "audio" "init"
+#just docker/es/wait-for-index "audio-init-filtered"
+#just ingestion_server/point-alias "audio" "init-filtered" "audio-filtered"
+#just docker/es/wait-for-index "audio-filtered" "audio-init-filtered"
```

3. `j api/init`
4. `j down && j ingestion_server/up && j catalog/up`
5. Trigger the `create_filtered_audio_index` DAG locally **with config** with `init` as the origin and destination index.
6. Observe that the `get_current_index` and `trigger_delete_index` steps skip, but the rest of the DAG processes as expected.
7. Run another audio data refresh and observe that in a second run of the `create_filtered_audio_index` which gets triggered by the data refresh, it runs all steps.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
