### PR TITLE
Alter label-pr logic to account for stack label already being present

### DIFF
--- a/automations/python/label_pr.py
+++ b/automations/python/label_pr.py
@@ -197,7 +197,9 @@ def main():
     pr = get_pull_request(gh, args.pr_url)
     log.info(f"Found PR: {pr.title}")
 
-    if pr.labels:
+    # Skip a PR if it already has labels, as long as it has labels that are NOT
+    # a stack label - if all of its labels are stack labels, apply the new labels too
+    if pr.labels and not all(["stack" in label.name for label in pr.labels]):
         log.info("PR already labelled")
         return
 
@@ -220,11 +222,12 @@ def main():
                 labels_to_add.append(label)
 
         if labels_to_add:
-            pr.set_labels(*labels_to_add)
+            pr.set_labels(*labels_to_add, *pr.labels)
             # Only break when all labels are applied, if we're missing any
             # then continue to the else to apply the awaiting triage label.
-            # Stack can have more than one label so this is not an exact check
-            if len(labels_to_add) >= len(required_label_categories):
+            # Stack can have more than one label and is typically already applied
+            # by this step, so remove it from the total count of labels to add.
+            if len(labels_to_add) >= len(required_label_categories) - 1:
                 break
     else:
         log.info("Could not find properly labelled issue")


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This fixes an issue wherein once the stack label had automatically been applied by the CI/CD workflow, a PR could no longer automatically receive labels from a linked issue (i.e. the label PR step would just skip the PR because it already had labels). Example: see [this workflow run](https://github.com/WordPress/openverse/actions/runs/4984933110) for the initial CI check of #2106

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR changes the label PR logic so that it now _excludes_ "stack" labels when it is checking if a PR should be considered labeled. Since we assume that all PRs will receive a stack label based on the CI/CD workflow, I've also lowered the requisite number of "required labels" for the final check when the label action is determining whether to also add the "awaiting triage" label.

The upshot of this is that most cases where we have a PR with a stack label applied automatically based on the files changed, and a linked PR with the other required categories, the label PR action should now behave as expected.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

See my testing in #2106! To try this yourself, be sure to add the `ACCESS_TOKEN` environment variable, remove the aspect/priority/goal labels from #2106, then run `LOGGING_LEVEL=20 python label_pr.py --pr-url https://github.com/WordPress/openverse/pull/2106`.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
