### PR TITLE
Fix release contributions by removing explicit author link creation

### DIFF
--- a/.github/release-drafter-api.yml
+++ b/.github/release-drafter-api.yml
@@ -14,7 +14,7 @@ categories:
   - title: Bug Fixes
     label: "🛠 goal: fix"
 # Identical to the default except it uses `-` instead of `*` to match our Markdown linter
-change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by [@$AUTHOR](https://github.com/$AUTHOR)"
+change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by @$AUTHOR"
 exclude-labels:
   - "skip-changelog"
 include-labels:

--- a/.github/release-drafter-catalog.yml
+++ b/.github/release-drafter-catalog.yml
@@ -14,7 +14,7 @@ categories:
   - title: Bug Fixes
     label: "🛠 goal: fix"
 # Identical to the default except it uses `-` instead of `*` to match our Markdown linter
-change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by [@$AUTHOR](https://github.com/$AUTHOR)"
+change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by @$AUTHOR"
 exclude-labels:
   - "skip-changelog"
 include-labels:

--- a/.github/release-drafter-frontend.yml
+++ b/.github/release-drafter-frontend.yml
@@ -14,7 +14,7 @@ categories:
   - title: Bug Fixes
     label: "🛠 goal: fix"
 # Identical to the default except it uses `-` instead of `*` to match our Markdown linter
-change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by [@$AUTHOR](https://github.com/$AUTHOR)"
+change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by @$AUTHOR"
 exclude-labels:
   - "skip-changelog"
 include-labels:

--- a/.github/release-drafter-ingestion_server.yml
+++ b/.github/release-drafter-ingestion_server.yml
@@ -14,7 +14,7 @@ categories:
   - title: Bug Fixes
     label: "🛠 goal: fix"
 # Identical to the default except it uses `-` instead of `*` to match our Markdown linter
-change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by [@$AUTHOR](https://github.com/$AUTHOR)"
+change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by @$AUTHOR"
 exclude-labels:
   - "skip-changelog"
 include-labels:

--- a/documentation/_ext/link_usernames.py
+++ b/documentation/_ext/link_usernames.py
@@ -41,10 +41,6 @@ def _replace_username(match: re.Match) -> str:
 
 
 def replace_username_references(app, docname, source):
-    # Changelogs are already created with the usernames as references, so these files
-    # should just be skipped entirely
-    if docname.startswith("changelogs"):
-        return
     logger.debug(f"In file: {docname}")
     source[0] = GITHUB_USERNAME_REGEX.sub(_replace_username, source[0])
 

--- a/documentation/changelogs/api/2023.04.12.23.29.59.md
+++ b/documentation/changelogs/api/2023.04.12.23.29.59.md
@@ -3,143 +3,100 @@
 ## New Features
 
 - Set rate-limit headers on each response
-  ([#775](https://github.com/WordPress/openverse/pull/775))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#775](https://github.com/WordPress/openverse/pull/775)) @dhruvkb
 
 ## Improvements
 
 - Fix issues in the workflow simplifications of #1054
-  ([#1058](https://github.com/WordPress/openverse/pull/1058))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1058](https://github.com/WordPress/openverse/pull/1058)) @dhruvkb
 - Simplify CI + CD workflow
-  ([#1054](https://github.com/WordPress/openverse/pull/1054))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1054](https://github.com/WordPress/openverse/pull/1054)) @dhruvkb
 - Improve documentation for partial stack setups
-  ([#974](https://github.com/WordPress/openverse/pull/974))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#974](https://github.com/WordPress/openverse/pull/974)) @dhruvkb
 - Use upstream thumbnail if available
-  ([#898](https://github.com/WordPress/openverse/pull/898))
-  [@krysal](https://github.com/krysal)
+  ([#898](https://github.com/WordPress/openverse/pull/898)) @krysal
 - Remove XML from the API
-  ([#986](https://github.com/WordPress/openverse/pull/986))
-  [@obulat](https://github.com/obulat)
+  ([#986](https://github.com/WordPress/openverse/pull/986)) @obulat
 - Update URLs to point to docs.openverse.org
-  ([#991](https://github.com/WordPress/openverse/pull/991))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#991](https://github.com/WordPress/openverse/pull/991)) @dhruvkb
 - Absorb `build-nginx` job into `build-images` job
-  ([#944](https://github.com/WordPress/openverse/pull/944))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#944](https://github.com/WordPress/openverse/pull/944)) @dhruvkb
 
 ## Internal Improvements
 
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) @AetherUnbound
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) @sarayourfriend
 - Update nginx Docker tag to v1.23.4
-  ([#1108](https://github.com/WordPress/openverse/pull/1108))
-  [@renovate](https://github.com/renovate)
+  ([#1108](https://github.com/WordPress/openverse/pull/1108)) @renovate
 - Use context manager for multiprocessing in the ingestion server
-  ([#1057](https://github.com/WordPress/openverse/pull/1057))
-  [@obulat](https://github.com/obulat)
+  ([#1057](https://github.com/WordPress/openverse/pull/1057)) @obulat
 - Bump boto3 from 1.26.99 to 1.26.105 in /api
-  ([#1133](https://github.com/WordPress/openverse/pull/1133))
-  [@dependabot](https://github.com/dependabot)
+  ([#1133](https://github.com/WordPress/openverse/pull/1133)) @dependabot
 - Add env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) @dhruvkb
 - Add a Slack notification job to the CI + CD workflow
-  ([#1066](https://github.com/WordPress/openverse/pull/1066))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1066](https://github.com/WordPress/openverse/pull/1066)) @dhruvkb
 - Bump pillow from 9.4.0 to 9.5.0 in /api
-  ([#1115](https://github.com/WordPress/openverse/pull/1115))
-  [@dependabot](https://github.com/dependabot)
+  ([#1115](https://github.com/WordPress/openverse/pull/1115)) @dependabot
 - Bump sentry-sdk from 1.17.0 to 1.18.0 in /api
-  ([#1112](https://github.com/WordPress/openverse/pull/1112))
-  [@dependabot](https://github.com/dependabot)
+  ([#1112](https://github.com/WordPress/openverse/pull/1112)) @dependabot
 - Bump orjson from 3.8.8 to 3.8.9 in /api
-  ([#1114](https://github.com/WordPress/openverse/pull/1114))
-  [@dependabot](https://github.com/dependabot)
+  ([#1114](https://github.com/WordPress/openverse/pull/1114)) @dependabot
 - Bump ipython from 8.11.0 to 8.12.0 in /api
-  ([#1113](https://github.com/WordPress/openverse/pull/1113))
-  [@dependabot](https://github.com/dependabot)
+  ([#1113](https://github.com/WordPress/openverse/pull/1113)) @dependabot
 - Pass actor for staging deploys with the `f` flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) @sarayourfriend
 - Restore Django Admin views
-  ([#1065](https://github.com/WordPress/openverse/pull/1065))
-  [@krysal](https://github.com/krysal)
+  ([#1065](https://github.com/WordPress/openverse/pull/1065)) @krysal
 - Save cleaned up data during the cleanup step
-  ([#904](https://github.com/WordPress/openverse/pull/904))
-  [@obulat](https://github.com/obulat)
+  ([#904](https://github.com/WordPress/openverse/pull/904)) @obulat
 - Defer the `tags_list` for media models
-  ([#1029](https://github.com/WordPress/openverse/pull/1029))
-  [@obulat](https://github.com/obulat)
+  ([#1029](https://github.com/WordPress/openverse/pull/1029)) @obulat
 - Bump boto3 from 1.26.97 to 1.26.99 in /api
-  ([#1042](https://github.com/WordPress/openverse/pull/1042))
-  [@dependabot](https://github.com/dependabot)
+  ([#1042](https://github.com/WordPress/openverse/pull/1042)) @dependabot
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) @sarayourfriend
 - Add CNAME in other use of `actions-gh-pages`
-  ([#1006](https://github.com/WordPress/openverse/pull/1006))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1006](https://github.com/WordPress/openverse/pull/1006)) @dhruvkb
 - Fix local build of the API and add its `recreate` just command
-  ([#994](https://github.com/WordPress/openverse/pull/994))
-  [@krysal](https://github.com/krysal)
+  ([#994](https://github.com/WordPress/openverse/pull/994)) @krysal
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) @dhruvkb
 
 ## Bug Fixes
 
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) @AetherUnbound
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) @sarayourfriend
 - Pass `GITHUB_TOKEN` to deploy docs
-  ([#1134](https://github.com/WordPress/openverse/pull/1134))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1134](https://github.com/WordPress/openverse/pull/1134)) @dhruvkb
 - Add `SLACK_WEBHOOK_TYPE` env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) @dhruvkb
 - Pass actor for staging deploys with the flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) @dhruvkb
 - Add to GitHub CLI step
-  ([#1103](https://github.com/WordPress/openverse/pull/1103))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1103](https://github.com/WordPress/openverse/pull/1103)) @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) @sarayourfriend
 - Fix typo in docs building on
-  ([#1067](https://github.com/WordPress/openverse/pull/1067))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1067](https://github.com/WordPress/openverse/pull/1067)) @dhruvkb
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) @sarayourfriend
 - Add CNAME in other use of
-  ([#1006](https://github.com/WordPress/openverse/pull/1006))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1006](https://github.com/WordPress/openverse/pull/1006)) @dhruvkb
 - Add docs CNAME to config
-  ([#1005](https://github.com/WordPress/openverse/pull/1005))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1005](https://github.com/WordPress/openverse/pull/1005)) @zackkrida
 - Fix diagrams with transparent background in README.md of "ingestion_server"
   for dark mode. ([#1000](https://github.com/WordPress/openverse/pull/1000))
-  [@AdarshRawat1](https://github.com/AdarshRawat1)
+  @AdarshRawat1
 - Fix local build of the API and add its `recreate` just command
-  ([#994](https://github.com/WordPress/openverse/pull/994))
-  [@krysal](https://github.com/krysal)
+  ([#994](https://github.com/WordPress/openverse/pull/994)) @krysal
 - Treat any non 200 status as failure for thingiverse
-  ([#940](https://github.com/WordPress/openverse/pull/940))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#940](https://github.com/WordPress/openverse/pull/940)) @sarayourfriend
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) @dhruvkb

--- a/documentation/changelogs/api/2023.04.18.15.27.15.md
+++ b/documentation/changelogs/api/2023.04.18.15.27.15.md
@@ -3,26 +3,21 @@
 ## New Features
 
 - Implementation Plan: Filtering and designating sensitive results in the API
-  ([#996](https://github.com/WordPress/openverse/pull/996))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#996](https://github.com/WordPress/openverse/pull/996)) @sarayourfriend
 
 ## Improvements
 
 - Fix typo in github link
-  ([#1802](https://github.com/WordPress/openverse/pull/1802))
-  [@capitan-beto](https://github.com/capitan-beto)
+  ([#1802](https://github.com/WordPress/openverse/pull/1802)) @capitan-beto
 
 ## Internal Improvements
 
 - Bump sentry-sdk from 1.18.0 to 1.19.1 in /api
-  ([#1214](https://github.com/WordPress/openverse/pull/1214))
-  [@dependabot](https://github.com/dependabot)
+  ([#1214](https://github.com/WordPress/openverse/pull/1214)) @dependabot
 - Use `pytest.ini` and add `pytest-sugar`
-  ([#1227](https://github.com/WordPress/openverse/pull/1227))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1227](https://github.com/WordPress/openverse/pull/1227)) @dhruvkb
 
 ## Bug Fixes
 
 - Only use upstream thumbs with photon for SMK, for now
-  ([#1812](https://github.com/WordPress/openverse/pull/1812))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1812](https://github.com/WordPress/openverse/pull/1812)) @zackkrida

--- a/documentation/changelogs/api/2023.04.19.00.01.39.md
+++ b/documentation/changelogs/api/2023.04.19.00.01.39.md
@@ -3,20 +3,16 @@
 ## New Features
 
 - Publish changelog for api-2023.04.18.15.27.15
-  ([#1813](https://github.com/WordPress/openverse/pull/1813))
-  [@openverse-bot](https://github.com/openverse-bot)
+  ([#1813](https://github.com/WordPress/openverse/pull/1813)) @openverse-bot
 
 ## Improvements
 
 - Treat 403s from Flickr as dead links
-  ([#1201](https://github.com/WordPress/openverse/pull/1201))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1201](https://github.com/WordPress/openverse/pull/1201)) @sarayourfriend
 
 ## Bug Fixes
 
 - Increase photon request timeout
-  ([#1809](https://github.com/WordPress/openverse/pull/1809))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1809](https://github.com/WordPress/openverse/pull/1809)) @sarayourfriend
 - Update how `psycopg2` errors are referenced
-  ([#1807](https://github.com/WordPress/openverse/pull/1807))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1807](https://github.com/WordPress/openverse/pull/1807)) @dhruvkb

--- a/documentation/changelogs/api/2023.04.23.23.22.14.md
+++ b/documentation/changelogs/api/2023.04.23.23.22.14.md
@@ -3,32 +3,24 @@
 ## Improvements
 
 - Update Python code to use Python 3.11
-  ([#1852](https://github.com/WordPress/openverse/pull/1852))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1852](https://github.com/WordPress/openverse/pull/1852)) @dhruvkb
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) @dhruvkb
 - Add a `just ps` recipe for displaying service ports
-  ([#1160](https://github.com/WordPress/openverse/pull/1160))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1160](https://github.com/WordPress/openverse/pull/1160)) @AetherUnbound
 
 ## Internal Improvements
 
 - Dispatch deployment workflows from infrastructure repository
-  ([#1865](https://github.com/WordPress/openverse/pull/1865))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1865](https://github.com/WordPress/openverse/pull/1865)) @sarayourfriend
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) @dhruvkb
 - Add a `just ps` recipe for displaying service ports
-  ([#1160](https://github.com/WordPress/openverse/pull/1160))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1160](https://github.com/WordPress/openverse/pull/1160)) @AetherUnbound
 - Fix `pgcli` just commands for the api and catalog
-  ([#1822](https://github.com/WordPress/openverse/pull/1822))
-  [@krysal](https://github.com/krysal)
+  ([#1822](https://github.com/WordPress/openverse/pull/1822)) @krysal
 
 ## Bug Fixes
 
 - Fix `pgcli` just commands for the api and catalog
-  ([#1822](https://github.com/WordPress/openverse/pull/1822))
-  [@krysal](https://github.com/krysal)
+  ([#1822](https://github.com/WordPress/openverse/pull/1822)) @krysal

--- a/documentation/changelogs/api/2023.04.27.07.29.23.md
+++ b/documentation/changelogs/api/2023.04.27.07.29.23.md
@@ -3,17 +3,13 @@
 ## Improvements
 
 - Avoid the need to specify each image individually in `load-img`
-  ([#1855](https://github.com/WordPress/openverse/pull/1855))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1855](https://github.com/WordPress/openverse/pull/1855)) @dhruvkb
 
 ## Internal Improvements
 
 - Remove `tags_list` from models and ingestion_server
-  ([#956](https://github.com/WordPress/openverse/pull/956))
-  [@obulat](https://github.com/obulat)
+  ([#956](https://github.com/WordPress/openverse/pull/956)) @obulat
 - Bump orjson from 3.8.9 to 3.8.10 in /api
-  ([#1218](https://github.com/WordPress/openverse/pull/1218))
-  [@dependabot](https://github.com/dependabot)
+  ([#1218](https://github.com/WordPress/openverse/pull/1218)) @dependabot
 - Bump psycopg2 from 2.9.5 to 2.9.6 in /api
-  ([#1219](https://github.com/WordPress/openverse/pull/1219))
-  [@dependabot](https://github.com/dependabot)
+  ([#1219](https://github.com/WordPress/openverse/pull/1219)) @dependabot

--- a/documentation/changelogs/api/2023.05.02.21.26.28.md
+++ b/documentation/changelogs/api/2023.05.02.21.26.28.md
@@ -3,43 +3,32 @@
 ## New Features
 
 - Project Proposal: Sensitive content report moderation
-  ([#1176](https://github.com/WordPress/openverse/pull/1176)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1176](https://github.com/WordPress/openverse/pull/1176)) by @sarayourfriend
 - Install drf-spectacular
-  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by @dhruvkb
 
 ## Internal Improvements
 
 - Bump ipython from 8.12.1 to 8.13.1 in /api
-  ([#1958](https://github.com/WordPress/openverse/pull/1958)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1958](https://github.com/WordPress/openverse/pull/1958)) by @dependabot
 - Bump sentry-sdk from 1.21.0 to 1.21.1 in /api
-  ([#1956](https://github.com/WordPress/openverse/pull/1956)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1956](https://github.com/WordPress/openverse/pull/1956)) by @dependabot
 - Bump fakeredis from 2.10.2 to 2.11.2 in /api
-  ([#1953](https://github.com/WordPress/openverse/pull/1953)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1953](https://github.com/WordPress/openverse/pull/1953)) by @dependabot
 - Bump boto3 from 1.26.122 to 1.26.123 in /api
-  ([#1957](https://github.com/WordPress/openverse/pull/1957)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1957](https://github.com/WordPress/openverse/pull/1957)) by @dependabot
 - Remove `orjson` ([#1922](https://github.com/WordPress/openverse/pull/1922)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  @dhruvkb
 - Reintroduce API changelog 2023.04.12.23.29.59.md
-  ([#1800](https://github.com/WordPress/openverse/pull/1800)) by
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1800](https://github.com/WordPress/openverse/pull/1800)) by @zackkrida
 - Simplify report views
-  ([#1872](https://github.com/WordPress/openverse/pull/1872)) by
-  [@krysal](https://github.com/krysal)
+  ([#1872](https://github.com/WordPress/openverse/pull/1872)) by @krysal
 - Bump django from 4.1.7 to 4.2 in /api
-  ([#1221](https://github.com/WordPress/openverse/pull/1221)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1221](https://github.com/WordPress/openverse/pull/1221)) by @dependabot
 
 ## Bug Fixes
 
 - Raise `UpstreamThumbnailException` for unsuccessful requests
-  ([#1892](https://github.com/WordPress/openverse/pull/1892)) by
-  [@krysal](https://github.com/krysal)
+  ([#1892](https://github.com/WordPress/openverse/pull/1892)) by @krysal
 - Reintroduce API changelog 2023.04.12.23.29.59.md
-  ([#1800](https://github.com/WordPress/openverse/pull/1800)) by
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1800](https://github.com/WordPress/openverse/pull/1800)) by @zackkrida

--- a/documentation/changelogs/api/2023.05.15.21.51.49.md
+++ b/documentation/changelogs/api/2023.05.15.21.51.49.md
@@ -3,41 +3,31 @@
 ## Improvements
 
 - Query the filtered indexes
-  ([#1903](https://github.com/WordPress/openverse/pull/1903)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1903](https://github.com/WordPress/openverse/pull/1903)) by @sarayourfriend
 
 ## Internal Improvements
 
 - Update consistent python test module naming pattern
   ([#2051](https://github.com/WordPress/openverse/pull/2051)) by
-  [@harsitagarwalla187](https://github.com/harsitagarwalla187)
+  @harsitagarwalla187
 - Add Cloudflare malicious traffic runbook
-  ([#1858](https://github.com/WordPress/openverse/pull/1858)) by
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1858](https://github.com/WordPress/openverse/pull/1858)) by @zackkrida
 - Simplify and reorder parameters to `catalog/pgcli` recipe
-  ([#2023](https://github.com/WordPress/openverse/pull/2023)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#2023](https://github.com/WordPress/openverse/pull/2023)) by @AetherUnbound
 - Restructure API to remove confusion about 'catalog'
-  ([#1936](https://github.com/WordPress/openverse/pull/1936)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1936](https://github.com/WordPress/openverse/pull/1936)) by @dhruvkb
 - Remove `piexif` and suppress warnings
-  ([#2016](https://github.com/WordPress/openverse/pull/2016)) by
-  [@krysal](https://github.com/krysal)
+  ([#2016](https://github.com/WordPress/openverse/pull/2016)) by @krysal
 
 ## Bug Fixes
 
 - Re-add accidentally removed CORS middleware
-  ([#2075](https://github.com/WordPress/openverse/pull/2075)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#2075](https://github.com/WordPress/openverse/pull/2075)) by @dhruvkb
 - Remove unused and empty settings file
-  ([#2069](https://github.com/WordPress/openverse/pull/2069)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#2069](https://github.com/WordPress/openverse/pull/2069)) by @dhruvkb
 - Add throttle classess for health check endpoint
-  ([#2061](https://github.com/WordPress/openverse/pull/2061)) by
-  [@krysal](https://github.com/krysal)
+  ([#2061](https://github.com/WordPress/openverse/pull/2061)) by @krysal
 - Simplify and reorder parameters to `catalog/pgcli` recipe
-  ([#2023](https://github.com/WordPress/openverse/pull/2023)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#2023](https://github.com/WordPress/openverse/pull/2023)) by @AetherUnbound
 - Bump redis from 4.3.4 to 4.4.4 in /utilities/dead_links
-  ([#2035](https://github.com/WordPress/openverse/pull/2035)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#2035](https://github.com/WordPress/openverse/pull/2035)) by @dependabot

--- a/documentation/changelogs/catalog/2023.04.27.02.43.13.md
+++ b/documentation/changelogs/catalog/2023.04.27.02.43.13.md
@@ -3,38 +3,28 @@
 ## Improvements
 
 - Add `LABEL` to link repo with GHCR image
-  ([#1223](https://github.com/WordPress/openverse/pull/1223))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1223](https://github.com/WordPress/openverse/pull/1223)) @dhruvkb
 
 ## Internal Improvements
 
 - Accommodate multi-heading DAG docs
-  ([#1866](https://github.com/WordPress/openverse/pull/1866))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1866](https://github.com/WordPress/openverse/pull/1866)) @sarayourfriend
 - Make foreign_identifier required in `add_item`
-  ([#1887](https://github.com/WordPress/openverse/pull/1887))
-  [@obulat](https://github.com/obulat)
+  ([#1887](https://github.com/WordPress/openverse/pull/1887)) @obulat
 - Add `catalog/recreate` just command and remove a file
-  ([#1856](https://github.com/WordPress/openverse/pull/1856))
-  [@krysal](https://github.com/krysal)
+  ([#1856](https://github.com/WordPress/openverse/pull/1856)) @krysal
 - Bump pre-commit from 3.2.1 to 3.2.2 in /catalog
-  ([#1210](https://github.com/WordPress/openverse/pull/1210))
-  [@dependabot](https://github.com/dependabot)
+  ([#1210](https://github.com/WordPress/openverse/pull/1210)) @dependabot
 - Bump pytest-sugar from 0.9.6 to 0.9.7 in /catalog
-  ([#1212](https://github.com/WordPress/openverse/pull/1212))
-  [@dependabot](https://github.com/dependabot)
+  ([#1212](https://github.com/WordPress/openverse/pull/1212)) @dependabot
 - Add `LABEL` to link repo with GHCR image
-  ([#1223](https://github.com/WordPress/openverse/pull/1223))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1223](https://github.com/WordPress/openverse/pull/1223)) @dhruvkb
 
 ## Bug Fixes
 
 - Update timeouts for image popularity view creation
-  ([#1906](https://github.com/WordPress/openverse/pull/1906))
-  [@stacimc](https://github.com/stacimc)
+  ([#1906](https://github.com/WordPress/openverse/pull/1906)) @stacimc
 - Consolidate all transient dev container dirs for the catalog
-  ([#1829](https://github.com/WordPress/openverse/pull/1829))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1829](https://github.com/WordPress/openverse/pull/1829)) @AetherUnbound
 - Fix line ending of Java SDK file
-  ([#1222](https://github.com/WordPress/openverse/pull/1222))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1222](https://github.com/WordPress/openverse/pull/1222)) @zackkrida

--- a/documentation/changelogs/frontend/2023.04.23.23.07.51.md
+++ b/documentation/changelogs/frontend/2023.04.23.23.07.51.md
@@ -3,335 +3,229 @@
 ## New Features
 
 - Add documentation for the CI + CD workflow
-  ([#1001](https://github.com/WordPress/openverse/pull/1001))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1001](https://github.com/WordPress/openverse/pull/1001)) @dhruvkb
 - Analytics event: COPY_ATTRIBUTION
-  ([#1147](https://github.com/WordPress/openverse/pull/1147))
-  [@obulat](https://github.com/obulat)
+  ([#1147](https://github.com/WordPress/openverse/pull/1147)) @obulat
 - Analytics event: GET_MEDIA
-  ([#1180](https://github.com/WordPress/openverse/pull/1180))
-  [@obulat](https://github.com/obulat)
+  ([#1180](https://github.com/WordPress/openverse/pull/1180)) @obulat
 - Add new buttons variants and sizes
-  ([#1003](https://github.com/WordPress/openverse/pull/1003))
-  [@obulat](https://github.com/obulat)
+  ([#1003](https://github.com/WordPress/openverse/pull/1003)) @obulat
 - Implement analytics in Nuxt
-  ([#844](https://github.com/WordPress/openverse/pull/844))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#844](https://github.com/WordPress/openverse/pull/844)) @dhruvkb
 - Adding brand assets ([#888](https://github.com/WordPress/openverse/pull/888))
-  [@panchovm](https://github.com/panchovm)
+  @panchovm
 - Add preferences for analytics
-  ([#843](https://github.com/WordPress/openverse/pull/843))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#843](https://github.com/WordPress/openverse/pull/843)) @dhruvkb
 - Add actions to search forms
-  ([#785](https://github.com/WordPress/openverse/pull/785))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#785](https://github.com/WordPress/openverse/pull/785)) @zackkrida
 
 ## Improvements
 
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) @dhruvkb
 - Move Nuxt testing docs to the Docs site
-  ([#1144](https://github.com/WordPress/openverse/pull/1144))
-  [@obulat](https://github.com/obulat)
+  ([#1144](https://github.com/WordPress/openverse/pull/1144)) @obulat
 - Convert `VContentLink` story to MDX
-  ([#1062](https://github.com/WordPress/openverse/pull/1062))
-  [@sepehrrezaei](https://github.com/sepehrrezaei)
+  ([#1062](https://github.com/WordPress/openverse/pull/1062)) @sepehrrezaei
 - Update the CTA buttons
-  ([#1049](https://github.com/WordPress/openverse/pull/1049))
-  [@obulat](https://github.com/obulat)
+  ([#1049](https://github.com/WordPress/openverse/pull/1049)) @obulat
 - Update the Copy button
-  ([#1140](https://github.com/WordPress/openverse/pull/1140))
-  [@obulat](https://github.com/obulat)
+  ([#1140](https://github.com/WordPress/openverse/pull/1140)) @obulat
 - Update sources button
-  ([#1021](https://github.com/WordPress/openverse/pull/1021))
-  [@obulat](https://github.com/obulat)
+  ([#1021](https://github.com/WordPress/openverse/pull/1021)) @obulat
 - Convert VModal story to MDX
-  ([#1091](https://github.com/WordPress/openverse/pull/1091))
-  [@sepehrrezaei](https://github.com/sepehrrezaei)
+  ([#1091](https://github.com/WordPress/openverse/pull/1091)) @sepehrrezaei
 - Extract VCloseButton and add descriptive labels
-  ([#988](https://github.com/WordPress/openverse/pull/988))
-  [@obulat](https://github.com/obulat)
+  ([#988](https://github.com/WordPress/openverse/pull/988)) @obulat
 - Convert VPill and VItemGroup stories to mdx
-  ([#1092](https://github.com/WordPress/openverse/pull/1092))
-  [@sepehrrezaei](https://github.com/sepehrrezaei)
+  ([#1092](https://github.com/WordPress/openverse/pull/1092)) @sepehrrezaei
 - Update other references of media count to 700 million
-  ([#1098](https://github.com/WordPress/openverse/pull/1098))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1098](https://github.com/WordPress/openverse/pull/1098)) @AetherUnbound
 - Simplify CI + CD workflow
-  ([#1054](https://github.com/WordPress/openverse/pull/1054))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1054](https://github.com/WordPress/openverse/pull/1054)) @dhruvkb
 - Improve documentation for partial stack setups
-  ([#974](https://github.com/WordPress/openverse/pull/974))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#974](https://github.com/WordPress/openverse/pull/974)) @dhruvkb
 - Project Proposal: Core UI improvement
-  ([#912](https://github.com/WordPress/openverse/pull/912))
-  [@panchovm](https://github.com/panchovm)
+  ([#912](https://github.com/WordPress/openverse/pull/912)) @panchovm
 - Update URLs to point to docs.openverse.org
-  ([#991](https://github.com/WordPress/openverse/pull/991))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#991](https://github.com/WordPress/openverse/pull/991)) @dhruvkb
 - Use profiles in Docker Compose
-  ([#914](https://github.com/WordPress/openverse/pull/914))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#914](https://github.com/WordPress/openverse/pull/914)) @dhruvkb
 - Add a counter to filter button and tab
-  ([#826](https://github.com/WordPress/openverse/pull/826))
-  [@obulat](https://github.com/obulat)
+  ([#826](https://github.com/WordPress/openverse/pull/826)) @obulat
 - Prepare Docker setup for monorepo
-  ([#889](https://github.com/WordPress/openverse/pull/889))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#889](https://github.com/WordPress/openverse/pull/889)) @dhruvkb
 - Update homepage copy to "700 million"
-  ([#842](https://github.com/WordPress/openverse/pull/842))
-  [@Rishav1707](https://github.com/Rishav1707)
+  ([#842](https://github.com/WordPress/openverse/pull/842)) @Rishav1707
 - Add stack label if available, make get-changes composite action
-  ([#786](https://github.com/WordPress/openverse/pull/786))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#786](https://github.com/WordPress/openverse/pull/786)) @AetherUnbound
 - Update home link screen reader text
-  ([#788](https://github.com/WordPress/openverse/pull/788))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#788](https://github.com/WordPress/openverse/pull/788)) @zackkrida
 
 ## Internal Improvements
 
 - Dispatch deployment workflows from infrastructure repository
-  ([#1865](https://github.com/WordPress/openverse/pull/1865))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1865](https://github.com/WordPress/openverse/pull/1865)) @sarayourfriend
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) @dhruvkb
 - Update Tailwind to version 3.3
-  ([#1060](https://github.com/WordPress/openverse/pull/1060))
-  [@obulat](https://github.com/obulat)
+  ([#1060](https://github.com/WordPress/openverse/pull/1060)) @obulat
 - Use the built-in Tailwind named groups
-  ([#1179](https://github.com/WordPress/openverse/pull/1179))
-  [@obulat](https://github.com/obulat)
+  ([#1179](https://github.com/WordPress/openverse/pull/1179)) @obulat
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) @AetherUnbound
 - Update deployment doc and add zero-downtime info about environment variables
-  ([#907](https://github.com/WordPress/openverse/pull/907))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#907](https://github.com/WordPress/openverse/pull/907)) @sarayourfriend
 - Delete unused VSearchTypeRadio.vue
-  ([#1143](https://github.com/WordPress/openverse/pull/1143))
-  [@obulat](https://github.com/obulat)
+  ([#1143](https://github.com/WordPress/openverse/pull/1143)) @obulat
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) @sarayourfriend
 - Use context manager for multiprocessing in the ingestion server
-  ([#1057](https://github.com/WordPress/openverse/pull/1057))
-  [@obulat](https://github.com/obulat)
+  ([#1057](https://github.com/WordPress/openverse/pull/1057)) @obulat
 - Add more docs for Plausible and auto-initialise custom event names
-  ([#1122](https://github.com/WordPress/openverse/pull/1122))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1122](https://github.com/WordPress/openverse/pull/1122)) @sarayourfriend
 - Prepare VButton for updates
-  ([#1002](https://github.com/WordPress/openverse/pull/1002))
-  [@obulat](https://github.com/obulat)
+  ([#1002](https://github.com/WordPress/openverse/pull/1002)) @obulat
 - Add `SLACK_WEBHOOK_TYPE` env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) @dhruvkb
 - Fix types in VFilters and VContentReport
-  ([#1030](https://github.com/WordPress/openverse/pull/1030))
-  [@obulat](https://github.com/obulat)
+  ([#1030](https://github.com/WordPress/openverse/pull/1030)) @obulat
 - Update other references of media count to 700 million
-  ([#1100](https://github.com/WordPress/openverse/pull/1100))
-  [@krysal](https://github.com/krysal)
+  ([#1100](https://github.com/WordPress/openverse/pull/1100)) @krysal
 - Pass actor for staging deploys with the `-f` flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) @sarayourfriend
 - Save cleaned up data during the cleanup step
-  ([#904](https://github.com/WordPress/openverse/pull/904))
-  [@obulat](https://github.com/obulat)
+  ([#904](https://github.com/WordPress/openverse/pull/904)) @obulat
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) @sarayourfriend
 - Update TS configuration to use composite projects and fix VSCode integration
-  ([#951](https://github.com/WordPress/openverse/pull/951))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#951](https://github.com/WordPress/openverse/pull/951)) @sarayourfriend
 - Update Nuxt to v.2.16.3
-  ([#952](https://github.com/WordPress/openverse/pull/952))
-  [@obulat](https://github.com/obulat)
+  ([#952](https://github.com/WordPress/openverse/pull/952)) @obulat
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) @dhruvkb
 - Update Playwright ([#919](https://github.com/WordPress/openverse/pull/919))
-  [@obulat](https://github.com/obulat)
+  @obulat
 - Use profiles in Docker Compose
-  ([#914](https://github.com/WordPress/openverse/pull/914))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#914](https://github.com/WordPress/openverse/pull/914)) @dhruvkb
 - Update pinia and pinia/testing
-  ([#917](https://github.com/WordPress/openverse/pull/917))
-  [@obulat](https://github.com/obulat)
+  ([#917](https://github.com/WordPress/openverse/pull/917)) @obulat
 - Always build both api & ingestion server images for either service
-  ([#936](https://github.com/WordPress/openverse/pull/936))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#936](https://github.com/WordPress/openverse/pull/936)) @AetherUnbound
 - Build `api` when ingestion server changes
-  ([#925](https://github.com/WordPress/openverse/pull/925))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#925](https://github.com/WordPress/openverse/pull/925)) @dhruvkb
 - Prepare Docker setup for monorepo
-  ([#889](https://github.com/WordPress/openverse/pull/889))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#889](https://github.com/WordPress/openverse/pull/889)) @dhruvkb
 - Skip more jobs based on changed files
-  ([#895](https://github.com/WordPress/openverse/pull/895))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#895](https://github.com/WordPress/openverse/pull/895)) @dhruvkb
 - Update Vue from 2.7.10 to 2.7.14
-  ([#916](https://github.com/WordPress/openverse/pull/916))
-  [@obulat](https://github.com/obulat)
+  ([#916](https://github.com/WordPress/openverse/pull/916)) @obulat
 - Move peerDependencyRules to root package.json
-  ([#828](https://github.com/WordPress/openverse/pull/828))
-  [@obulat](https://github.com/obulat)
+  ([#828](https://github.com/WordPress/openverse/pull/828)) @obulat
 - Only generate POT file if `en.json5` has changed
-  ([#893](https://github.com/WordPress/openverse/pull/893))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#893](https://github.com/WordPress/openverse/pull/893)) @dhruvkb
 - Only run stack label addition step on pull requests
-  ([#882](https://github.com/WordPress/openverse/pull/882))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#882](https://github.com/WordPress/openverse/pull/882)) @AetherUnbound
 - Simplify and fix bundle size workflow
-  ([#894](https://github.com/WordPress/openverse/pull/894))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#894](https://github.com/WordPress/openverse/pull/894)) @dhruvkb
 - Split deployment workflow into 4 separate workflows
-  ([#886](https://github.com/WordPress/openverse/pull/886))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#886](https://github.com/WordPress/openverse/pull/886)) @AetherUnbound
 - Add feature flag for fake marking results as sensitive
-  ([#862](https://github.com/WordPress/openverse/pull/862))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#862](https://github.com/WordPress/openverse/pull/862)) @dhruvkb
 - Update sentry; fix config
-  ([#870](https://github.com/WordPress/openverse/pull/870))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#870](https://github.com/WordPress/openverse/pull/870)) @zackkrida
 - Add stack label if available, make get-changes composite action
-  ([#786](https://github.com/WordPress/openverse/pull/786))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#786](https://github.com/WordPress/openverse/pull/786)) @AetherUnbound
 - Combine VImageCellSquare with VImageCell
-  ([#814](https://github.com/WordPress/openverse/pull/814))
-  [@obulat](https://github.com/obulat)
+  ([#814](https://github.com/WordPress/openverse/pull/814)) @obulat
 - Replace imports from capi with vue imports
-  ([#816](https://github.com/WordPress/openverse/pull/816))
-  [@obulat](https://github.com/obulat)
+  ([#816](https://github.com/WordPress/openverse/pull/816)) @obulat
 - Update TS dependencies
-  ([#805](https://github.com/WordPress/openverse/pull/805))
-  [@obulat](https://github.com/obulat)
+  ([#805](https://github.com/WordPress/openverse/pull/805)) @obulat
 - Unify rollback & deployment, simplify deployment workflow
-  ([#767](https://github.com/WordPress/openverse/pull/767))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#767](https://github.com/WordPress/openverse/pull/767)) @AetherUnbound
 
 ## Bug Fixes
 
 - Fix focus rings ([#1253](https://github.com/WordPress/openverse/pull/1253))
-  [@obulat](https://github.com/obulat)
+  @obulat
 - Update frontend Dockerfile to use same release ARG as API
-  ([#1827](https://github.com/WordPress/openverse/pull/1827))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1827](https://github.com/WordPress/openverse/pull/1827)) @sarayourfriend
 - Disable Plausible at init
-  ([#1182](https://github.com/WordPress/openverse/pull/1182))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1182](https://github.com/WordPress/openverse/pull/1182)) @dhruvkb
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) @AetherUnbound
 - Add a check for `statement`'s name to fix the failure
-  ([#1177](https://github.com/WordPress/openverse/pull/1177))
-  [@obulat](https://github.com/obulat)
+  ([#1177](https://github.com/WordPress/openverse/pull/1177)) @obulat
 - Fix Storybook tests by waiting for URL instead of a port
-  ([#1137](https://github.com/WordPress/openverse/pull/1137))
-  [@obulat](https://github.com/obulat)
+  ([#1137](https://github.com/WordPress/openverse/pull/1137)) @obulat
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) @sarayourfriend
 - Make `label` prop required for VIconButton
-  ([#954](https://github.com/WordPress/openverse/pull/954))
-  [@obulat](https://github.com/obulat)
+  ([#954](https://github.com/WordPress/openverse/pull/954)) @obulat
 - Fix Tailwind line heights
-  ([#946](https://github.com/WordPress/openverse/pull/946))
-  [@obulat](https://github.com/obulat)
+  ([#946](https://github.com/WordPress/openverse/pull/946)) @obulat
 - Pass `GITHUB_TOKEN` to deploy docs
-  ([#1134](https://github.com/WordPress/openverse/pull/1134))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1134](https://github.com/WordPress/openverse/pull/1134)) @dhruvkb
 - Add `SLACK_WEBHOOK_TYPE` env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) @dhruvkb
 - Fix types in VFilters and VContentReport
-  ([#1030](https://github.com/WordPress/openverse/pull/1030))
-  [@obulat](https://github.com/obulat)
+  ([#1030](https://github.com/WordPress/openverse/pull/1030)) @obulat
 - Add a wait to filter button test to fix CI
-  ([#1124](https://github.com/WordPress/openverse/pull/1124))
-  [@obulat](https://github.com/obulat)
+  ([#1124](https://github.com/WordPress/openverse/pull/1124)) @obulat
 - Pass actor for staging deploys with the `-f` flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) @dhruvkb
 - Add `GITHUB_TOKEN` to GitHub CLI step
-  ([#1103](https://github.com/WordPress/openverse/pull/1103))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1103](https://github.com/WordPress/openverse/pull/1103)) @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) @sarayourfriend
 - Fix typo in docs building on `main`
-  ([#1067](https://github.com/WordPress/openverse/pull/1067))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1067](https://github.com/WordPress/openverse/pull/1067)) @dhruvkb
 - Pin pnpm version in frontend `Dockerfile`
-  ([#1051](https://github.com/WordPress/openverse/pull/1051))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1051](https://github.com/WordPress/openverse/pull/1051)) @dhruvkb
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) @sarayourfriend
 - Update TS configuration to use composite projects and fix VSCode integration
-  ([#951](https://github.com/WordPress/openverse/pull/951))
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#951](https://github.com/WordPress/openverse/pull/951)) @sarayourfriend
 - Switch to internal header on single results
-  ([#981](https://github.com/WordPress/openverse/pull/981))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#981](https://github.com/WordPress/openverse/pull/981)) @zackkrida
 - Add decoding of the strings that don't have backslashes
-  ([#979](https://github.com/WordPress/openverse/pull/979))
-  [@obulat](https://github.com/obulat)
+  ([#979](https://github.com/WordPress/openverse/pull/979)) @obulat
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) @dhruvkb
 - Make `searchTerm` for VAudioTrack and VImageCell optional
-  ([#955](https://github.com/WordPress/openverse/pull/955))
-  [@obulat](https://github.com/obulat)
+  ([#955](https://github.com/WordPress/openverse/pull/955)) @obulat
 - Update opensearch.xml to fix bad url
-  ([#961](https://github.com/WordPress/openverse/pull/961))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#961](https://github.com/WordPress/openverse/pull/961)) @zackkrida
 - Make Plausible setup idempotent
-  ([#943](https://github.com/WordPress/openverse/pull/943))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#943](https://github.com/WordPress/openverse/pull/943)) @dhruvkb
 - Fix background color on report pages
-  ([#915](https://github.com/WordPress/openverse/pull/915))
-  [@obulat](https://github.com/obulat)
+  ([#915](https://github.com/WordPress/openverse/pull/915)) @obulat
 - Fix global audio player's close button
-  ([#927](https://github.com/WordPress/openverse/pull/927))
-  [@obulat](https://github.com/obulat)
+  ([#927](https://github.com/WordPress/openverse/pull/927)) @obulat
 - Always build both api & ingestion server images for either service
-  ([#936](https://github.com/WordPress/openverse/pull/936))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#936](https://github.com/WordPress/openverse/pull/936)) @AetherUnbound
 - Fix links on the main Storybook page
-  ([#930](https://github.com/WordPress/openverse/pull/930))
-  [@obulat](https://github.com/obulat)
+  ([#930](https://github.com/WordPress/openverse/pull/930)) @obulat
 - Build `api` when ingestion server changes
-  ([#925](https://github.com/WordPress/openverse/pull/925))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#925](https://github.com/WordPress/openverse/pull/925)) @dhruvkb
 - Fix global audio player layout
-  ([#918](https://github.com/WordPress/openverse/pull/918))
-  [@obulat](https://github.com/obulat)
+  ([#918](https://github.com/WordPress/openverse/pull/918)) @obulat
 - Skip more jobs based on changed files
-  ([#895](https://github.com/WordPress/openverse/pull/895))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#895](https://github.com/WordPress/openverse/pull/895)) @dhruvkb
 - Move peerDependencyRules to root package.json
-  ([#828](https://github.com/WordPress/openverse/pull/828))
-  [@obulat](https://github.com/obulat)
+  ([#828](https://github.com/WordPress/openverse/pull/828)) @obulat
 - Add get-image-tag as dependency for nginx build step
-  ([#909](https://github.com/WordPress/openverse/pull/909))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#909](https://github.com/WordPress/openverse/pull/909)) @AetherUnbound
 - Only run stack label addition step on pull requests
-  ([#882](https://github.com/WordPress/openverse/pull/882))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#882](https://github.com/WordPress/openverse/pull/882)) @AetherUnbound
 - Simplify and fix bundle size workflow
-  ([#894](https://github.com/WordPress/openverse/pull/894))
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#894](https://github.com/WordPress/openverse/pull/894)) @dhruvkb
 - Update sentry; fix config
-  ([#870](https://github.com/WordPress/openverse/pull/870))
-  [@zackkrida](https://github.com/zackkrida)
+  ([#870](https://github.com/WordPress/openverse/pull/870)) @zackkrida
 - Fix crash when more than one `q` parameter is provided in URL
-  ([#806](https://github.com/WordPress/openverse/pull/806))
-  [@obulat](https://github.com/obulat)
+  ([#806](https://github.com/WordPress/openverse/pull/806)) @obulat
 - Unify rollback & deployment, simplify deployment workflow
-  ([#767](https://github.com/WordPress/openverse/pull/767))
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#767](https://github.com/WordPress/openverse/pull/767)) @AetherUnbound

--- a/documentation/changelogs/frontend/2023.05.02.19.17.32.md
+++ b/documentation/changelogs/frontend/2023.05.02.19.17.32.md
@@ -3,68 +3,49 @@
 ## New Features
 
 - Analytics event: BACK_TO_SEARCH
-  ([#1118](https://github.com/WordPress/openverse/pull/1118)) by
-  [@masif2002](https://github.com/masif2002)
+  ([#1118](https://github.com/WordPress/openverse/pull/1118)) by @masif2002
 - Project Proposal: Sensitive content report moderation
-  ([#1176](https://github.com/WordPress/openverse/pull/1176)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1176](https://github.com/WordPress/openverse/pull/1176)) by @sarayourfriend
 - Install drf-spectacular
-  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by @dhruvkb
 - Analytics event: REPORT_MEDIA
-  ([#1181](https://github.com/WordPress/openverse/pull/1181)) by
-  [@obulat](https://github.com/obulat)
+  ([#1181](https://github.com/WordPress/openverse/pull/1181)) by @obulat
 
 ## Improvements
 
 - Replace span with h2 on image search results
-  ([#1888](https://github.com/WordPress/openverse/pull/1888)) by
-  [@obulat](https://github.com/obulat)
+  ([#1888](https://github.com/WordPress/openverse/pull/1888)) by @obulat
 - Update Back to results button to use the new VButton variant and size
-  ([#1141](https://github.com/WordPress/openverse/pull/1141)) by
-  [@obulat](https://github.com/obulat)
+  ([#1141](https://github.com/WordPress/openverse/pull/1141)) by @obulat
 - Update report buttons
-  ([#1004](https://github.com/WordPress/openverse/pull/1004)) by
-  [@obulat](https://github.com/obulat)
+  ([#1004](https://github.com/WordPress/openverse/pull/1004)) by @obulat
 - Convert VPopover story to MDX
-  ([#1089](https://github.com/WordPress/openverse/pull/1089)) by
-  [@sepehrrezaei](https://github.com/sepehrrezaei)
+  ([#1089](https://github.com/WordPress/openverse/pull/1089)) by @sepehrrezaei
 - Add SVG Sprite Module for icons
-  ([#1808](https://github.com/WordPress/openverse/pull/1808)) by
-  [@obulat](https://github.com/obulat)
+  ([#1808](https://github.com/WordPress/openverse/pull/1808)) by @obulat
 - Update the VFilterButton to use the new variants
-  ([#1132](https://github.com/WordPress/openverse/pull/1132)) by
-  [@obulat](https://github.com/obulat)
+  ([#1132](https://github.com/WordPress/openverse/pull/1132)) by @obulat
 - Avoid the need to specify each image individually in `load-img`
-  ([#1855](https://github.com/WordPress/openverse/pull/1855)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1855](https://github.com/WordPress/openverse/pull/1855)) by @dhruvkb
 
 ## Internal Improvements
 
 - Remove primary button variant and make variant required
-  ([#1188](https://github.com/WordPress/openverse/pull/1188)) by
-  [@obulat](https://github.com/obulat)
+  ([#1188](https://github.com/WordPress/openverse/pull/1188)) by @obulat
 - Remove @types/lodash.sortBy from project
-  ([#1937](https://github.com/WordPress/openverse/pull/1937)) by
-  [@wasimTQ](https://github.com/wasimTQ)
+  ([#1937](https://github.com/WordPress/openverse/pull/1937)) by @wasimTQ
 - Improve Playwright navigation utilities
-  ([#1869](https://github.com/WordPress/openverse/pull/1869)) by
-  [@obulat](https://github.com/obulat)
+  ([#1869](https://github.com/WordPress/openverse/pull/1869)) by @obulat
 - Use `bordered-white` variant for VSearchTypeButton.vue
-  ([#1146](https://github.com/WordPress/openverse/pull/1146)) by
-  [@obulat](https://github.com/obulat)
+  ([#1146](https://github.com/WordPress/openverse/pull/1146)) by @obulat
 
 ## Bug Fixes
 
 - Correctly pass `maxDiffPixelRatio` to add tolerance for pages-single-result VR
-  test ([#1960](https://github.com/WordPress/openverse/pull/1960)) by
-  [@obulat](https://github.com/obulat)
+  test ([#1960](https://github.com/WordPress/openverse/pull/1960)) by @obulat
 - Lower the number of columns when sidebar is open
-  ([#1178](https://github.com/WordPress/openverse/pull/1178)) by
-  [@obulat](https://github.com/obulat)
+  ([#1178](https://github.com/WordPress/openverse/pull/1178)) by @obulat
 - Replace the links to old repos in code
-  ([#1918](https://github.com/WordPress/openverse/pull/1918)) by
-  [@obulat](https://github.com/obulat)
+  ([#1918](https://github.com/WordPress/openverse/pull/1918)) by @obulat
 - Compute search path query parameters for the type passed
-  ([#1871](https://github.com/WordPress/openverse/pull/1871)) by
-  [@obulat](https://github.com/obulat)
+  ([#1871](https://github.com/WordPress/openverse/pull/1871)) by @obulat

--- a/documentation/changelogs/frontend/2023.05.15.22.13.27.md
+++ b/documentation/changelogs/frontend/2023.05.15.22.13.27.md
@@ -3,41 +3,31 @@
 ## New Features
 
 - Project Proposal: Additional search views
-  ([#1890](https://github.com/WordPress/openverse/pull/1890)) by
-  [@fcoveram](https://github.com/fcoveram)
+  ([#1890](https://github.com/WordPress/openverse/pull/1890)) by @fcoveram
 - Analytics event: SELECT_EXTERNAL_SOURCE
-  ([#1158](https://github.com/WordPress/openverse/pull/1158)) by
-  [@obulat](https://github.com/obulat)
+  ([#1158](https://github.com/WordPress/openverse/pull/1158)) by @obulat
 
 ## Improvements
 
 - Use contentlist role for search results for a11y
-  ([#1979](https://github.com/WordPress/openverse/pull/1979)) by
-  [@obulat](https://github.com/obulat)
+  ([#1979](https://github.com/WordPress/openverse/pull/1979)) by @obulat
 - Added a recreate recipe for frontend
-  ([#2042](https://github.com/WordPress/openverse/pull/2042)) by
-  [@Aditya062003](https://github.com/Aditya062003)
+  ([#2042](https://github.com/WordPress/openverse/pull/2042)) by @Aditya062003
 
 ## Internal Improvements
 
 - Added a recreate recipe for frontend
-  ([#2042](https://github.com/WordPress/openverse/pull/2042)) by
-  [@Aditya062003](https://github.com/Aditya062003)
+  ([#2042](https://github.com/WordPress/openverse/pull/2042)) by @Aditya062003
 - Add Cloudflare malicious traffic runbook
-  ([#1858](https://github.com/WordPress/openverse/pull/1858)) by
-  [@zackkrida](https://github.com/zackkrida)
+  ([#1858](https://github.com/WordPress/openverse/pull/1858)) by @zackkrida
 
 ## Bug Fixes
 
 - Handle more than one value for a url query parameter
-  ([#1889](https://github.com/WordPress/openverse/pull/1889)) by
-  [@obulat](https://github.com/obulat)
+  ([#1889](https://github.com/WordPress/openverse/pull/1889)) by @obulat
 - Fix i18n setup in the unit tests
-  ([#2049](https://github.com/WordPress/openverse/pull/2049)) by
-  [@obulat](https://github.com/obulat)
+  ([#2049](https://github.com/WordPress/openverse/pull/2049)) by @obulat
 - Use testing-library in test-utils/render
-  ([#2044](https://github.com/WordPress/openverse/pull/2044)) by
-  [@obulat](https://github.com/obulat)
+  ([#2044](https://github.com/WordPress/openverse/pull/2044)) by @obulat
 - Remove authentication in bulk translation downloads
-  ([#1993](https://github.com/WordPress/openverse/pull/1993)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1993](https://github.com/WordPress/openverse/pull/1993)) by @dhruvkb

--- a/documentation/changelogs/ingestion_server/2023.05.03.22.29.52.md
+++ b/documentation/changelogs/ingestion_server/2023.05.03.22.29.52.md
@@ -3,221 +3,151 @@
 ## New Features
 
 - Add filtered index creation DAG
-  ([#1833](https://github.com/WordPress/openverse/pull/1833)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1833](https://github.com/WordPress/openverse/pull/1833)) by @sarayourfriend
 - Install drf-spectacular
-  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1876](https://github.com/WordPress/openverse/pull/1876)) by @dhruvkb
 - Add documentation for the CI + CD workflow
-  ([#1001](https://github.com/WordPress/openverse/pull/1001)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1001](https://github.com/WordPress/openverse/pull/1001)) by @dhruvkb
 - Add `create_and_populate_filtered_index` action to ingestion server
-  ([#1202](https://github.com/WordPress/openverse/pull/1202)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1202](https://github.com/WordPress/openverse/pull/1202)) by @sarayourfriend
 
 ## Improvements
 
 - Avoid the need to specify each image individually in `load-img`
-  ([#1855](https://github.com/WordPress/openverse/pull/1855)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1855](https://github.com/WordPress/openverse/pull/1855)) by @dhruvkb
 - Update Python code to use Python 3.11
-  ([#1852](https://github.com/WordPress/openverse/pull/1852)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1852](https://github.com/WordPress/openverse/pull/1852)) by @dhruvkb
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) by @dhruvkb
 - Add a `just ps` recipe for displaying service ports
-  ([#1160](https://github.com/WordPress/openverse/pull/1160)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1160](https://github.com/WordPress/openverse/pull/1160)) by @AetherUnbound
 - Simplify CI + CD workflow
-  ([#1054](https://github.com/WordPress/openverse/pull/1054)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1054](https://github.com/WordPress/openverse/pull/1054)) by @dhruvkb
 - Improve documentation for partial stack setups
-  ([#974](https://github.com/WordPress/openverse/pull/974)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#974](https://github.com/WordPress/openverse/pull/974)) by @dhruvkb
 - Absorb `build-nginx` job into `build-images` job
-  ([#944](https://github.com/WordPress/openverse/pull/944)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#944](https://github.com/WordPress/openverse/pull/944)) by @dhruvkb
 - Use profiles in Docker Compose
-  ([#914](https://github.com/WordPress/openverse/pull/914)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#914](https://github.com/WordPress/openverse/pull/914)) by @dhruvkb
 - Prepare Docker setup for monorepo
-  ([#889](https://github.com/WordPress/openverse/pull/889)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#889](https://github.com/WordPress/openverse/pull/889)) by @dhruvkb
 - Add stack label if available, make get-changes composite action
-  ([#786](https://github.com/WordPress/openverse/pull/786)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#786](https://github.com/WordPress/openverse/pull/786)) by @AetherUnbound
 
 ## Internal Improvements
 
 - Bump tldextract from 3.4.0 to 3.4.1 in /ingestion_server
-  ([#1952](https://github.com/WordPress/openverse/pull/1952)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1952](https://github.com/WordPress/openverse/pull/1952)) by @dependabot
 - Bump boto3 from 1.26.115 to 1.26.123 in /ingestion_server
-  ([#1951](https://github.com/WordPress/openverse/pull/1951)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1951](https://github.com/WordPress/openverse/pull/1951)) by @dependabot
 - Bump sentry-sdk from 1.19.1 to 1.21.1 in /ingestion_server
-  ([#1954](https://github.com/WordPress/openverse/pull/1954)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1954](https://github.com/WordPress/openverse/pull/1954)) by @dependabot
 - Bump ipython from 8.12.0 to 8.13.1 in /ingestion_server
-  ([#1955](https://github.com/WordPress/openverse/pull/1955)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1955](https://github.com/WordPress/openverse/pull/1955)) by @dependabot
 - Remove `tags_list` from models and ingestion_server
-  ([#956](https://github.com/WordPress/openverse/pull/956)) by
-  [@obulat](https://github.com/obulat)
+  ([#956](https://github.com/WordPress/openverse/pull/956)) by @obulat
 - Dispatch deployment workflows from infrastructure repository
-  ([#1865](https://github.com/WordPress/openverse/pull/1865)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1865](https://github.com/WordPress/openverse/pull/1865)) by @sarayourfriend
 - Deduce Python/Node.js/pnpm version in Docker images
-  ([#1225](https://github.com/WordPress/openverse/pull/1225)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1225](https://github.com/WordPress/openverse/pull/1225)) by @dhruvkb
 - Add a `just ps` recipe for displaying service ports
-  ([#1160](https://github.com/WordPress/openverse/pull/1160)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1160](https://github.com/WordPress/openverse/pull/1160)) by @AetherUnbound
 - Bump boto3 from 1.26.104 to 1.26.115 in /ingestion_server
-  ([#1801](https://github.com/WordPress/openverse/pull/1801)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1801](https://github.com/WordPress/openverse/pull/1801)) by @dependabot
 - Bump filelock from 3.10.7 to 3.12.0 in /ingestion_server
-  ([#1821](https://github.com/WordPress/openverse/pull/1821)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1821](https://github.com/WordPress/openverse/pull/1821)) by @dependabot
 - Bump pytest from 7.2.2 to 7.3.1 in /ingestion_server
-  ([#1211](https://github.com/WordPress/openverse/pull/1211)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1211](https://github.com/WordPress/openverse/pull/1211)) by @dependabot
 - Bump sentry-sdk from 1.18.0 to 1.19.1 in /ingestion_server
-  ([#1213](https://github.com/WordPress/openverse/pull/1213)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1213](https://github.com/WordPress/openverse/pull/1213)) by @dependabot
 - Bump psycopg2 from 2.9.5 to 2.9.6 in /ingestion_server
-  ([#1215](https://github.com/WordPress/openverse/pull/1215)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1215](https://github.com/WordPress/openverse/pull/1215)) by @dependabot
 - Use `pytest.ini` and add `pytest-sugar`
-  ([#1227](https://github.com/WordPress/openverse/pull/1227)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1227](https://github.com/WordPress/openverse/pull/1227)) by @dhruvkb
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) by @AetherUnbound
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) by @sarayourfriend
 - Use context manager for multiprocessing in the ingestion server
-  ([#1057](https://github.com/WordPress/openverse/pull/1057)) by
-  [@obulat](https://github.com/obulat)
+  ([#1057](https://github.com/WordPress/openverse/pull/1057)) by @obulat
 - Add `SLACK_WEBHOOK_TYPE` env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) by @dhruvkb
 - Bump boto3 from 1.26.100 to 1.26.104 in /ingestion_server
-  ([#1110](https://github.com/WordPress/openverse/pull/1110)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1110](https://github.com/WordPress/openverse/pull/1110)) by @dependabot
 - Add Sentry to the ingestion server
-  ([#1106](https://github.com/WordPress/openverse/pull/1106)) by
-  [@krysal](https://github.com/krysal)
+  ([#1106](https://github.com/WordPress/openverse/pull/1106)) by @krysal
 - Pass actor for staging deploys with the `-f` flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) by @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) by @sarayourfriend
 - Save cleaned up data during the cleanup step
-  ([#904](https://github.com/WordPress/openverse/pull/904)) by
-  [@obulat](https://github.com/obulat)
+  ([#904](https://github.com/WordPress/openverse/pull/904)) by @obulat
 - Bump boto3 from 1.26.84 to 1.26.100 in /ingestion_server
-  ([#1048](https://github.com/WordPress/openverse/pull/1048)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1048](https://github.com/WordPress/openverse/pull/1048)) by @dependabot
 - Bump pytest-order from 1.0.1 to 1.1.0 in /ingestion_server
-  ([#1040](https://github.com/WordPress/openverse/pull/1040)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1040](https://github.com/WordPress/openverse/pull/1040)) by @dependabot
 - Bump filelock from 3.9.0 to 3.10.7 in /ingestion_server
-  ([#1041](https://github.com/WordPress/openverse/pull/1041)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1041](https://github.com/WordPress/openverse/pull/1041)) by @dependabot
 - Bump bottle from 0.12.24 to 0.12.25 in /ingestion_server
-  ([#1044](https://github.com/WordPress/openverse/pull/1044)) by
-  [@dependabot](https://github.com/dependabot)
+  ([#1044](https://github.com/WordPress/openverse/pull/1044)) by @dependabot
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) by @sarayourfriend
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) by @dhruvkb
 - Use profiles in Docker Compose
-  ([#914](https://github.com/WordPress/openverse/pull/914)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#914](https://github.com/WordPress/openverse/pull/914)) by @dhruvkb
 - Always build both api & ingestion server images for either service
-  ([#936](https://github.com/WordPress/openverse/pull/936)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#936](https://github.com/WordPress/openverse/pull/936)) by @AetherUnbound
 - Build `api` when ingestion server changes
-  ([#925](https://github.com/WordPress/openverse/pull/925)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#925](https://github.com/WordPress/openverse/pull/925)) by @dhruvkb
 - Prepare Docker setup for monorepo
-  ([#889](https://github.com/WordPress/openverse/pull/889)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#889](https://github.com/WordPress/openverse/pull/889)) by @dhruvkb
 - Skip more jobs based on changed files
-  ([#895](https://github.com/WordPress/openverse/pull/895)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#895](https://github.com/WordPress/openverse/pull/895)) by @dhruvkb
 - Only generate POT file if `en.json5` has changed
-  ([#893](https://github.com/WordPress/openverse/pull/893)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#893](https://github.com/WordPress/openverse/pull/893)) by @dhruvkb
 - Provider tally extraction script
-  ([#397](https://github.com/WordPress/openverse/pull/397)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#397](https://github.com/WordPress/openverse/pull/397)) by @AetherUnbound
 - Only run stack label addition step on pull requests
-  ([#882](https://github.com/WordPress/openverse/pull/882)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#882](https://github.com/WordPress/openverse/pull/882)) by @AetherUnbound
 - Split deployment workflow into 4 separate workflows
-  ([#886](https://github.com/WordPress/openverse/pull/886)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#886](https://github.com/WordPress/openverse/pull/886)) by @AetherUnbound
 - Add stack label if available, make get-changes composite action
-  ([#786](https://github.com/WordPress/openverse/pull/786)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#786](https://github.com/WordPress/openverse/pull/786)) by @AetherUnbound
 
 ## Bug Fixes
 
 - Change deployment workflow name from colon to dash
-  ([#1174](https://github.com/WordPress/openverse/pull/1174)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#1174](https://github.com/WordPress/openverse/pull/1174)) by @AetherUnbound
 - Safely call create-or-update-comment when dealing with forks
-  ([#997](https://github.com/WordPress/openverse/pull/997)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#997](https://github.com/WordPress/openverse/pull/997)) by @sarayourfriend
 - Make `label` prop required for VIconButton
-  ([#954](https://github.com/WordPress/openverse/pull/954)) by
-  [@obulat](https://github.com/obulat)
+  ([#954](https://github.com/WordPress/openverse/pull/954)) by @obulat
 - Pass `GITHUB_TOKEN` to deploy docs
-  ([#1134](https://github.com/WordPress/openverse/pull/1134)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1134](https://github.com/WordPress/openverse/pull/1134)) by @dhruvkb
 - Add `SLACK_WEBHOOK_TYPE` env var to reporting job
-  ([#1131](https://github.com/WordPress/openverse/pull/1131)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1131](https://github.com/WordPress/openverse/pull/1131)) by @dhruvkb
 - Pass actor for staging deploys with the `-f` flag
-  ([#1104](https://github.com/WordPress/openverse/pull/1104)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1104](https://github.com/WordPress/openverse/pull/1104)) by @dhruvkb
 - Add `GITHUB_TOKEN` to GitHub CLI step
-  ([#1103](https://github.com/WordPress/openverse/pull/1103)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1103](https://github.com/WordPress/openverse/pull/1103)) by @dhruvkb
 - Dispatch workflows instead of regular reuse to show deployment runs
-  ([#1034](https://github.com/WordPress/openverse/pull/1034)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#1034](https://github.com/WordPress/openverse/pull/1034)) by @sarayourfriend
 - Fix typo in docs building on `main`
-  ([#1067](https://github.com/WordPress/openverse/pull/1067)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#1067](https://github.com/WordPress/openverse/pull/1067)) by @dhruvkb
 - Add tag app release action
-  ([#987](https://github.com/WordPress/openverse/pull/987)) by
-  [@sarayourfriend](https://github.com/sarayourfriend)
+  ([#987](https://github.com/WordPress/openverse/pull/987)) by @sarayourfriend
 - Skip build and publish job if nothing to do
-  ([#977](https://github.com/WordPress/openverse/pull/977)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#977](https://github.com/WordPress/openverse/pull/977)) by @dhruvkb
 - Always build both api & ingestion server images for either service
-  ([#936](https://github.com/WordPress/openverse/pull/936)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#936](https://github.com/WordPress/openverse/pull/936)) by @AetherUnbound
 - Build `api` when ingestion server changes
-  ([#925](https://github.com/WordPress/openverse/pull/925)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#925](https://github.com/WordPress/openverse/pull/925)) by @dhruvkb
 - Skip more jobs based on changed files
-  ([#895](https://github.com/WordPress/openverse/pull/895)) by
-  [@dhruvkb](https://github.com/dhruvkb)
+  ([#895](https://github.com/WordPress/openverse/pull/895)) by @dhruvkb
 - Add get-image-tag as dependency for nginx build step
-  ([#909](https://github.com/WordPress/openverse/pull/909)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#909](https://github.com/WordPress/openverse/pull/909)) by @AetherUnbound
 - Only run stack label addition step on pull requests
-  ([#882](https://github.com/WordPress/openverse/pull/882)) by
-  [@AetherUnbound](https://github.com/AetherUnbound)
+  ([#882](https://github.com/WordPress/openverse/pull/882)) by @AetherUnbound
 - Add a stemming override for the word "universe"
-  ([#890](https://github.com/WordPress/openverse/pull/890)) by
-  [@zackkrida](https://github.com/zackkrida)
+  ([#890](https://github.com/WordPress/openverse/pull/890)) by @zackkrida

--- a/templates/release-drafter.yml.jinja
+++ b/templates/release-drafter.yml.jinja
@@ -14,7 +14,7 @@ categories:
   - title: Bug Fixes
     label: "🛠 goal: fix"
 # Identical to the default except it uses `-` instead of `*` to match our Markdown linter
-change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by [@$AUTHOR](https://github.com/$AUTHOR)"
+change-template: "- $TITLE ([#$NUMBER](https://github.com/WordPress/openverse/pull/$NUMBER)) by @$AUTHOR"
 exclude-labels:
   - "skip-changelog"
 include-labels:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes an issue wherein contributors were no longer linked on a GitHub release page, see https://github.com/WordPress/openverse/releases/tag/api-2023.05.15.21.51.49 vs https://github.com/WordPress/openverse/releases/tag/ingestion_server-2023.05.03.22.29.52

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

In #2036, I removed the explicit "credits" section from the release/changelog generation in hopes that GitHub's automatic "Contributors" section would suffice. Unfortunately, in that PR I also pre-rendered the GitHub usernames as links (e.g. `[@$AUTHOR](https://github.com/$AUTHOR)` rather than just `$AUTHOR`). This meant that GitHub was no longer doing it's automatic mentioning behind the scenes, and so it could no longer create the "Contributors" section automatically. Per step 8 of their release document creation docs[^1] _(emphasis mine)_:

> In the "Describe this release" field, type a description for your release. **If you @mention anyone in the description, the published release will include a Contributors section with an avatar list of all the mentioned users.** Alternatively, you can automatically generate your release notes by clicking Generate release notes.

I believe that by making those Markdown links as part of the generation, I was circumventing GitHub's mechanism for doing this linking.

[^1]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release

As such, I've removed the changelog exclusion from the `link_usernames.py` script and also removed all the explicit links from our already existing changelog so as not to have the rudimentary parser I wrote double up on links (I used the regex pattern `\[(@[A-Za-z0-9-]+)\].*?\)` and replacement `$1` in PyCharm to accomplish this).

This should also now make future releases appropriately include the automatic "Contributors" section.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just documentation/live` locally and check that each of the changelogs still appropriately link the GitHub usernames (alternatively, wait for our GitHub actions to render the docs site and use the link below).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
