### PR TITLE
Add a simple script for getting a sanitized commit message

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -882,6 +882,17 @@ jobs:
       - get-image-tag
       - publish-images
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get commit message
+        id: commit
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          PYTHONPATH: ${{ github.workspace }}/automations/python
+        working-directory: automations/python/workflows
+        run: python get_commit_message.py
+
       - name: Deploy staging frontend
         uses: felixp8/dispatch-and-wait@v0.1.0
         with:
@@ -893,7 +904,7 @@ jobs:
             {
               "actor": "${{ github.actor }}",
               "tag": "${{ needs.get-image-tag.outputs.image_tag }}",
-              "run_name": "${{ github.event.head_commit.message }}"
+              "run_name": "${{ steps.commit.outputs.commit_message }}"
             }
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment
@@ -911,6 +922,17 @@ jobs:
       - get-image-tag
       - publish-images
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get commit message
+        id: commit
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          PYTHONPATH: ${{ github.workspace }}/automations/python
+        working-directory: automations/python/workflows
+        run: python get_commit_message.py
+
       - name: Deploy staging API
         uses: felixp8/dispatch-and-wait@v0.1.0
         with:
@@ -922,7 +944,7 @@ jobs:
             {
               "actor": "${{ github.actor }}",
               "tag": "${{ needs.get-image-tag.outputs.image_tag }}",
-              "run_name": "${{ github.event.head_commit.message }}"
+              "run_name": "${{ steps.commit.outputs.commit_message }}"
             }
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment

--- a/automations/python/workflows/get_commit_message.py
+++ b/automations/python/workflows/get_commit_message.py
@@ -1,0 +1,24 @@
+import os
+
+from shared.actions import write_to_github_output
+
+
+def main() -> None:
+    """
+    Get the COMMIT_MESSAGE environment variable and convert it into a single
+    line of text, with quote characters escaped.
+
+    This is necessary because GitHub Actions does not provide any functions for string
+    manipulation and interpolating this wholesale into the JSON client payload
+    will cause the workflow to fail since it's not valid JSON.
+    """
+    commit_message = os.environ["COMMIT_MESSAGE"]
+    # Split newlines
+    message = commit_message.split("\n", 1)[0]
+    # Escape quotes
+    message = message.replace('"', '\\"')
+    write_to_github_output([f"commit_message={message}"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Quick follow up after the merge of #2080 which inadvertently broke staging deployments

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

It appears that the git commit message is interpolated whole-sale into the `run_name` field of the JSON, which was causing problems with parsing. Example:

```json
    "actor": "krysal",
    "tag": "8bc6ab7988d395c5ab8b74a3c11b1a36890fe5d1",
    "run_name": "Check the file type of the thumbnail before passing it to Photon (#2086)
  
  Co-authored-by: Madison Swain-Bowden <bowdenm@spu.edu>
  Co-authored-by: Staci Mullins <63313398+stacimc@users.noreply.github.com>"
  }
```

Since GitHub Actions provides no faculties for doing string manipulation on expressions besides `join` and `toJSON`/`fromJSON`, I've added a small python script which captures only the first line of the commit message and escapes any double quotes.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I'll try to give this a shot by running it on the merged commit that failed previously, if possible.

You can test this by running the following:

```bash
$ COMMIT_MESSAGE='Check the "file" type of the thumbnail before passing it to Photon (#2086)
  "this is a quote!"
  Co-authored-by: Madison Swain-Bowden <bowdenm@spu.edu>
  Co-authored-by: Staci Mullins <63313398+stacimc@users.noreply.github.com>' PYTHONPATH=automations/python/ python automations/python/workflows/get_commit_message.py
```

This should give `commit_message=Check the \"file\" type of the thumbnail before passing it to Photon (#2086)`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
