### PR TITLE
Analytics event: `SUBMIT_SEARCH`

### DIFF
--- a/frontend/src/components/VFourOhFour.vue
+++ b/frontend/src/components/VFourOhFour.vue
@@ -45,6 +45,7 @@ import { useMeta, useRouter } from "@nuxtjs/composition-api"
 
 import { useSearchStore } from "~/stores/search"
 
+import { useAnalytics } from "~/composables/use-analytics"
 import { ALL_MEDIA } from "~/constants/media"
 
 import VLink from "~/components/VLink.vue"
@@ -65,8 +66,13 @@ export default defineComponent({
     const searchStore = useSearchStore()
     const router = useRouter()
 
+    const { sendCustomEvent } = useAnalytics()
+
     const handleSearch = (searchTerm) => {
-      if (!searchTerm) return
+      sendCustomEvent("SUBMIT_SEARCH", {
+        searchType: ALL_MEDIA,
+        query: searchTerm,
+      })
 
       router.push(searchStore.updateSearchPath({ type: ALL_MEDIA, searchTerm }))
     }

--- a/frontend/src/components/VHeader/VHeaderDesktop.vue
+++ b/frontend/src/components/VHeader/VHeaderDesktop.vue
@@ -54,6 +54,7 @@ import { useUiStore } from "~/stores/ui"
 
 import { IsHeaderScrolledKey, IsSidebarVisibleKey } from "~/types/provides"
 
+import { useAnalytics } from "~/composables/use-analytics"
 import { useSearch } from "~/composables/use-search"
 
 import { ensureFocus } from "~/utils/reakit-utils/focus"
@@ -89,7 +90,10 @@ export default defineComponent({
 
     const isFetching = computed(() => mediaStore.fetchState.isFetching)
 
-    const { updateSearchState, searchTerm, searchStatus } = useSearch()
+    const { sendCustomEvent } = useAnalytics()
+
+    const { updateSearchState, searchTerm, searchStatus } =
+      useSearch(sendCustomEvent)
 
     const clearSearchTerm = () => {
       searchTerm.value = ""

--- a/frontend/src/components/VHeader/VHeaderMobile/VHeaderMobile.vue
+++ b/frontend/src/components/VHeader/VHeaderMobile/VHeaderMobile.vue
@@ -121,6 +121,7 @@ import { keycodes } from "~/constants/key-codes"
 
 import { IsHeaderScrolledKey } from "~/types/provides"
 
+import { useAnalytics } from "~/composables/use-analytics"
 import { useDialogControl } from "~/composables/use-dialog-control"
 import { useSearch } from "~/composables/use-search"
 
@@ -163,7 +164,10 @@ export default defineComponent({
 
     const isFetching = computed(() => mediaStore.fetchState.isFetching)
 
-    const { updateSearchState, searchTerm, searchStatus } = useSearch()
+    const { sendCustomEvent } = useAnalytics()
+
+    const { updateSearchState, searchTerm, searchStatus } =
+      useSearch(sendCustomEvent)
 
     const handleSearch = async () => {
       window.scrollTo({ top: 0, left: 0, behavior: "auto" })

--- a/frontend/src/composables/use-search.ts
+++ b/frontend/src/composables/use-search.ts
@@ -3,10 +3,14 @@ import { useRouter } from "@nuxtjs/composition-api"
 
 import { useSearchStore } from "~/stores/search"
 import { useMediaStore } from "~/stores/media"
+
 import { useI18nResultsCount } from "~/composables/use-i18n-utilities"
 import { useMatchSearchRoutes } from "~/composables/use-match-routes"
+import type { EventName, Events } from "~/types/analytics"
 
-export const useSearch = () => {
+export const useSearch = (
+  sendCustomEvent: <T extends EventName>(name: T, payload: Events[T]) => void
+) => {
   const mediaStore = useMediaStore()
   const searchStore = useSearchStore()
   const router = useRouter()
@@ -55,6 +59,11 @@ export const useSearch = () => {
   const updateSearchState = () => {
     if (searchTerm.value === "") return
     if (!searchTermChanged.value && isSearchRoute.value) return
+
+    sendCustomEvent("SUBMIT_SEARCH", {
+      searchType: searchStore.searchType,
+      query: searchTerm.value,
+    })
 
     const searchPath = searchStore.updateSearchPath({
       searchTerm: searchTerm.value,

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -16,26 +16,30 @@
 </template>
 
 <script lang="ts">
-import { computed, onMounted, ref } from "vue"
+import { computed, defineComponent, onMounted, ref } from "vue"
 
-import { defineComponent, useMeta, useRouter } from "@nuxtjs/composition-api"
+import { useMeta, useRouter } from "@nuxtjs/composition-api"
 
 import {
   ALL_MEDIA,
   SupportedSearchType,
   supportedSearchTypes,
 } from "~/constants/media"
+import { useAnalytics } from "~/composables/use-analytics"
 import { useLayout } from "~/composables/use-layout"
 
 import { useMediaStore } from "~/stores/media"
 import { useSearchStore } from "~/stores/search"
 import { useUiStore } from "~/stores/ui"
 
+import VHomeGallery from "~/components/VHomeGallery/VHomeGallery.vue"
+import VHomepageContent from "~/components/VHomepageContent.vue"
+
 export default defineComponent({
   name: "HomePage",
   components: {
-    VHomeGallery: () => import("~/components/VHomeGallery/VHomeGallery.vue"),
-    VHomepageContent: () => import("~/components/VHomepageContent.vue"),
+    VHomeGallery,
+    VHomepageContent,
   },
   setup() {
     const router = useRouter()
@@ -43,6 +47,8 @@ export default defineComponent({
     const mediaStore = useMediaStore()
     const searchStore = useSearchStore()
     const uiStore = useUiStore()
+
+    const { sendCustomEvent } = useAnalytics()
 
     useMeta({
       meta: [
@@ -73,7 +79,10 @@ export default defineComponent({
     }
 
     const handleSearch = (searchTerm: string) => {
-      if (!searchTerm) return
+      sendCustomEvent("SUBMIT_SEARCH", {
+        searchType: searchType.value,
+        query: searchTerm,
+      })
 
       router.push(
         searchStore.updateSearchPath({

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -14,6 +14,20 @@ import type { ReportReason } from "~/constants/content-report"
  */
 export type Events = {
   /**
+   * Description: A search performed by the user
+   * Questions:
+   *   - How many searches do we serve per day/month/year?
+   *   - What are the most popular searches in Openverse?
+   *   - Which media types are the most popular?
+   *   - Do most users search from the homepage, or internal searchbar?
+   */
+  SUBMIT_SEARCH: {
+    /** The media type being searched */
+    searchType: SearchType
+    /** The search term */
+    query: string
+  }
+  /**
    * Description: The user clicks on one of the images in the gallery on the homepage.
    * Questions:
    * - Do users know homepage images are links?

--- a/frontend/test/unit/specs/components/VHeader/v-header-desktop.spec.js
+++ b/frontend/test/unit/specs/components/VHeader/v-header-desktop.spec.js
@@ -1,0 +1,53 @@
+import { fireEvent } from "@testing-library/vue"
+
+import { ref } from "vue"
+
+import { render } from "~~/test/unit/test-utils/render"
+
+import { useAnalytics } from "~/composables/use-analytics"
+
+import { IsHeaderScrolledKey, IsSidebarVisibleKey } from "~/types/provides"
+
+import VHeaderDesktop from "~/components/VHeader/VHeaderDesktop.vue"
+
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(),
+}))
+jest.mock("~/composables/use-match-routes", () => ({
+  // mocking `Ref<boolean>` as `{ value: boolean }`
+  useMatchSearchRoutes: jest.fn(() => ({ matches: { value: true } })),
+}))
+
+describe("VHeaderDesktop", () => {
+  const routerMock = { push: jest.fn() }
+  const sendCustomEventMock = jest.fn()
+  window.scrollTo = jest.fn()
+
+  let options = null
+
+  beforeEach(() => {
+    useAnalytics.mockImplementation(() => ({
+      sendCustomEvent: sendCustomEventMock,
+    }))
+    options = {
+      mocks: { $router: routerMock },
+      stubs: ["ClientOnly"],
+      provide: {
+        [IsHeaderScrolledKey]: ref(false),
+        [IsSidebarVisibleKey]: ref(false),
+      },
+    }
+  })
+  it("sends SUBMIT_SEARCH analytics event when submitted", async () => {
+    const screen = render(VHeaderDesktop, options)
+    const input = screen.getByRole("combobox")
+
+    await fireEvent.update(input, "cat")
+    await fireEvent.submit(input)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("SUBMIT_SEARCH", {
+      query: "cat",
+      searchType: "all",
+    })
+  })
+})

--- a/frontend/test/unit/specs/components/VHeader/v-header-mobile.spec.js
+++ b/frontend/test/unit/specs/components/VHeader/v-header-mobile.spec.js
@@ -1,0 +1,52 @@
+import { fireEvent } from "@testing-library/vue"
+import { ref } from "vue"
+
+import { render } from "~~/test/unit/test-utils/render"
+
+import { useAnalytics } from "~/composables/use-analytics"
+
+import { IsHeaderScrolledKey, IsSidebarVisibleKey } from "~/types/provides"
+
+import VHeaderMobile from "~/components/VHeader/VHeaderMobile/VHeaderMobile.vue"
+
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(),
+}))
+jest.mock("~/composables/use-match-routes", () => ({
+  // mocking `Ref<boolean>` as `{ value: boolean }`
+  useMatchSearchRoutes: jest.fn(() => ({ matches: { value: true } })),
+}))
+
+describe("VHeaderMobile", () => {
+  const routerMock = { push: jest.fn() }
+  const sendCustomEventMock = jest.fn()
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
+  window.scrollTo = jest.fn()
+
+  let options = null
+
+  beforeEach(() => {
+    options = {
+      mocks: { $router: routerMock },
+      stubs: ["ClientOnly"],
+      provide: {
+        [IsHeaderScrolledKey]: ref(false),
+        [IsSidebarVisibleKey]: ref(false),
+      },
+    }
+  })
+  it("sends SUBMIT_SEARCH analytics event when submitted", async () => {
+    const screen = render(VHeaderMobile, options)
+    const input = screen.getByRole("combobox")
+
+    await fireEvent.update(input, "cat")
+    await fireEvent.submit(input)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("SUBMIT_SEARCH", {
+      query: "cat",
+      searchType: "all",
+    })
+  })
+})

--- a/frontend/test/unit/specs/components/four-oh-four.spec.js
+++ b/frontend/test/unit/specs/components/four-oh-four.spec.js
@@ -1,0 +1,37 @@
+import { fireEvent, screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
+
+import { useAnalytics } from "~/composables/use-analytics"
+
+import VFourOhFour from "~/components/VFourOhFour.vue"
+
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(),
+}))
+describe("VFourOhFour", () => {
+  let options
+  const sendCustomEventMock = jest.fn()
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
+  const query = "cat"
+  beforeEach(() => {
+    options = {
+      mocks: { $router: { push: jest.fn() } },
+    }
+  })
+
+  it("should send SUBMIT_SEARCH analytics event when search submitted", async () => {
+    render(VFourOhFour, options)
+
+    const input = screen.getByRole("searchbox")
+    await fireEvent.update(input, query)
+    await fireEvent.submit(input)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("SUBMIT_SEARCH", {
+      query,
+      searchType: "all",
+    })
+  })
+})

--- a/frontend/test/unit/specs/pages/index-page.spec.js
+++ b/frontend/test/unit/specs/pages/index-page.spec.js
@@ -1,0 +1,59 @@
+import { fireEvent, screen } from "@testing-library/vue"
+
+import { render } from "~~/test/unit/test-utils/render"
+
+import IndexPage from "~/pages/index.vue"
+
+import { useAnalytics } from "~/composables/use-analytics"
+
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: jest.fn(),
+}))
+describe("IndexPage", () => {
+  let options
+  const sendCustomEventMock = jest.fn()
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
+  const query = "cat"
+  beforeEach(() => {
+    options = {
+      mocks: { $router: { push: jest.fn() } },
+      stubs: ["VHomeGallery"],
+    }
+  })
+
+  it("should send SUBMIT_SEARCH analytics event when search submitted", async () => {
+    render(IndexPage, options)
+
+    const input = screen.getByRole("searchbox")
+    await fireEvent.update(input, query)
+    await fireEvent.submit(input)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("SUBMIT_SEARCH", {
+      query,
+      searchType: "all",
+    })
+  })
+
+  it("should send SUBMIT_SEARCH analytics event with correct mediaType when search submitted", async () => {
+    render(IndexPage, options)
+
+    const button = screen.getByRole("button", {
+      name: "Select a content type: All content",
+    })
+    await fireEvent.click(button)
+
+    const audio = screen.getByRole("radio", { name: "Audio" })
+    await fireEvent.click(audio)
+
+    const input = screen.getByRole("searchbox")
+    await fireEvent.update(input, query)
+    await fireEvent.submit(input)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("SUBMIT_SEARCH", {
+      query,
+      searchType: "audio",
+    })
+  })
+})


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1068 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a `SUBMIT_SEARCH` analytics event that is fired when the search is submitted from the homepage, the search bar in the search page header, and the 404 page.

~This PR also simplifies the `VSearchButton` component removing the version that used a text label, and using it in both the SearchBar and the StandaloneSearchBar (which is used on 404 and home pages, and does not remove the search text when the server-rendered page is hydrated).~ **Edit:** Extracted to standalone PR #2148.

The unused input sizes (standalone/large) are also removed.
Home page directly imports the child components instead of lazy-loading them, because they are always loaded anyways.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Set up analytics (`just frontend/up`, `just frontend/init`) and run the app (`just frontend/run dev`).
Open the app (localhost:8443) and the analytics server (http://0.0.0.0:50288/).
Try executing searches from all three places in the description, and see that the Custom events section[^1] shows the events correctly.

[^1]: https://docs.openverse.org/frontend/guides/analytics.html#custom-events

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
