### PR TITLE
Allow feature flags to use `sessionStorage` and ignore `ff_` query params

### DIFF
--- a/documentation/frontend/reference/feature_flags.md
+++ b/documentation/frontend/reference/feature_flags.md
@@ -101,6 +101,20 @@ page.
 should [populate `en.json5`](#key-title) if the feature is switchable and
 visible to the user.
 
+##### `storage`
+
+This determines whether the feature is stored in a cookie (`'cookie'`) or in
+`sessionStorage` (`'session'`). By default all feature flags are stored in
+cookies but certain preferences that should only be applicable for a single
+session can be stored in `sessionStorage` instead.
+
+##### `supportsQuery`
+
+By default, all switchable flags can be set per-request using the `ff_<flag>`
+query parameters. This is useful for testing and debugging. However, some flags
+dealing with sensitivity can be used to make malicious URLs, so they can avoid
+being set via query parameters by setting this to `false`.
+
 ### `groups`
 
 This setting pertains to how feature flags can serve as user-level preferences.

--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -6,7 +6,8 @@
         "production": "disabled"
       },
       "description": "Mark 50% of results as mature to test content safety.",
-      "defaultState": "off"
+      "defaultState": "off",
+      "storage": "cookie"
     },
     "external_sources": {
       "status": {
@@ -14,14 +15,16 @@
         "production": "disabled"
       },
       "description": "Toggle the external sources in the header's search type switcher.",
-      "defaultState": "off"
+      "defaultState": "off",
+      "storage": "cookie"
     },
     "analytics": {
       "status": {
         "staging": "switchable",
         "production": "disabled"
       },
-      "description": "Record custom events and page views."
+      "description": "Record custom events and page views.",
+      "storage": "cookie"
     }
   },
   "groups": [

--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -25,6 +25,22 @@
       },
       "description": "Record custom events and page views.",
       "storage": "cookie"
+    },
+    "sensitive_content": {
+      "status": {
+        "staging": "switchable",
+        "production": "disabled"
+      },
+      "description": "Turn on sensitive content fetching and blurring.",
+      "defaultState": "off",
+      "storage": "cookie"
+    },
+    "fetch_sensitive": {
+      "status": "switchable",
+      "defaultState": "off",
+      "description": "Show results marked as sensitive in the results area.",
+      "supportsQuery": false,
+      "storage": "session"
     }
   },
   "groups": [

--- a/frontend/src/constants/feature-flag.ts
+++ b/frontend/src/constants/feature-flag.ts
@@ -12,3 +12,10 @@ export const OFF = "off"
 export const FEATURE_STATES = [ON, OFF] as const
 
 export type FeatureState = typeof FEATURE_STATES[number]
+
+export const SESSION = "session"
+export const COOKIE = "cookie"
+
+export const STORAGES = [SESSION, COOKIE] as const
+
+export type Storage = typeof STORAGES[number]

--- a/frontend/src/layouts/content-layout.vue
+++ b/frontend/src/layouts/content-layout.vue
@@ -54,6 +54,7 @@ import { useLayout } from "~/composables/use-layout"
 
 import { useUiStore } from "~/stores/ui"
 import { useSearchStore } from "~/stores/search"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 import { IsHeaderScrolledKey, IsSidebarVisibleKey } from "~/types/provides"
 
@@ -86,6 +87,11 @@ export default defineComponent({
     const { app } = useContext()
     const uiStore = useUiStore()
     const searchStore = useSearchStore()
+
+    const featureStore = useFeatureFlagStore()
+    onMounted(() => {
+      featureStore.initFromSession()
+    })
 
     const { updateBreakpoint } = useLayout()
 

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -22,6 +22,7 @@ import { PortalTarget as VTeleportTarget } from "portal-vue"
 import { useLayout } from "~/composables/use-layout"
 
 import { useUiStore } from "~/stores/ui"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 import VBanners from "~/components/VBanner/VBanners.vue"
 import VFooter from "~/components/VFooter/VFooter.vue"
@@ -44,6 +45,11 @@ export default defineComponent({
   },
   setup() {
     const uiStore = useUiStore()
+
+    const featureStore = useFeatureFlagStore()
+    onMounted(() => {
+      featureStore.initFromSession()
+    })
 
     const { updateBreakpoint } = useLayout()
 

--- a/frontend/src/pages/preferences.vue
+++ b/frontend/src/pages/preferences.vue
@@ -117,7 +117,8 @@ export default defineComponent({
       checked: boolean
     }) => {
       featureFlagStore.toggleFeature(name, checked ? ON : OFF)
-      $cookies.set("features", featureFlagStore.flagStateMap)
+      featureFlagStore.writeToCookies($cookies)
+      featureFlagStore.writeToSession()
     }
 
     return {

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -188,8 +188,11 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
           // TODO: type `FlagName` should be inferred by TS
           const flagName = name.substring(3) as FlagName
           const flag = this.flags[flagName]
-          if (getFlagStatus(flag) === SWITCHABLE) {
-            flag.preferredState = state
+          if (
+            getFlagStatus(flag) === SWITCHABLE &&
+            flag.supportsQuery !== false
+          ) {
+            Vue.set(flag, "preferredState", state)
           }
         })
     },

--- a/frontend/src/types/feature-flag.ts
+++ b/frontend/src/types/feature-flag.ts
@@ -1,4 +1,8 @@
-import type { FeatureState, FlagStatus } from "~/constants/feature-flag"
+import type {
+  FeatureState,
+  FlagStatus,
+  Storage,
+} from "~/constants/feature-flag"
 import type { DeployEnv } from "~/constants/deploy-env"
 
 export interface FeatureFlag {
@@ -8,4 +12,6 @@ export interface FeatureFlag {
 
   defaultState?: FeatureState
   preferredState?: FeatureState // only set for switchable flag with known preference
+
+  storage: Storage
 }

--- a/frontend/src/types/feature-flag.ts
+++ b/frontend/src/types/feature-flag.ts
@@ -13,5 +13,7 @@ export interface FeatureFlag {
   defaultState?: FeatureState
   preferredState?: FeatureState // only set for switchable flag with known preference
 
+  supportsQuery?: boolean // default: true
+
   storage: Storage
 }


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR is a PoC for #2118 that demonstrates feature flags that can be backed by session-storage. It also allows feature flags to ignore `ff_` query params when reading from them can open the possibility for malicious activity.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

### Session storage

0. Check out the PR and run the dev server.
1. Visit `/preferences`.
2. Flip the `fetch_sensitive` flag to on.
3. Navigate around the site and come back to `/preferences`.
4. See that the flag is still on.
5. Close the tab and open a new one.
6. Visit `/preferences`.
7. See that the flag is off now.

### No `ff_` query

0. Check out the PR and run the dev server.
1. Visit `/preferences`. Ensure `sensitive_content` and `fetch_sensitive` are both off.
2. Visit `/preferences?ff_sensitive_content=on`. See that the switch is flipped on.
3. Visit `/preferences?ff_fetch_sensitive=on`. See that the switch is still off.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
