### PR TITLE
Fix various issues that existed in the rotate_db_snapshots DAG

### DIFF
--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -669,12 +669,10 @@ It runs on Saturdays at 00:00 UTC in order to happen before the data refresh.
 The DAG will automatically delete the oldest snapshots when more snaphots exist
 than it is configured to retain.
 
-Relies on three variables:
+Requires two variables:
 
-`CATALOG_RDS_DB_IDENTIFIER`: (Required) The "DBIdentifier" of the RDS DB
-instance. `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: (Required) How many historical
-snapshots to retain. `CATALOG_RDS_REGION`: (Optional) The region of the RDS DB
-instance. Defaults to `us-east-1`.
+`CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
+`CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
 
 ## `science_museum_workflow`
 

--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -669,10 +669,12 @@ It runs on Saturdays at 00:00 UTC in order to happen before the data refresh.
 The DAG will automatically delete the oldest snapshots when more snaphots exist
 than it is configured to retain.
 
-Requires two variables:
+Relies on three variables:
 
-`AIRFLOW_RDS_ARN`: The ARN of the RDS DB instance that needs snapshots.
-`AIRFLOW_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
+`CATALOG_RDS_DB_IDENTIFIER`: (Required) The "DBIdentifier" of the RDS DB
+instance. `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: (Required) How many historical
+snapshots to retain. `CATALOG_RDS_REGION`: (Optional) The region of the RDS DB
+instance. Defaults to `us-east-1`.
 
 ## `science_museum_workflow`
 

--- a/catalog/dags/common/constants.py
+++ b/catalog/dags/common/constants.py
@@ -32,3 +32,4 @@ XCOM_PULL_TEMPLATE = "{{{{ ti.xcom_pull(task_ids='{}', key='{}') }}}}"
 POSTGRES_CONN_ID = os.getenv("OPENLEDGER_CONN_ID", "postgres_openledger_testing")
 OPENLEDGER_API_CONN_ID = os.getenv("OPENLEDGER_API_CONN_ID", "postgres_openledger_api")
 AWS_CONN_ID = os.getenv("AWS_CONN_ID", "aws_conn_id")
+AWS_RDS_CONN_ID = os.environ.get("AWS_RDS_CONN_ID", AWS_CONN_ID)

--- a/catalog/dags/database/staging_database_restore/constants.py
+++ b/catalog/dags/database/staging_database_restore/constants.py
@@ -1,8 +1,3 @@
-import os
-
-from common.constants import AWS_CONN_ID
-
-
 _ID_FORMAT = "{}-openverse-db"
 
 DAG_ID = "staging_database_restore"
@@ -14,6 +9,5 @@ OLD_IDENTIFIER = _ID_FORMAT.format("dev-old")
 SAFE_TO_MUTATE = {STAGING_IDENTIFIER, TEMP_IDENTIFIER, OLD_IDENTIFIER}
 
 SKIP_VARIABLE = "SKIP_STAGING_DATABASE_RESTORE"
-AWS_RDS_CONN_ID = os.environ.get("AWS_RDS_CONN_ID", AWS_CONN_ID)
 SLACK_USERNAME = "Staging Database Restore"
 SLACK_ICON = ":database-pink:"

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -10,6 +10,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from common import slack
+from common.constants import AWS_RDS_CONN_ID
 from database.staging_database_restore import constants
 from database.staging_database_restore.utils import (
     ensure_mutate_allowed,
@@ -170,7 +171,7 @@ def make_rds_sensor(task_id: str, db_identifier: str, retries: int = 0) -> RdsDb
         task_id=task_id,
         db_identifier=db_identifier,
         target_statuses=["available"],
-        aws_conn_id=constants.AWS_RDS_CONN_ID,
+        aws_conn_id=AWS_RDS_CONN_ID,
         mode="reschedule",
         timeout=60 * 60,  # 1 hour
         retries=retries,

--- a/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
@@ -24,7 +24,7 @@ from airflow.providers.amazon.aws.operators.rds import RdsDeleteDbInstanceOperat
 from airflow.providers.amazon.aws.sensors.rds import RdsSnapshotExistenceSensor
 from airflow.utils.trigger_rule import TriggerRule
 
-from common.constants import DAG_DEFAULT_ARGS
+from common.constants import AWS_RDS_CONN_ID, DAG_DEFAULT_ARGS
 from database.staging_database_restore import constants
 from database.staging_database_restore.staging_database_restore import (
     get_latest_prod_snapshot,
@@ -66,7 +66,7 @@ def restore_staging_database():
         task_id="ensure_snapshot_ready",
         db_type="instance",
         db_snapshot_identifier=latest_snapshot,
-        aws_conn_id=constants.AWS_RDS_CONN_ID,
+        aws_conn_id=AWS_RDS_CONN_ID,
         mode="reschedule",
         timeout=60 * 60 * 4,  # 4 hours
     )
@@ -118,7 +118,7 @@ def restore_staging_database():
         task_id="delete_old",
         db_instance_identifier=constants.OLD_IDENTIFIER,
         rds_kwargs={"SkipFinalSnapshot": True, "DeleteAutomatedBackups": False},
-        aws_conn_id=constants.AWS_RDS_CONN_ID,
+        aws_conn_id=AWS_RDS_CONN_ID,
         wait_for_completion=True,
     )
 

--- a/catalog/dags/database/staging_database_restore/utils.py
+++ b/catalog/dags/database/staging_database_restore/utils.py
@@ -2,6 +2,7 @@ import functools
 
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 
+from common.constants import AWS_RDS_CONN_ID
 from database.staging_database_restore import constants
 
 
@@ -14,9 +15,7 @@ def setup_rds_hook(func: callable) -> callable:
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        rds_hook = kwargs.pop("rds_hook", None) or RdsHook(
-            aws_conn_id=constants.AWS_RDS_CONN_ID
-        )
+        rds_hook = kwargs.pop("rds_hook", None) or RdsHook(aws_conn_id=AWS_RDS_CONN_ID)
         return func(*args, **kwargs, rds_hook=rds_hook)
 
     return wrapped

--- a/catalog/dags/maintenance/rotate_db_snapshots.py
+++ b/catalog/dags/maintenance/rotate_db_snapshots.py
@@ -108,6 +108,7 @@ def rotate_db_snapshots():
         # This is the default for ``target_statuses`` but making it explicit is clearer
         target_statuses=["available"],
         aws_conn_id=AWS_RDS_CONN_ID,
+        mode="reschedule",
     )
 
     (

--- a/catalog/dags/maintenance/rotate_db_snapshots.py
+++ b/catalog/dags/maintenance/rotate_db_snapshots.py
@@ -9,11 +9,12 @@ It runs on Saturdays at 00:00 UTC in order to happen before the data refresh.
 The DAG will automatically delete the oldest snapshots when more snaphots
 exist than it is configured to retain.
 
-Requires three variables:
+Relies on three variables:
 
-`CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
-`CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
-`CATALOG_RDS_REGION`: The region of the RDS DB instance.
+`CATALOG_RDS_DB_IDENTIFIER`: (Required) The "DBIdentifier" of the RDS DB instance.
+`CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: (Required) How many historical snapshots to retain.
+`CATALOG_RDS_REGION`: (Optional) The region of the RDS DB instance. Defaults to
+`us-east-1`.
 """
 
 import logging

--- a/catalog/tests/dags/maintenance/test_rotate_db_snapshots.py
+++ b/catalog/tests/dags/maintenance/test_rotate_db_snapshots.py
@@ -2,26 +2,28 @@ import random
 from datetime import datetime, timedelta
 from unittest import mock
 
-import boto3
 import pytest
 
-from maintenance.rotate_db_snapshots import delete_previous_snapshots
+from common.constants import AWS_RDS_CONN_ID
+from maintenance.rotate_db_snapshots import (
+    AIRFLOW_MANAGED_SNAPSHOT_ID_PREFIX,
+    delete_previous_snapshots,
+)
 
 
 @pytest.fixture
-def boto_client(monkeypatch):
-    get_client = mock.MagicMock()
+def rds_hook(monkeypatch):
+    RdsHook = mock.MagicMock()
 
-    monkeypatch.setattr(boto3, "client", get_client)
-    return get_client
+    monkeypatch.setattr("maintenance.rotate_db_snapshots.RdsHook", RdsHook)
+    return RdsHook
 
 
 @pytest.fixture
-def rds_client(boto_client):
-    rds = mock.MagicMock()
-
-    boto_client.return_value = rds
-    return rds
+def hook(rds_hook):
+    hook_instance = mock.MagicMock()
+    rds_hook.return_value = hook_instance
+    return hook_instance
 
 
 def _make_snapshots(count: int, shuffle=False) -> dict:
@@ -31,8 +33,8 @@ def _make_snapshots(count: int, shuffle=False) -> dict:
         date = date - timedelta(days=1)
         snaps.append(
             {
-                "DBSnapshotIdentifier": _id,
-                "SnapshotCreateTime": date.isoformat(),
+                "DBSnapshotIdentifier": f"{AIRFLOW_MANAGED_SNAPSHOT_ID_PREFIX}-{_id}",
+                "SnapshotCreateTime": date,  # boto3 returns datetime objects
             }
         )
     return {"DBSnapshots": snaps}
@@ -41,7 +43,7 @@ def _make_snapshots(count: int, shuffle=False) -> dict:
 @pytest.mark.parametrize(
     ("snapshots", "snapshots_to_retain"),
     (
-        # Less than 7
+        # Less than the number we want to keep
         (_make_snapshots(1), 2),
         (_make_snapshots(1), 5),
         # Exactly the number we want to keep
@@ -50,21 +52,21 @@ def _make_snapshots(count: int, shuffle=False) -> dict:
     ),
 )
 def test_delete_previous_snapshots_no_snapshots_to_delete(
-    snapshots, snapshots_to_retain, rds_client
+    snapshots, snapshots_to_retain, hook
 ):
-    rds_client.describe_db_snapshots.return_value = snapshots
+    hook.conn.describe_db_snapshots.return_value = snapshots
     delete_previous_snapshots.function("fake_arn", snapshots_to_retain, "fake_region")
-    rds_client.delete_db_snapshot.assert_not_called()
+    hook.conn.delete_db_snapshot.assert_not_called()
 
 
-def test_delete_previous_snapshots(rds_client):
+def test_delete_previous_snapshots(hook):
     snapshots_to_retain = 6
     snapshots = _make_snapshots(10)
     snapshots_to_delete = snapshots["DBSnapshots"][snapshots_to_retain:]
-    rds_client.describe_db_snapshots.return_value = snapshots
+    hook.conn.describe_db_snapshots.return_value = snapshots
 
     delete_previous_snapshots.function("fake_arn", snapshots_to_retain, "fake_region")
-    rds_client.delete_db_snapshot.assert_has_calls(
+    hook.conn.delete_db_snapshot.assert_has_calls(
         [
             mock.call(DBSnapshotIdentifier=snapshot["DBSnapshotIdentifier"])
             for snapshot in snapshots_to_delete
@@ -72,7 +74,22 @@ def test_delete_previous_snapshots(rds_client):
     )
 
 
-def test_sorts_snapshots(rds_client):
+def test_delete_previous_snapshots_ignores_non_airflow_managed_ones(hook):
+    snapshots_to_retain = 2
+    snapshots = _make_snapshots(4)
+    # Set the last one to an unmanaged snapshot leaving 1 to delete
+    snapshots["DBSnapshots"][-1]["DBSnapshotIdentifier"] = "not-managed-by-airflow-123"
+    snapshot_to_delete = snapshots["DBSnapshots"][-2]
+
+    hook.conn.describe_db_snapshots.return_value = snapshots
+
+    delete_previous_snapshots.function("fake_arn", snapshots_to_retain, "fake_region")
+    hook.conn.delete_db_snapshot.assert_has_calls(
+        [mock.call(DBSnapshotIdentifier=snapshot_to_delete["DBSnapshotIdentifier"])]
+    )
+
+
+def test_sorts_snapshots(hook):
     """
     As far as we can tell the API does return them pre-sorted but it isn't documented
     so just to be sure we'll sort them anyway.
@@ -84,9 +101,9 @@ def test_sorts_snapshots(rds_client):
     # shuffle the snapshots to mimic an unstable API return order
     random.shuffle(snapshots["DBSnapshots"])
 
-    rds_client.describe_db_snapshots.return_value = snapshots
+    hook.conn.describe_db_snapshots.return_value = snapshots
     delete_previous_snapshots.function("fake_arn", snapshots_to_retain, "fake_region")
-    rds_client.delete_db_snapshot.assert_has_calls(
+    hook.conn.delete_db_snapshot.assert_has_calls(
         [
             mock.call(DBSnapshotIdentifier=snapshot["DBSnapshotIdentifier"])
             for snapshot in snapshots_to_delete
@@ -94,9 +111,9 @@ def test_sorts_snapshots(rds_client):
     )
 
 
-def test_instantiates_rds_client_with_region(boto_client, rds_client):
-    rds_client.describe_db_snapshots.return_value = _make_snapshots(0)
+def test_instantiates_rds_hook_with_region(rds_hook, hook):
+    hook.conn.describe_db_snapshots.return_value = _make_snapshots(0)
 
     region = "fake_region"
     delete_previous_snapshots.function("fake_arn", 0, region)
-    boto_client.assert_called_once_with("rds", region_name=region)
+    rds_hook.assert_called_once_with(region_name=region, aws_conn_id=AWS_RDS_CONN_ID)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Originally this started as a PR to fix `hook_params` not being templated in the AWS operators, but it turned into much more.

Original issue being fixed: If you have access to production Airflow, here are the logs:

https://airflow.openverse.engineering/dags/rotate_db_snapshots/grid?search=rotate_db_snapshots&dag_run_id=manual__2023-05-22T03%3A56%3A33.707669%2B00%3A00&task_id=create_snapshot&tab=logs

Log output copied:

```
[2023-05-22, 03:56:38 UTC] {taskinstance.py:1847} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/operators/rds.py", line 103, in execute
    create_instance_snap = self.hook.conn.create_db_snapshot(
  File "/usr/local/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/hooks/base_aws.py", line 649, in conn
    return self.get_client_type(region_name=self.region_name)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/hooks/base_aws.py", line 614, in get_client_type
    return session.client(
  File "/home/airflow/.local/lib/python3.10/site-packages/boto3/session.py", line 299, in client
    return self._session.create_client(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/session.py", line 918, in create_client
    region_name = self._resolve_region_name(region_name, config)
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/session.py", line 1002, in _resolve_region_name
    validate_region_name(region_name)
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/utils.py", line 1272, in validate_region_name
    raise InvalidRegionError(region_name=region_name)
botocore.exceptions.InvalidRegionError: Provided region_name '{{ var.value.AIRFLOW_RDS_REGION }}' doesn't match a supported format.
[2023-05-22, 03:56:38 UTC] {taskinstance.py:1368} INFO - Marking task as FAILED. dag_id=rotate_db_snapshots, task_id=create_snapshot, execution_date=20230522T035633, start_date=20230522T035637, end_date=20230522T035638
```

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Summary of fixes:

- Pull region variable from `Variable.get` to work around `hook_params` not being a templated field on the AWS operators
- Use the RdsHook in the Python operator to delete previous snapshots. This is mostly to make it easier to use the `AWS_RDS_CONN_ID` everywhere in this DAG.
- As above, use AWS_RDS_CONN_ID everywhere (to enable local testing)
- Remove unnecessary datetime cast (boto3 already returns datetime objects)
- Be more selective about which snapshots get deleted: do not try to delete RDS automated snapshots (RDS does not allow them to be manually managed) and use a more specific prefix when creating snapshots in the DAG so we can select only snapshots created by the DAG to delete.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the DAG locally against the staging API database by setting `CATALOG_RDS_DB_IDENTIFIER` to `dev-openverse-db`. Create a new AWS connection via the Airflow UI named `aws_rds_conn_id`. Set `CATALOG_RDS_SNAPSHOTS_TO_RETAIN` to 2 and check against the RDS snapshots dashboard here: https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#database:id=dev-openverse-db;is-cluster=false;tab=maintenance-and-backups

You should see a new snapshot get created. While the DAG waits for the snapshot to become available, you'll see an additional snapshot in the list with the prefix from the DAG. After the snapshot becomes available, you should see the oldest of the previously existing snapshots get deleted.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
