### PR TITLE
Decode cached file type for thumbnails

### DIFF
--- a/api/api/utils/photon.py
+++ b/api/api/utils/photon.py
@@ -56,6 +56,7 @@ def check_image_type(image_url: str, media_obj) -> None:
     if not ext:
         # If the extension is not present in the URL, try to get it from the redis cache
         ext = cache.get(key)
+        ext = ext.decode("utf-8") if ext else None
 
     if not ext:
         # If the extension is still not present, try getting it from the content type


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes an issue identified by @obulat in which cached types are not taken correctly as Redis returns them not as strings but as binaries, `b'jpeg'`, causing Jamendo thumbnails to fail. Look for example at https://api.openverse.engineering/v1/audio/70fe3934-ac2b-4c15-bd8a-c6912500f07a/thumb/

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Here I decode the cached value (if exists) before comparing it with Photon's allowed types.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Similar to instructions in #2086, add this row to your sample_data/sample_image.csv, run `just api/recreate` and visit http://localhost:50280/v1/images/aeeaaff0-1802-495f-b49e-b288d54fa167/thumb/ several times to see if it works.

```
aeeaaff0-1802-495f-b49e-b288d54fa167,2016-11-21 19:08:53.755535+00,2018-09-11 23:38:56.523813+00,provider_api,rijksmuseum,rijksmuseum,569c6833-b521-4b01-96bc-11cb241c7e33,https://www.rijksmuseum.nl/en/collection/RP-P-OB-55.291,https://lh3.ggpht.com/ErHoLWKSjuAhKzjPY-EfSkvlXbd9ec_uQICjJ1ygXLwj1x8oaSoNRL2Z9tE1gDjgWiMim71Gvd_InaEEX8WqafV-qf0=s0,,3960,3369,,cc0,1.0,Abraham Danielsz. Hondius,,"Leeuw en slang in gevecht, Abraham Daniëlsz. Hondius, 1672","{""license_url"": ""https://creativecommons.org/publicdomain/zero/1.0/"",""raw_license_url"": null}",,,2016-11-29 22:08:15.491458+00,False,,,
```

I'm not sure how to add a unit test for this at the moment but I'm pushing the fix still so we can decide together. Many more thumbnails will fail if this is not fixed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
