### PR TITLE
Make analytics switchable in production

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -19,10 +19,8 @@
       "storage": "cookie"
     },
     "analytics": {
-      "status": {
-        "staging": "switchable",
-        "production": "disabled"
-      },
+      "status": "switchable",
+      "defaultState": "off",
       "description": "Record custom events and page views.",
       "storage": "cookie"
     },


### PR DESCRIPTION
Makes analytics switchable in production, defaulting to off.

## Testing Instructions

`just frontend/run dev` and make sure the toggle on the `/privacy` page is disabled by default, but also that if you click it it stays "on" after page refresh.