### PR TITLE
Include `env` as a dependency for `up` just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,7 +96,7 @@ lint hook="" *files="": precommit
 ########
 
 # Create .env files from templates
-env:
+@env:
     # Root
     ([ ! -f .env ] && cp env.template .env) || true
     # Docker
@@ -156,7 +156,7 @@ build *args:
 
 # Also see `up` recipe in sub-justfiles
 # Bring all Docker services up, in all profiles
-up *flags: && ps
+up *flags: env && ps
     #!/usr/bin/env bash
     set -eo pipefail
     while true; do


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #964 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

~~This PR adds the `env` just recipe as a dependency of both the `py-install` and `node-install` recipes, then changes the syntax for the `install` recipe to use just's implicit dependency management. This ensures `env` is run once rather than for each install command when `just install` is run.~~ 

~~Since `up` is the more common recipe, adding it as a dependency to `install` seems reasonable since it shouldn't be necessary to run that frequently.~~

Per @sarayourfriend's comment below, I have change this so `env` is now a dependency of `up`.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I tested this by cloning a fresh repo (not a quick process!) and ensuring that the steps in the Quickstart guide (i.e. `just install` -> `just up`) did indeed succeed now because the `.env` files are created.

Running `just install` should be sufficient for testing though, as that will show the env steps running.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
