### PR TITLE
Wrap the RecentSearches in ClientOnly

### DIFF
--- a/frontend/src/components/VHeader/VHeaderMobile/VHeaderMobile.vue
+++ b/frontend/src/components/VHeader/VHeaderMobile/VHeaderMobile.vue
@@ -95,16 +95,17 @@
           </slot>
         </form>
       </div>
-
-      <VRecentSearches
-        v-show="showRecentSearches"
-        :selected-idx="selectedIdx"
-        :entries="entries"
-        :bordered="false"
-        class="mt-4"
-        @select="handleSelect"
-        @clear="handleClear"
-      />
+      <ClientOnly>
+        <VRecentSearches
+          v-show="showRecentSearches"
+          :selected-idx="selectedIdx"
+          :entries="entries"
+          :bordered="false"
+          class="mt-4"
+          @select="handleSelect"
+          @clear="handleClear"
+        />
+      </ClientOnly>
     </VInputModal>
   </header>
 </template>


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #473 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the client-server mismatch on the mobile.

When you open the server-rendered mobile search page (directly opening the address like localhost:8443/search/?q=cat, or refreshing the search page) instead of navigating to it from the homepage, the contents of the recent searches list from the server are different from the local list saved in the local storage. This causes a mismatch of the server-rendered layout and the client-rendered layout. Nuxt re-renders the layout completely instead of adding the event handlers to the server-rendered layout when "hydrating".

To prevent this, we use the `ClientOnly` wrapper component, which stops the Recent Searches from rendering on the server. Recent Searches on mobile will now only render on the client, after the server-rendered layout is ready. This will match the way it is done on desktop.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Open the app on a narrow screen with mobile layout. Execute a search to fill in the local storage with some "recent searches. Then, go to localhost:8443/search/?q=openverse directly. You should not see the "client-server mismatch" error messages in the browser console.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
