### PR TITLE
Fix the image cell markup

### DIFF
--- a/frontend/src/components/VAudioTrack/VAudioTrack.vue
+++ b/frontend/src/components/VAudioTrack/VAudioTrack.vue
@@ -7,8 +7,10 @@
     :aria-label="ariaLabel"
     :role="isComposite ? 'application' : undefined"
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
-    @keydown.native="handleKeydown"
-    @blur.native="handleBlur"
+    @keydown="handleKeydown"
+    @blur="handleBlur"
+    @mousedown="$emit('mousedown', $event)"
+    @focus="$emit('focus', $event)"
   >
     <Component
       :is="layoutComponent"
@@ -247,6 +249,7 @@ export default defineComponent({
         type: "audio",
         id: props.audio.id,
       })
+      activeMediaStore.setMessage({ message: null })
       updateTimeLoop()
     }
     const setPaused = () => {
@@ -355,10 +358,13 @@ export default defineComponent({
             errorMsg = "err_unknown"
             $sentry.captureException(err)
         }
+        console.log("Error playing audio:", err, errorMsg)
         errorMsg = i18n.t(`audio-track.messages.${errorMsg}`).toString()
+        console.log("Setting message in active media store: ", errorMsg)
         activeMediaStore.setMessage({ message: errorMsg })
         localAudio?.pause()
       })
+      console.log("Playing audio:", localAudio?.src)
     }
     const pause = () => localAudio?.pause()
 

--- a/frontend/src/components/VLink.vue
+++ b/frontend/src/components/VLink.vue
@@ -7,6 +7,9 @@
     v-on="$listeners"
     @mousedown.native="$emit('mousedown', $event)"
     @click.native="$emit('click', $event)"
+    @blur.native="$emit('blur', $event)"
+    @focus.native="$emit('focus', $event)"
+    @keydown.native="$emit('keydown', $event)"
   >
     <slot />
   </NuxtLink>

--- a/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
@@ -42,14 +42,14 @@
           :search-term="searchTerm"
           aspect-ratio="square"
         />
-        <li v-if="isDetail.audio(item)" :key="item.id">
-          <VAudioCell
-            :audio="item"
-            :search-term="searchTerm"
-            @interacted="hideSnackbar"
-            @focus.native="showSnackbar"
-          />
-        </li>
+        <VAudioCell
+          v-if="isDetail.audio(item)"
+          :key="item.id"
+          :audio="item"
+          :search-term="searchTerm"
+          @interacted="hideSnackbar"
+          @focus="showSnackbar"
+        />
       </template>
     </ol>
 

--- a/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
@@ -34,7 +34,7 @@
       "
       :aria-label="$t('browse-page.aria.results', { query: searchTerm })"
     >
-      <li v-for="item in allMedia" :key="item.id">
+      <template v-for="item in allMedia">
         <VImageCell
           v-if="isDetail.image(item)"
           :key="item.id"
@@ -42,15 +42,15 @@
           :search-term="searchTerm"
           aspect-ratio="square"
         />
-        <VAudioCell
-          v-if="isDetail.audio(item)"
-          :key="item.id"
-          :audio="item"
-          :search-term="searchTerm"
-          @interacted="hideSnackbar"
-          @focus.native="showSnackbar"
-        />
-      </li>
+        <li v-if="isDetail.audio(item)" :key="item.id">
+          <VAudioCell
+            :audio="item"
+            :search-term="searchTerm"
+            @interacted="hideSnackbar"
+            @focus.native="showSnackbar"
+          />
+        </li>
+      </template>
     </ol>
 
     <VLoadMore class="mt-4" />

--- a/frontend/src/components/VSearchResultsGrid/VAudioCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAudioCell.vue
@@ -1,10 +1,13 @@
 <template>
-  <VAudioTrack
-    :audio="audio"
-    layout="box"
-    :search-term="searchTerm"
-    v-on="$listeners"
-  />
+  <li>
+    <VAudioTrack
+      :audio="audio"
+      layout="box"
+      :search-term="searchTerm"
+      v-bind="$attrs"
+      v-on="$listeners"
+    />
+  </li>
 </template>
 
 <script lang="ts">
@@ -16,6 +19,7 @@ import VAudioTrack from "~/components/VAudioTrack/VAudioTrack.vue"
 
 export default defineComponent({
   components: { VAudioTrack },
+  inheritAttrs: false,
   props: {
     audio: {
       type: Object as PropType<AudioDetail>,

--- a/frontend/src/components/VSearchResultsGrid/VImageCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCell.vue
@@ -1,13 +1,12 @@
 <template>
-  <VLink
-    itemprop="contentUrl"
-    :title="contextSensitiveTitle"
-    :href="imageLink"
-    class="group relative block w-full overflow-hidden rounded-sm bg-dark-charcoal-10 text-dark-charcoal-10 focus-bold-filled"
-    :aria-label="contextSensitiveTitle"
-    :style="styles.container"
-  >
-    <Component :is="as">
+  <li :style="styles.container">
+    <VLink
+      itemprop="contentUrl"
+      :title="contextSensitiveTitle"
+      :href="imageLink"
+      class="group relative block w-full overflow-hidden rounded-sm bg-dark-charcoal-10 text-dark-charcoal-10 focus-bold-filled"
+      :aria-label="contextSensitiveTitle"
+    >
       <figure
         itemprop="image"
         itemscope
@@ -36,9 +35,9 @@
           <VLicense :license="image.license" :hide-name="true" />
         </figcaption>
       </figure>
-    </Component>
-    <i v-if="!isSquare" :style="styles.iPadding" class="block" aria-hidden />
-  </VLink>
+      <i v-if="!isSquare" :style="styles.iPadding" class="block" aria-hidden />
+    </VLink>
+  </li>
 </template>
 
 <script lang="ts">
@@ -82,10 +81,6 @@ export default defineComponent({
     aspectRatio: {
       type: String as PropType<AspectRatio>,
       default: "square",
-    },
-    as: {
-      type: String as PropType<"li" | "div">,
-      default: "li",
     },
   },
   setup(props) {

--- a/frontend/src/components/VSearchResultsGrid/VImageGrid.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageGrid.vue
@@ -8,7 +8,6 @@
       <VImageCell
         v-for="image in images"
         :key="image.id"
-        as="li"
         :image="image"
         :search-term="searchTerm"
         aspect-ratio="intrinsic"

--- a/frontend/src/pages/search/audio.vue
+++ b/frontend/src/pages/search/audio.vue
@@ -26,8 +26,8 @@
           layout="row"
           :search-term="searchTerm"
           @interacted="hideSnackbar"
-          @mousedown.native="handleMouseDown"
-          @focus.native="showSnackbar"
+          @mousedown="handleMouseDown"
+          @focus="showSnackbar"
         />
       </li>
     </ol>


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2193 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
#1979 introduced incorrect markup into the search results page: there are two incorrectly nested `li` items:

<img width="227" alt="Screenshot 2023-05-25 at 12 45 40 PM" src="https://github.com/WordPress/openverse/assets/15233243/16667c37-dd71-4713-bda8-21608eb97a12">

This PR removes the inner `li`. To do that, it wraps the `VImageCell` with a `li`. To maintain the correct grid layout, the styles are moved from inner element to the `li`.

_Edited to add:_ After @dhruvkb commented that audio cell and image cell should have similar implementations, and should both be wrapped in `li`, I added those changes to the AudioCell. To make sure that the event listeners are correctly handled, I also refactored `VLink` component.

`VLink` wraps two different components:
1. for external links, it is an `<a>` link. All of the normal event handlers (`@click`, `@focus`, etc) work well here. 
2. for internal links, it is a `<NuxtLink>` which needs `.native` modifier to correctly apply the event handlers.

To simplify the `VLink` component's API, I moved all of the `.native` modifiers inside the `NuxtLink`. Now, you don't have to know if the link is external or internal, you can use the normal event handlers without the `.native` modifier.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The image grid should look as usual, and no results should have `li` elements that are incorrectly nested.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
