### PR TITLE
Truncate OAuth tables after staging DB restore

### DIFF
--- a/catalog/dags/common/constants.py
+++ b/catalog/dags/common/constants.py
@@ -31,5 +31,8 @@ XCOM_PULL_TEMPLATE = "{{{{ ti.xcom_pull(task_ids='{}', key='{}') }}}}"
 
 POSTGRES_CONN_ID = os.getenv("OPENLEDGER_CONN_ID", "postgres_openledger_testing")
 OPENLEDGER_API_CONN_ID = os.getenv("OPENLEDGER_API_CONN_ID", "postgres_openledger_api")
+POSTGRES_API_STAGING_CONN_ID = os.getenv(
+    "POSTGRES_API_STAGING_CONN_ID", "postgres_openledger_api_staging"
+)
 AWS_CONN_ID = os.getenv("AWS_CONN_ID", "aws_conn_id")
 AWS_RDS_CONN_ID = os.environ.get("AWS_RDS_CONN_ID", AWS_CONN_ID)

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -26,6 +26,7 @@ REQUIRED_DB_INFO = {
     "PubliclyAccessible",
     "DBInstanceClass",
     "AllocatedStorage",
+    "CopyTagsToSnapshot",
 }
 
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -29,6 +29,15 @@ REQUIRED_DB_INFO = {
     "CopyTagsToSnapshot",
 }
 
+TABLES_TO_TRUNCATE = [
+    "api_throttledapplication",
+    "api_oauth2registration",
+    "api_oauth2verification",
+    "oauth2_provider_accesstoken",
+    "oauth2_provider_grant",
+    "oauth2_provider_idtoken",
+    "oauth2_provider_refreshtoken",
+]
 
 log = logging.getLogger(__name__)
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -29,16 +29,6 @@ REQUIRED_DB_INFO = {
     "CopyTagsToSnapshot",
 }
 
-TABLES_TO_TRUNCATE = [
-    "api_throttledapplication",
-    "api_oauth2registration",
-    "api_oauth2verification",
-    "oauth2_provider_accesstoken",
-    "oauth2_provider_grant",
-    "oauth2_provider_idtoken",
-    "oauth2_provider_refreshtoken",
-]
-
 log = logging.getLogger(__name__)
 
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
@@ -18,6 +18,7 @@ run using a different hook:
 
 import logging
 from datetime import datetime, timedelta
+from textwrap import dedent as d
 
 from airflow.decorators import dag
 from airflow.providers.amazon.aws.operators.rds import RdsDeleteDbInstanceOperator
@@ -132,7 +133,12 @@ def restore_staging_database():
     # Truncate the oauth tables, the cascade ensures all related tables are truncated
     truncate_tables = PGExecuteQueryOperator(
         task_id="truncate_oauth_tables",
-        sql="TRUNCATE TABLE api_throttledapplication RESTART IDENTITY CASCADE;",
+        sql=d(
+            """
+            TRUNCATE TABLE api_throttledapplication RESTART IDENTITY CASCADE;
+            TRUNCATE TABLE api_oauth2registration RESTART IDENTITY CASCADE;
+            """
+        ),
         postgres_conn_id=POSTGRES_API_STAGING_CONN_ID,
         execution_timeout=timedelta(minutes=5),
     )

--- a/catalog/env.template
+++ b/catalog/env.template
@@ -51,6 +51,7 @@ AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpo
 # Catalog DB connection. Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@upstream_db:5432/openledger
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@upstream_db:5432/openledger
+AIRFLOW_CONN_POSTGRES_OPENLEDGER_API_STAGING=postgres://deploy:deploy@db:5432/openledger
 OPENLEDGER_CONN_ID=postgres_openledger_upstream
 TEST_CONN_ID=postgres_openledger_testing
 

--- a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
+++ b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
@@ -92,6 +92,7 @@ def test_get_staging_db_details(details, mock_rds_hook):
         "MultiAZ": False,
         "PubliclyAccessible": False,
         "VpcSecurityGroupIds": ["vpcsg1", "vpcsg2"],
+        "CopyTagsToSnapshot": True,
     }
 
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Another step towards completing #1989

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the truncation steps described in the IP for this work on step 12.3 here: https://docs.openverse.org/projects/proposals/search_relevancy_sandbox/20230406-implementation_plan_update_staging_database.html#dag

We also needed a connection to the staging database (we haven't had the need arise for one yet) so I added a new connection for that. The naming convention we have isn't _great_ but I didn't particularly want to change that at this juncture. I've added this connection to our production Airflow instance.

The DAG definition specifies a handful of tables to truncate, but fortunately all of them reference `api_throttledapplication` either directly or indirectly, so a single `TRUNCATE...CASCADE` will truncate them all (and prevents deadlocks which might be incurred by truncating them all in parallel).

![image](https://github.com/WordPress/openverse/assets/10214785/878d14bf-1c93-441c-a414-313a55329a46)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Testing this is a little troublesome - you'll need to perform all the setup instructions provided in #2099.

Additionally, we can't connect to the _actual_ staging database because we need to connect to the jumphost first, and it's difficult (read: extremely tedious) to try and get the Airflow container to connect to the database which is bound to the host at 5432. The easiest way to test this is to have those commands run on the _local_ API database instead. This can be done by setting `AIRFLOW_CONN_POSTGRES_OPENLEDGER_API_STAGING=postgres://deploy:deploy@db:5432/openledger`. Then run `just api/init` and `just c` to set up the API and start the catalog. You can then kick off the DAG, and the truncation steps should run against the local API database.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
