### PR TITLE
Deploy staging API after staging DB restore

### DIFF
--- a/catalog/dags/common/github.py
+++ b/catalog/dags/common/github.py
@@ -87,3 +87,9 @@ class GitHubAPI:
             "GET",
             f"repos/{owner}/{repo}/branches/{branch}/protection",
         )
+
+    def get_package_versions(self, package: str, owner: str = "WordPress"):
+        return self._make_request(
+            "GET",
+            f"orgs/{owner}/packages/container/{package}/versions",
+        )

--- a/catalog/dags/common/github.py
+++ b/catalog/dags/common/github.py
@@ -93,3 +93,17 @@ class GitHubAPI:
             "GET",
             f"orgs/{owner}/packages/container/{package}/versions",
         )
+
+    def dispatch_workflow(
+        self,
+        repo: str,
+        workflow_id: str,
+        inputs: dict = None,
+        ref: str = "main",
+        owner: str = "WordPress",
+    ):
+        return self._make_request(
+            "POST",
+            f"repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+            json={"inputs": inputs or {}, "ref": ref},
+        )

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -225,3 +225,17 @@ def get_latest_api_package_version(github: GitHubAPI) -> str:
         raise ValueError(f"Latest version is not marked as 'latest': {latest_version}")
 
     return latest_version
+
+
+@task
+@setup_github
+def deploy_staging(latest_version: str, github: GitHubAPI) -> None:
+    """Deploy the latest version of the API package to staging."""
+    github.dispatch_workflow(
+        "openverse-infrastructure",
+        "deploy-staging-api.yml",
+        {
+            "tag": latest_version,
+            "run_name": f"staging database restore - {latest_version}",
+        },
+    )

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -221,8 +221,11 @@ def get_latest_api_package_version(github: GitHubAPI = None) -> str:
     # to the same build we don't care which is used.
     latest_version = sorted(tags - {"latest"})[0]
     log.info(f"Found latest version: {latest_version}")
-    if "latest" not in tags:
-        raise ValueError(f"Latest version is not marked as 'latest': {latest_version}")
+    if not ("latest" in tags or latest_version.startswith("rel-")):
+        raise ValueError(
+            f"Latest version is not a release and not marked with 'latest': "
+            f"{latest_version}"
+        )
 
     return latest_version
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -223,7 +223,7 @@ def get_latest_api_package_version(github: GitHubAPI = None) -> str:
     log.info(f"Found latest version: {latest_version}")
     if not ("latest" in tags or latest_version.startswith("rel-")):
         raise ValueError(
-            f"Latest version is not a release and not marked with 'latest': "
+            f"Latest version is not a release or not marked with 'latest': "
             f"{latest_version}"
         )
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore.py
@@ -219,7 +219,7 @@ def get_latest_api_package_version(github: GitHubAPI = None) -> str:
     tags = set(versions[0]["metadata"]["container"]["tags"])
     # There might actually be more than one tag here, but since they all point
     # to the same build we don't care which is used.
-    latest_version = list(tags - {"latest"})[0]
+    latest_version = sorted(tags - {"latest"})[0]
     log.info(f"Found latest version: {latest_version}")
     if "latest" not in tags:
         raise ValueError(f"Latest version is not marked as 'latest': {latest_version}")

--- a/catalog/dags/database/staging_database_restore/utils.py
+++ b/catalog/dags/database/staging_database_restore/utils.py
@@ -1,8 +1,10 @@
 import functools
 
+from airflow.models import Variable
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 
 from common.constants import AWS_RDS_CONN_ID
+from common.github import GitHubAPI
 from database.staging_database_restore import constants
 
 
@@ -17,6 +19,23 @@ def setup_rds_hook(func: callable) -> callable:
     def wrapped(*args, **kwargs):
         rds_hook = kwargs.pop("rds_hook", None) or RdsHook(aws_conn_id=AWS_RDS_CONN_ID)
         return func(*args, **kwargs, rds_hook=rds_hook)
+
+    return wrapped
+
+
+def setup_github(func: callable) -> callable:
+    """
+    Provide an instance of the GitHubAPI as one of the parameters for the
+    called function. If the function is explicitly supplied with a github instance,
+    use that one.
+    :return:
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        github_pat = Variable.get("GITHUB_API_KEY")
+        github = kwargs.pop("github", None) or GitHubAPI(github_pat)
+        return func(*args, **kwargs, github=github)
 
     return wrapped
 

--- a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
+++ b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
@@ -9,6 +9,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from catalog.tests.dags.database.staging_database_restore.data import (
     DESCRIBE_DB_INSTANCES_RESPONSE,
 )
+from common.github import GitHubAPI
 from database.staging_database_restore import staging_database_restore
 
 
@@ -18,6 +19,11 @@ REFERENCE_DATE = datetime(2021, 1, 1, 0, 0, 0)
 @pytest.fixture
 def mock_rds_hook() -> RdsHook:
     return mock.MagicMock(spec=RdsHook)
+
+
+@pytest.fixture
+def mock_github() -> GitHubAPI:
+    return mock.MagicMock(spec=GitHubAPI)
 
 
 @pytest.mark.parametrize("should_skip", [True, False])
@@ -109,3 +115,37 @@ def test_make_rename_task_group():
     # This should not be affected by the trigger rule
     assert await_rename.trigger_rule == TriggerRule.ALL_SUCCESS
     assert await_rename.retries == 2
+
+
+@pytest.mark.parametrize(
+    "tags, expected",
+    [
+        (
+            ["11926a78cfe8ca150fe6d232a5689141c35417d1", "latest"],
+            "11926a78cfe8ca150fe6d232a5689141c35417d1",
+        ),
+        (
+            [
+                "11926a78cfe8ca150fe6d232a5689141c35417d1",
+                "2e82df0105a94f7b85c48321fc3e05c23edc49bd",
+                "latest",
+            ],
+            "11926a78cfe8ca150fe6d232a5689141c35417d1",
+        ),
+        pytest.param(
+            ["11926a78cfe8ca150fe6d232a5689141c35417d1"],
+            None,
+            marks=pytest.mark.raises(
+                exception=ValueError, match="Latest version is not marked"
+            ),
+        ),
+    ],
+)
+def test_get_latest_api_package_version(tags, expected, mock_github):
+    mock_github.get_package_versions.return_value = [
+        {"metadata": {"container": {"tags": tags}}}
+    ]
+    actual = staging_database_restore.get_latest_api_package_version.function(
+        github=mock_github
+    )
+    assert actual == expected

--- a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
+++ b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
@@ -125,6 +125,14 @@ def test_make_rename_task_group():
             "11926a78cfe8ca150fe6d232a5689141c35417d1",
         ),
         (
+            ["rel-2023.05.30.17.57.04", "latest"],
+            "rel-2023.05.30.17.57.04",
+        ),
+        (
+            ["rel-2023.05.30.17.57.04"],
+            "rel-2023.05.30.17.57.04",
+        ),
+        (
             [
                 "11926a78cfe8ca150fe6d232a5689141c35417d1",
                 "2e82df0105a94f7b85c48321fc3e05c23edc49bd",
@@ -136,7 +144,7 @@ def test_make_rename_task_group():
             ["11926a78cfe8ca150fe6d232a5689141c35417d1"],
             None,
             marks=pytest.mark.raises(
-                exception=ValueError, match="Latest version is not marked"
+                exception=ValueError, match="Latest version is not"
             ),
         ),
     ],


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Another step towards completing #1989, builds off of #2207

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a step to the staging database restore DAG which pulls the most recent API package version and dispatches the staging API deployment workflow with that version. While the deployment workflow itself needs a follow-up update to allow the `openverse-bot` to run deployments, this does correctly trigger the deployment workflow! Example: https://github.com/WordPress/openverse-infrastructure/actions/runs/5096003624

![Screenshot_2023-05-26_17-32-01](https://github.com/WordPress/openverse/assets/10214785/62b7b391-5bba-4d02-a5a5-64224d6bf77f)


I added a similar mechanism for setting up the GitHubAPI as we had for the RdsHook, it seemed easiest for the two functions we were using it in. I also changed the flow a little to only report completion after the truncate & deployment steps were complete, rather than alongside.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

To test this, follow the instructions in #2099 and #2207. Make sure you have the `GITHUB_API_KEY` Airflow Variable defined as well with our team PAT. When the DAG gets to these steps, it should appropriately kick off the staging API deployment (although it will fail until we make the appropriate adjustments to it).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
