### PR TITLE
Hide popover on click outside

### DIFF
--- a/frontend/src/composables/use-dialog-content.ts
+++ b/frontend/src/composables/use-dialog-content.ts
@@ -58,6 +58,7 @@ export function useDialogContent({
 
     autoFocusOnShowRef,
     trapFocusRef,
+    hideOnClickOutsideRef,
   })
   useFocusOnHide({
     dialogRef,

--- a/frontend/src/composables/use-focus-on-show.ts
+++ b/frontend/src/composables/use-focus-on-show.ts
@@ -18,6 +18,7 @@ type Props = {
   visibleRef: Ref<boolean>
   autoFocusOnShowRef: Ref<boolean>
   trapFocusRef: Ref<boolean>
+  hideOnClickOutsideRef: Ref<boolean>
   initialFocusElementRef: Ref<HTMLElement | null>
 }
 
@@ -29,6 +30,7 @@ export const useFocusOnShow = ({
   visibleRef,
   autoFocusOnShowRef,
   trapFocusRef,
+  hideOnClickOutsideRef,
   initialFocusElementRef,
 }: Props) => {
   let activateFocusTrap = () => {
@@ -48,7 +50,9 @@ export const useFocusOnShow = ({
       // We already do that in a more flexible, adaptive way in our Dialog composables.
       initialFocus: false,
       // if set to true, focus-trap prevents the default for the keyboard event, and we cannot handle it in our composables.
-      escapeDeactivates: false, // Even though we pass `initialFocus` as `false` above, `focus-trap` still
+      escapeDeactivates: false,
+      clickOutsideDeactivates: () => hideOnClickOutsideRef.value,
+      // Even though we pass `initialFocus` as `false` above, `focus-trap` still
       // checks if the container has at least one tabbable element. Because it sometimes
       // doesn't play nicely with Vue's rendering life-cycle, we need to get it a
       // dynamic way to retrieve the fallback node.


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2220 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets `clickOutsideDeactivates` for the popover to make sure that it is closed when you click outside.

This PR also fixes the issue reported by @AetherUnbound in https://github.com/WordPress/openverse/pull/2141#pullrequestreview-1442655633: when the external sources popover cannot be closed in any way but clicking on the "Close" button.

I also tried rebasing this PR on top of #2199 and removing `.skip` from the test - and the test passes.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app, open the search page, scroll to the bottom of the results and open "External sources" popover. Click outside of the popover - it should close.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
