### PR TITLE
Add analytics events for external links

### DIFF
--- a/frontend/src/components/VAudioTrack/layouts/VFullLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VFullLayout.vue
@@ -34,6 +34,7 @@
               <VLink
                 class="rounded-sm p-px focus:outline-none focus:ring focus:ring-pink"
                 :href="audio.creator_url"
+                :send-external-link-click-event="false"
               >
                 {{ audio.creator }}
               </VLink>
@@ -59,6 +60,7 @@
         show-external-icon
         :external-icon-size="6"
         class="description-bold order-1 my-1 ms-auto flex-shrink-0 lg:order-2"
+        :send-external-link-click-event="false"
         @click="sendGetMediaEvent"
       >
         {{ $t("audio-details.weblink") }}

--- a/frontend/src/components/VContentLink/VContentLink.vue
+++ b/frontend/src/components/VContentLink/VContentLink.vue
@@ -6,6 +6,7 @@
     variant="bordered-gray"
     size="disabled"
     class="h-auto w-full flex-col !items-start !justify-start gap-1 overflow-hidden p-4 sm:h-18 sm:flex-row sm:!items-center sm:gap-2 sm:px-6"
+    :send-external-link-click-event="false"
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
     @mousedown="handleClick"
   >

--- a/frontend/src/components/VContentReport/VContentReportForm.vue
+++ b/frontend/src/components/VContentReport/VContentReportForm.vue
@@ -98,6 +98,7 @@
             show-external-icon
             :external-icon-size="6"
             :href="DMCA_FORM_URL"
+            :send-external-link-click-event="false"
             @click="handleDmcaSubmit"
           >
             {{ $t("media-details.content-report.form.dmca.open") }}

--- a/frontend/src/components/VLink.vue
+++ b/frontend/src/components/VLink.vue
@@ -21,6 +21,7 @@
     :role="href ? undefined : 'link'"
     :aria-disabled="!href"
     :class="{ 'inline-flex w-max items-center gap-x-2': showExternalIcon }"
+    @click="handleExternalClick"
     v-on="$listeners"
   >
     <slot /><VIcon
@@ -45,6 +46,8 @@
  */
 import { computed, defineComponent } from "vue"
 import { useContext } from "@nuxtjs/composition-api"
+
+import { useAnalytics } from "~/composables/use-analytics"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
 
@@ -73,6 +76,13 @@ export default defineComponent({
       type: Number,
       default: 4,
     },
+    /**
+     * Whether the generic EXTERNAL_LINK_CLICK event should be sent on click.
+     */
+    sendExternalLinkClickEvent: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props) {
     const { app } = useContext()
@@ -80,6 +90,7 @@ export default defineComponent({
       href: string
       showExternalIcon: boolean
       externalIconSize: number
+      sendExternalLinkClickEvent: boolean
     } {
       return typeof p.href === "string" && !["", "#"].includes(p.href)
     }
@@ -96,10 +107,21 @@ export default defineComponent({
         : null
     )
 
+    const { sendCustomEvent } = useAnalytics()
+
+    const handleExternalClick = () => {
+      if (!checkHref(props) || !props.sendExternalLinkClickEvent) return
+      sendCustomEvent("EXTERNAL_LINK_CLICK", {
+        url: props.href,
+      })
+    }
+
     return {
       linkTo,
       isNuxtLink,
       isInternal,
+
+      handleExternalClick,
     }
   },
 })

--- a/frontend/src/components/VLink.vue
+++ b/frontend/src/components/VLink.vue
@@ -78,6 +78,7 @@ export default defineComponent({
     },
     /**
      * Whether the generic EXTERNAL_LINK_CLICK event should be sent on click.
+     * Set to `false` if the link click is tracked by another analytics event.
      */
     sendExternalLinkClickEvent: {
       type: Boolean,

--- a/frontend/src/components/VMediaInfo/VMediaLicense.vue
+++ b/frontend/src/components/VMediaInfo/VMediaLicense.vue
@@ -11,7 +11,11 @@
         class="mb-2 block text-sm md:mb-4 md:text-base"
       >
         <template #link>
-          <VLink :href="licenseUrl">
+          <VLink
+            :href="licenseUrl"
+            :send-external-link-click-event="false"
+            @click="sendVisitLicensePage"
+          >
             {{ fullLicenseName }}
           </VLink>
         </template>
@@ -30,6 +34,8 @@
           <VLink
             :aria-label="$t('media-details.aria.attribution.tool')"
             :href="licenseUrl"
+            :send-external-link-click-event="false"
+            @click="sendVisitLicensePage"
             >{{ $t("media-details.reuse.tool.link") }}</VLink
           >
         </template>
@@ -43,6 +49,7 @@ import { computed, defineComponent, PropType } from "vue"
 
 import { getFullLicenseName, isLicense as isLicenseFn } from "~/utils/license"
 import { useI18n } from "~/composables/use-i18n"
+import { useAnalytics } from "~/composables/use-analytics"
 
 import type { License, LicenseVersion } from "~/constants/license"
 
@@ -68,6 +75,8 @@ export default defineComponent({
   },
   setup(props) {
     const i18n = useI18n()
+    const { sendCustomEvent } = useAnalytics()
+
     const isLicense = computed(() => isLicenseFn(props.license))
     const headerText = computed(() => {
       const licenseOrTool = isLicense.value ? "license" : "tool"
@@ -76,10 +85,19 @@ export default defineComponent({
     const fullLicenseName = computed(() =>
       getFullLicenseName(props.license, props.licenseVersion, i18n)
     )
+
+    const sendVisitLicensePage = () => {
+      sendCustomEvent("VISIT_LICENSE_PAGE", {
+        license: props.license,
+      })
+    }
+
     return {
       isLicense,
       headerText,
       fullLicenseName,
+
+      sendVisitLicensePage,
     }
   },
 })

--- a/frontend/src/pages/image/_id/index.vue
+++ b/frontend/src/pages/image/_id/index.vue
@@ -38,6 +38,7 @@
         :external-icon-size="6"
         has-icon-end
         size="large"
+        :send-external-link-click-event="false"
         @click="sendGetMediaEvent"
       >
         {{ $t("image-details.weblink") }}
@@ -56,6 +57,8 @@
                 })
               "
               :href="image.creator_url"
+              :send-external-link-click-event="false"
+              @click="sendVisitCreatorLinkEvent"
               >{{ image.creator }}</VLink
             >
             <span v-else>{{ image.creator }}</span>
@@ -222,6 +225,16 @@ export default defineComponent({
       })
     }
 
+    const sendVisitCreatorLinkEvent = () => {
+      if (!image.value) {
+        return
+      }
+      sendCustomEvent("VISIT_CREATOR_LINK", {
+        id: image.value.id,
+        url: image.value.creator_url,
+      })
+    }
+
     return {
       image,
       hasRelatedMedia,
@@ -239,6 +252,7 @@ export default defineComponent({
       backToSearchPath,
 
       sendGetMediaEvent,
+      sendVisitCreatorLinkEvent,
     }
   },
   async asyncData({ app, error, route, $pinia }) {

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -139,6 +139,38 @@ export type Events = {
     /** The name of the Vue component used to switch content types. */
     component: string
   }
+  /**
+   * Description: The user clicks to a link outside of Openverse.
+   * Questions:
+   *   - What types of external content do users seek?
+   *   - Are there external resources we should make more visible?
+   *   - Is there content we might want to add to Openverse directly?
+   */
+  EXTERNAL_LINK_CLICK: {
+    /** The url of the external link */
+    url: string
+  }
+  /**
+   * Description: The user visits a creator's link in the single result UI
+   * Questions:
+   *   - Are creator links clicked much? Does Openverse increase visibility
+   *     of included creator's profiles?
+   */
+  VISIT_CREATOR_LINK: {
+    /** The unique ID of the media */
+    id: string
+    /** The permalink to the creator's profile */
+    url: string
+  }
+  /**
+   * Description: The user visits a CC license description page on CC.org
+   * Questions:
+   *   - How often are external licenses viewed?
+   */
+  VISIT_LICENSE_PAGE: {
+    /** The slug of the license the user clicked on */
+    license: string
+  }
 }
 
 /**

--- a/frontend/test/unit/specs/components/v-content-link.spec.js
+++ b/frontend/test/unit/specs/components/v-content-link.spec.js
@@ -12,6 +12,11 @@ jest.mock("~/composables/use-analytics", () => ({
 
 describe("VContentLink", () => {
   let options = {}
+  const sendCustomEventMock = jest.fn()
+
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
 
   beforeEach(() => {
     options = {
@@ -33,11 +38,6 @@ describe("VContentLink", () => {
   })
 
   it("sends CHANGE_CONTENT_TYPE event when clicked", async () => {
-    const sendCustomEventMock = jest.fn()
-
-    useAnalytics.mockImplementation(() => ({
-      sendCustomEvent: sendCustomEventMock,
-    }))
     render(VContentLink, options)
     const btn = screen.getByRole("link")
 

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -5,6 +5,12 @@ import { render } from "~~/test/unit/test-utils/render"
 
 import VLink from "~/components/VLink.vue"
 
+jest.mock("~/composables/use-analytics", () => ({
+  useAnalytics: () => ({
+    sendCustomEvent: jest.fn(),
+  }),
+}))
+
 describe("VLink", () => {
   it.each`
     href                        | target      | rel

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -79,6 +79,7 @@ describe("VLink custom events", () => {
   afterEach(() => {
     sendCustomEventMock.mockReset()
   })
+
   it("External link sends a custom event", async () => {
     render(VLink, {
       props: { href },

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -3,15 +3,18 @@ import Vue from "vue"
 
 import { render } from "~~/test/unit/test-utils/render"
 
+import { useAnalytics } from "~/composables/use-analytics"
+
 import VLink from "~/components/VLink.vue"
 
 jest.mock("~/composables/use-analytics", () => ({
-  useAnalytics: () => ({
-    sendCustomEvent: jest.fn(),
-  }),
+  useAnalytics: jest.fn(),
 }))
 
 describe("VLink", () => {
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: jest.fn(),
+  }))
   it.each`
     href                        | target      | rel
     ${"/about"}                 | ${null}     | ${null}
@@ -48,7 +51,10 @@ describe("VLink", () => {
             this.text = "Code is Poetry"
           },
         },
-        template: `<div><VLink href="${href}" @click="handleClick">{{ text }}</VLink></div>`,
+        template: `
+          <div>
+          <VLink href="${href}" @click="handleClick">{{ text }}</VLink>
+          </div>`,
       })
     const WrapperComponent = createVLinkWrapper(href)
     render(WrapperComponent, {}, (localVue) => {
@@ -60,5 +66,40 @@ describe("VLink", () => {
     await fireEvent.click(linkBefore)
     const linkAfter = await screen.findByText("Code is Poetry")
     expect(linkAfter.tagName).toBe("A")
+  })
+})
+
+describe("VLink custom events", () => {
+  const sendCustomEventMock = jest.fn()
+  const href = "https://example.com"
+  useAnalytics.mockImplementation(() => ({
+    sendCustomEvent: sendCustomEventMock,
+  }))
+
+  afterEach(() => {
+    sendCustomEventMock.mockReset()
+  })
+  it("External link sends a custom event", async () => {
+    render(VLink, {
+      props: { href },
+      slots: { default: "Code is Poetry" },
+    })
+    const link = screen.getByRole("link")
+    await fireEvent.click(link)
+
+    expect(sendCustomEventMock).toHaveBeenCalledWith("EXTERNAL_LINK_CLICK", {
+      url: href,
+    })
+  })
+
+  it("External link does not send a custom event if prop is false", async () => {
+    render(VLink, {
+      props: { href: "https://example.com", sendExternalLinkClickEvent: false },
+      slots: { default: "Code is Poetry" },
+    })
+    const link = screen.getByRole("link")
+    await fireEvent.click(link)
+
+    expect(sendCustomEventMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1078 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds three closely-related analytics events:
- `EXTERNAL_LINK_CLICK`
- `VISIT_CREATOR_LINK`
- `VISIT_LICENSE_PAGE`

The `EXTERNAL_LINK_CLICK` event is fired every time an external `VLink` is clicked, unless `send-external-link-click-event` prop is `false`. This prop is used to replace the `EXTERNAL_LINK_CLICK` event with other custom events such as `GET_MEDIA`, if necessary.

I've also added the analytics events to links in the  copyable HTML media attribution statement:
<img width="456" alt="Screenshot 2023-06-06 at 2 13 42 PM" src="https://github.com/WordPress/openverse/assets/15233243/14f252f3-1170-4177-a8ca-ddd0f5ac0ca2">
Normally, clicking the creator link here should send `VISIT_CREATOR_LINK` event. However, it is impossible to get whether the link is the creator or title link from this HTML. I thought of using the heuristics of "if a link follows the word 'by'", but since the attribution HTML is translated, this is not reliable.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app (`just frontend/run dev`) and try clicking external links (most of them have the "external link" icon next to them) everywhere in the app. In `dev` mode, you should see the events and their payloads in the console. Clicking on any given external link should send a single event, either the `EXTERNAL_LINK_CLICK` or a different custom event like `GET_MEDIA`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
