### PR TITLE
Add DAG to remove Flickr thumbnails

### DIFF
--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -19,6 +19,7 @@ The following are DAGs grouped by their primary tag:
 1.  [Database](#database)
 1.  [Maintenance](#maintenance)
 1.  [Oauth](#oauth)
+1.  [Other](#other)
 1.  [Provider](#provider)
 1.  [Provider Reingestion](#provider-reingestion)
 
@@ -62,6 +63,12 @@ The following are DAGs grouped by their primary tag:
 | ----------------------------------------------- | ----------------- |
 | [`oauth2_authorization`](#oauth2_authorization) | `None`            |
 | [`oauth2_token_refresh`](#oauth2_token_refresh) | `0 */12 * * *`    |
+
+## Other
+
+| DAG ID                                                    | Schedule Interval |
+| --------------------------------------------------------- | ----------------- |
+| [`flickr_thumbnails_removal`](#flickr_thumbnails_removal) | `None`            |
 
 ## Provider
 
@@ -113,6 +120,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`finnish_museums_workflow`](#finnish_museums_workflow)
 1.  [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow)
 1.  [`flickr_reingestion_workflow`](#flickr_reingestion_workflow)
+1.  [`flickr_thumbnails_removal`](#flickr_thumbnails_removal)
 1.  [`flickr_workflow`](#flickr_workflow)
 1.  [`freesound_workflow`](#freesound_workflow)
 1.  [`image_data_refresh`](#image_data_refresh)
@@ -393,6 +401,11 @@ ETL Process: Use the API to identify all CC licensed images.
 Output: TSV file containing the images and the respective meta-data.
 
 Notes: https://www.flickr.com/help/terms/api Rate limit: 3600 requests per hour.
+
+## `flickr_thumbnails_removal`
+
+One-time run DAG to remove progressively all the old Flickr thumbnails, as they
+were determined to be unsuitable for the Openverse UI requirements.
 
 ## `flickr_workflow`
 

--- a/catalog/dags/flickr_thumbs_removal.py
+++ b/catalog/dags/flickr_thumbs_removal.py
@@ -50,7 +50,7 @@ def flickr_thumbnails_removal():
             query = dedent(
                 f"""
                 UPDATE image SET thumbnail = NULL WHERE identifier IN
-                (SELECT identifier {select_conditions} FETCH FIRST 10000 ROWS ONLY)
+                (SELECT identifier {select_conditions} FETCH FIRST 10000 ROWS ONLY FOR UPDATE SKIP LOCKED)
                 """
             )
             pg.run(query)

--- a/catalog/dags/flickr_thumbs_removal.py
+++ b/catalog/dags/flickr_thumbs_removal.py
@@ -1,3 +1,7 @@
+"""
+One-time run DAG to remove progressively all the old Flickr thumbnails,
+as they were determined to be unsuitable for the Openverse UI requirements.
+"""
 import logging
 from datetime import timedelta
 from textwrap import dedent

--- a/catalog/dags/flickr_thumbs_removal.py
+++ b/catalog/dags/flickr_thumbs_removal.py
@@ -43,21 +43,25 @@ def flickr_thumbnails_removal():
 
     @task()
     def delete(num_thumbs):
+        log_sql = True
         if num_thumbs == 0:
             logger.info("No Flickr thumbnails found.")
 
         while num_thumbs > 0:
             query = dedent(
                 f"""
-                UPDATE image SET thumbnail = NULL WHERE identifier IN
-                (SELECT identifier {select_conditions} FETCH FIRST 10000 ROWS ONLY FOR UPDATE SKIP LOCKED)
+                UPDATE image SET thumbnail = NULL WHERE identifier IN (
+                    SELECT identifier {select_conditions}
+                    FETCH FIRST 10000 ROWS ONLY FOR UPDATE SKIP LOCKED
+                )
                 """
             )
-            pg.run(query)
+            pg.run(query, log_sql=log_sql)
             num_thumbs -= 10000
             logger.info(
                 f"Flickr thumbnails left: {num_thumbs if num_thumbs > 0 else 0}."
             )
+            log_sql = False
 
     @task()
     def report():

--- a/catalog/dags/flickr_thumbs_removal.py
+++ b/catalog/dags/flickr_thumbs_removal.py
@@ -1,0 +1,72 @@
+import logging
+from datetime import timedelta
+from textwrap import dedent
+
+from airflow.decorators import dag, task
+
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
+from common.slack import send_message
+from common.sql import PostgresHook
+
+
+logger = logging.getLogger(__name__)
+
+
+DAG_ID = "flickr_thumbnails_removal"
+
+
+@dag(
+    dag_id=DAG_ID,
+    default_args={
+        **DAG_DEFAULT_ARGS,
+        "retries": 0,
+        "execution_timeout": timedelta(days=7),
+    },
+    schedule=None,
+    catchup=False,
+    doc_md=__doc__,
+)
+def flickr_thumbnails_removal():
+    pg = PostgresHook(postgres_conn_id=POSTGRES_CONN_ID)
+    select_conditions = "FROM image WHERE provider = 'flickr' AND thumbnail IS NOT NULL"
+
+    @task()
+    def count():
+        num_thumbs = pg.get_first(f"SELECT COUNT(*) {select_conditions}")[0]
+        logger.info(f"Flickr thumbnails found: {num_thumbs}.")
+
+        return num_thumbs
+
+    @task()
+    def delete(num_thumbs):
+        if num_thumbs == 0:
+            logger.info("No Flickr thumbnails found.")
+
+        while num_thumbs > 0:
+            query = dedent(
+                f"""
+                UPDATE image SET thumbnail = NULL WHERE identifier IN
+                (SELECT identifier {select_conditions} FETCH FIRST 10000 ROWS ONLY)
+                """
+            )
+            pg.run(query)
+            num_thumbs -= 10000
+            logger.info(
+                f"Flickr thumbnails left: {num_thumbs if num_thumbs > 0 else 0}."
+            )
+
+    @task()
+    def report():
+        msg = (
+            "All Flickr thumbnails were successfully removed. "
+            f"The `{DAG_ID}` DAG can be retired."
+        )
+        send_message(msg, DAG_ID)
+
+    num_thumbs = count()
+    d = delete(num_thumbs)
+    r = report()
+    d >> r
+
+
+flickr_thumbnails_removal()

--- a/catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/catalog/dags/providers/provider_api_scripts/flickr.py
@@ -120,9 +120,9 @@ class FlickrDataIngester(TimeDelineatedProviderDataIngester):
         for start_ts, end_ts in self.large_batches:
             # For each large batch, ingest records for that interval one license
             # type at a time.
-            for license in LICENSE_INFO.keys():
+            for license_ in LICENSE_INFO.keys():
                 super().ingest_records_for_timestamp_pair(
-                    start_ts=start_ts, end_ts=end_ts, license=license
+                    start_ts=start_ts, end_ts=end_ts, license=license_
                 )
         logger.info("Completed large batch processing by license type.")
 
@@ -139,14 +139,14 @@ class FlickrDataIngester(TimeDelineatedProviderDataIngester):
 
             # license will be available in the params if we're dealing
             # with a large batch. If not, fall back to all licenses
-            license = kwargs.get("license", self.default_license_param)
+            license_ = kwargs.get("license", self.default_license_param)
 
             return {
                 "min_upload_date": start_timestamp,
                 "max_upload_date": end_timestamp,
                 "page": 0,
                 "api_key": self.api_key,
-                "license": license,
+                "license": license_,
                 "per_page": self.batch_limit,
                 "method": "flickr.photos.search",
                 "media": "photos",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
       context: ./docker/upstream_db/
       target: db
     image: openverse-upstream_db
-    expose:
-      - "5432"
+    ports:
+      - "50255:5432"
     volumes:
       - catalog-postgres:/var/lib/postgresql/data
       - ./sample_data:/sample_data


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1816 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Flickr is the last and main provider retaining thumbnails that do not fit our requirements for showing in the Openverse UI (mostly on desktop), so here is a DAG to remove them progressively in batches. This should allow other tasks while running and advance steadily. It uses the new TaskFlow API which comes really handy for a DAG like this.

After the DAG has runs successfully, this will allow us to revert #1812 on the API side.

In minor related changes, I also exposed the port of the upstream_db for being able to use UI software like DataGrip or TablePlus, and fixed a shadowing name in the Flickr DAG.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run the normal flicker DAG to ingest some rows.
2. Modify those rows to have some fake thumbnails URLs
```sql
UPDATE image SET thumbnail='https://flickr.com/fake_thumb.JPG' WHERE identifier IN (
	SELECT identifier FROM image WHERE provider='flickr' AND thumbnail IS NULL
	FETCH FIRST 50000 ROWS ONLY
);
```
3. Run the new `flickr_thumbnails_removal` DAG
4. Check in the DB the Flickr rows
```sql
-- This query should return 0
SELECT count(*) FROM image WHERE provider='flickr' AND thumbnail IS NOT NULL;
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
