### PR TITLE
Document non-code maintainer tasks

### DIFF
--- a/documentation/general/contributing.md
+++ b/documentation/general/contributing.md
@@ -191,11 +191,11 @@ for a variety of reasons. For example, they can:
 - require additional context before they can be worked on
 - refer to implementation details that are no longer relevant due to
   infrastructural or design changes
-- the prioritisation of an issue could need changing
+- require changes in prioritisation
 
 These conditions cannot be easily identified automatically and require regular,
 ongoing work from contributors. Additionally, important issues can be
-accidentally ignored dur to the breadth of our backlog and it is critical for
+accidentally ignored due to the breadth of our backlog and it is critical for
 maintainers to dig through the oldest issues to ensure that issue prioritisation
 still makes sense.
 
@@ -218,9 +218,8 @@ and someone will help clear up any doubts.
 
 Issues may not have all the context required for them to be worked on. This can
 be caused by someone opening issues in a hurry, by the context around an issue
-changing over time, by links meant to clarify the context rotting, or other
-myriad reasons. If you identify an issue that needs more context, there are two
-options:
+changing over time, by outdated or broken links, and other myriad reasons. If
+you identify an issue that needs more context, there are two options:
 
 1. You can research and add the context yourself. In this case, it is a good
    idea to ping the person who originally opened the issue or other folks
@@ -237,6 +236,12 @@ identifies issues that require research or explanation before they can be worked
 on. If you are able to clarify any of these issues, please do so and ping a
 relevant maintainer to confirm the changes and remove the ticket work required
 label.
+
+Additionally, if you find issues that you're able to contribute context towards
+such that they would be good candidates for "good first issue" or "help wanted",
+please add those labels as well after you make your changes. This especially
+helps the new contributor experience as issues with clear instructions and good
+context are the most pleasant to work on when you first contribute to a project.
 
 In the course of this work, you may find issues that should be
 [closed because they are no longer valid](#closing-no-longer-valid-issues).

--- a/documentation/general/contributing.md
+++ b/documentation/general/contributing.md
@@ -62,6 +62,9 @@ replicated.
 
 - [Issues with the "🛠 goal: fix" label](https://github.com/WordPress/openverse/issues?q=is:open+is:issue+label:%22%F0%9F%9B%A0+goal:+fix%22)
 
+See also
+[the section below on issue backlog maintenance for related ways to help](#issue-backlog-maintenance).
+
 ### Pull request review
 
 New contributors are welcome and invited to provide feedback on pull requests.
@@ -175,3 +178,146 @@ If you know folks who have expertise in any of the above areas who you think
 might be interested in contributing to open source, send them our way! We're
 happy to help onboard folks to the project itself, as well as the tools and
 technologies we use.
+
+### Issue backlog maintenance
+
+The [Openverse issue backlog](https://github.com/WordPress/openverse/issues)
+requires regular maintenance and upkeep. Issues can become stale or unworkable
+for a variety of reasons. For example, they can:
+
+- be duplicates of other issues
+- have been silently fixed
+- have been explicitly fixed but accidentally left open
+- require additional context before they can be worked on
+- refer to implementation details that are no longer relevant due to
+  infrastructural or design changes
+- the prioritisation of an issue could need changing
+
+These conditions cannot be easily identified automatically and require regular,
+ongoing work from contributors. Additionally, important issues can be
+accidentally ignored dur to the breadth of our backlog and it is critical for
+maintainers to dig through the oldest issues to ensure that issue prioritisation
+still makes sense.
+
+The following sections give hints on how to manage certain common scenarios.
+Generally speaking, for any scenario where an issue is being closed, it is good
+to ping at least one other maintainer for advice or to corroborate your
+understanding of the situation. If you find issues that don't seem right for any
+reason, [ping any of the communication aliases](/meta/communication_aliases.md)
+and someone will help clear up any doubts.
+
+#### Useful issue query links
+
+- [Ticket work required](https://github.com/WordPress/openverse/labels/%F0%9F%A7%B9%20status%3A%20ticket%20work%20required);
+  see [the section below](#issues-that-need-more-information) for actionability
+- [Medium and low priority sorted by oldest first](https://github.com/WordPress/openverse/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%9F%A8+priority%3A+medium%22%2C%22%F0%9F%9F%A9+priority%3A+low%22+sort%3Acreated-asc);
+  see [the section below](#updating-prioritisation) for actionability
+- [All issues sorted by oldest first](https://github.com/WordPress/openverse/issues?q=is%3Aopen+is%3Aissue+sort%3Acreated-asc+)
+
+#### Issues that need more information
+
+Issues may not have all the context required for them to be worked on. This can
+be caused by someone opening issues in a hurry, by the context around an issue
+changing over time, by links meant to clarify the context rotting, or other
+myriad reasons. If you identify an issue that needs more context, there are two
+options:
+
+1. You can research and add the context yourself. In this case, it is a good
+   idea to ping the person who originally opened the issue or other folks
+   discussing the issue to confirm that the additional information you've added
+   is accurate.
+2. If for any reason you do not have the ability to research the issue yourself,
+   you should add the
+   ["ticket work required"](https://github.com/WordPress/openverse/labels/%F0%9F%A7%B9%20status%3A%20ticket%20work%20required)
+   label.
+
+Building off the second option, the
+[ticket work required label](https://github.com/WordPress/openverse/labels/%F0%9F%A7%B9%20status%3A%20ticket%20work%20required)
+identifies issues that require research or explanation before they can be worked
+on. If you are able to clarify any of these issues, please do so and ping a
+relevant maintainer to confirm the changes and remove the ticket work required
+label.
+
+In the course of this work, you may find issues that should be
+[closed because they are no longer valid](#closing-no-longer-valid-issues).
+Please see the linked section for how to handle those issues and
+[keep in mind the important caveat with regard to reproducibility covered in that section](#reproducibility).
+See also [bug reproduction reproduction and triage](#bug-reproduction--triage)
+above.
+
+#### Merging issues
+
+Clicking through a few pages of the issue backlog and scanning titles can
+sometimes reveal issues that are either duplicative or so closely related that
+they could be merged into a single issue. When doing so, always close the newer
+issues and copy any relevant information from the newer issues into the older
+issues. The reason to keep the oldest issue open is to accurately reflect the
+age of the issue. This is especially relevant for bugs as if we closed the
+oldest issues in favour of the newest ones, we wouldn't have accurate, easily
+queryable information about bug age.
+
+If you identify issues that appear to be duplicates or closely related such that
+they should be fixed at the same time, ping the folks who opened or have
+discussed the issues to confirm that before merging the issues.
+
+#### Closing no longer valid issues
+
+Issues may become invalid for many reasons. The most common are:
+
+- The issue refers to a feature which no longer exists. For example, a bug issue
+  for an endpoint or a page that no longer exists or is deprecated
+- The issue is no longer reproducible, i.e., the issue identified has been fixed
+- The work is no longer desired, either because it is part of an abandoned
+  project or because it contradicts other decisions that have been made since
+  the issue was opened
+
+In all of these cases it is important to ping the author of the issue and the
+people discussing it. For clarification on whether an issue is still desired, it
+is especially helpful to ping the
+[communication alias](/meta/communication_aliases.md) relevant for the part of
+the stack in question. Please heed
+
+```{warning}
+##### Reproducibility
+
+Keep in mind that some issues may appear like they are no longer valid due to
+irreproducibility. Take care when approaching these issues to confirm absolutely
+that the environment reported in the issue (if one is reported) is not relevant.
+Always ping the original author of the issue to confirm irreproducibility before
+jumping to the conclusion that the issue should be closed. Additionally, after
+pinging the author of the issue, add the "ticket work required" label.
+```
+
+**Openverse does not close issues strictly due to age**. Issues should only be
+closed if they meet the criteria described above, not merely because they are
+old. Old issues should be treated
+[following the prioritisation update guidelines described below](#updating-prioritisation).
+
+#### Updating prioritisation
+
+Issues are often prioritised at the moment or within the week that they are
+opened. Therefore, the priority labels for issues must be considered relevant to
+their age. Issues opened with a medium or low priority are not necessarily
+issues that can go forever without being addressed. These prioritisations merely
+indicate issues that do not need to be _immediately_ addressed. With that in
+mind, the oldest issues in our backlog, even if they have a low priority
+designation, should be re-evaluated on a regular basis to ensure that it doesn't
+make sense to start implementing them. Old issues are often overlooked for a
+variety of reasons:
+
+- They don't appear in our regular scans of the backlog because they're on the
+  final pages
+- They can sometimes be tricky or ambiguous issues and have been avoided by even
+  by contributors who are looking through old issues in favour of more
+  straight-forward ones
+
+If you find an old issue that looks like it could be worked on, if you are sure
+that it can be immediately worked on, add it to the
+[weekly dev chat agenda](https://docs.google.com/document/d/1AdcQVJy5B06J9N3jYCKk4GVKZZdyykjl4UP92kH_RpI/edit)
+for prioritisation. Maintainers will discuss the issue and decide whether it
+should be assigned for the following week or if can continue to be delayed.
+Leave a comment on the issue if you add it to the agenda document.
+Alternatively, if you are unsure whether it makes sense to start working on the
+issue, ping the author or
+[relevant communication alias](/meta/communication_aliases.md) for help making a
+decision.

--- a/documentation/meta/communication_aliases.md
+++ b/documentation/meta/communication_aliases.md
@@ -1,0 +1,13 @@
+# Communication aliases
+
+Each part of the Openverse stack has a GitHub team alias. These exist to make it
+easier to ping a subset of the Openverse maintainers familiar with a particular
+part of the codebase.
+
+| Alias                                 | Usage                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `@WordPress/openverse-maintainers`    | Ping all core maintainers for advice on general functionality or project maintenance |
+| `@WordPress/openverse-catalog`        | Ping maintainers most familiar with ongoing Airflow catalog work                     |
+| `@WordPress/openverse-frontend`       | Ping maintainers most familiar with ongoing Nuxt frontend client work                |
+| `@WordPress/openverse-api`            | Ping maintainers most familiar with ongoing Django API work                          |
+| `@WordPress/openverse-infrastructure` | Ping maintainers most familiar with the Openverse infrastructure                     |

--- a/documentation/meta/documentation/index.md
+++ b/documentation/meta/documentation/index.md
@@ -6,4 +6,5 @@
 quickstart
 guidelines
 extensions
+review
 ```

--- a/documentation/meta/documentation/review.md
+++ b/documentation/meta/documentation/review.md
@@ -1,0 +1,39 @@
+# Documentation proofreading and review
+
+Historically the Openverse project has occassionally done a "documentation bug
+bash" where maintainers sat down together to read through our existing
+documentation and identify potential issues or necessary changes. While this
+should happen in a concerted, maintainer-wide effort at least once a year, we
+can also individually perform some aspect of this on an ongoing basis.
+
+## What to look for
+
+When proofreading a particular documentation page, consider the following:
+
+- Who is the audience? Is the document accessible to that audience in tone,
+  language, and location?
+- What is the purpose? Is the document's purpose clear and does the document
+  fulfill that purpose?
+- What is the scope? Does the document sufficiently cover its intended scope?
+  Are there aspects missing? Are there spurious aspects that could be broken
+  into separate documents? On the other hand, are there pages that should be
+  combined or more clearly linked, whether in text or via organisation, in order
+  to fully cover the intended scope?
+- Does it work[^dog-fooding]? If the document is a guide, try out the steps for
+  yourself and confirm that they work. Are there gaps in the steps that can be
+  explicitly documented? Can any steps be simplified? Is there spurious
+  information that could be moved into supplementary documentation, especially
+  information that unnecessarily complicates the guide?
+
+If you identify discrepancies in any of these areas, open an issue. If possible,
+suggest an edit that would fix or improve the situation.
+
+Additionally, we should look for opportunities to document currently
+undocumented parts of the project. If you notice these, open issues to request
+the documentation.
+
+[^dog-fooding]:
+    This process of trying something we've built or written out for ourselves is
+    also sometimes called "dog fooding".
+
+<!-- TODO: Figure out a way to document the last time a documentation page was reviewed by a maintainer to make it easier for folks to review pages that most need it (i.e., ones that haven't recently been reviewed) -->

--- a/documentation/meta/index.md
+++ b/documentation/meta/index.md
@@ -5,8 +5,10 @@
 
 github_contribution_practices
 dev_flow
+maintainer_tasks
 ci_cd/index
 decision_making/index
 documentation/index
 traffic/index
+communication_aliases
 ```

--- a/documentation/meta/maintainer_tasks.md
+++ b/documentation/meta/maintainer_tasks.md
@@ -29,10 +29,16 @@ if they already have several PRs with reviews requested.
 
 ## Sentry review
 
-While the Openverse Mini-Support Rotation covers recording and triaging _new_
-Sentry issues, it does not include regularly checking the frequency of existing
-issues. You can review Sentry issues by frequency by visiting the following
-links:
+While the Openverse Mini-Support Rotation[^msr] covers recording and triaging
+_new_ Sentry issues, it does not include regularly checking the frequency of
+existing issues. You can review Sentry issues by frequency by visiting the
+following links:
+
+[^msr]:
+    The Openverse Mini-Support Rotation is managed by the core maintainers. Each
+    week, one of the maintainers takes on several responsibilities for regular
+    maintenance tasks, one of which is to check Sentry for new events that need
+    to be converted into GitHub issues.
 
 - [Django API](https://openverse.sentry.io/issues/?project=6107216&query=is%3Aunresolved&referrer=issue-list&sort=freq&statsPeriod=30d)
 - [Frontend](https://openverse.sentry.io/issues/?project=5799642&query=is%3Aunresolved&referrer=issue-list&sort=freq&statsPeriod=30d)

--- a/documentation/meta/maintainer_tasks.md
+++ b/documentation/meta/maintainer_tasks.md
@@ -1,0 +1,68 @@
+# Regular maintainer tasks
+
+This document summarises and collects links to information about tasks other
+than opening new code contributions that maintainers should consider, especially
+if they already have several PRs with reviews requested.
+
+- Review
+  [older open PRs, even ones not assigned to you](https://github.com/WordPress/openverse/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-asc+draft%3Afalse+-reviewed-by%3A%40me+review%3Arequired+-author%3A%40me+)
+- Review the
+  [issue backlog and perform some of the regular backlog maintenance tasks](/general/contributing.md#issue-backlog-maintenance)
+- Pick up the
+  [oldest, unassigned implementation plan](https://github.com/wordpress/openverse/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%A7%AD+project%3A+implementation+plan%22%2C%22%F0%9F%A7%AD+project%3A+proposal%22+sort%3Acreated-asc+no%3Aassignee)
+  - This will eventually result in a new PR but usually takes a while to
+    complete and are easy to overlook in favour of direct code contributions
+  - If an older implementation plan is assigned and hasn't been started and you
+    could pick it up, consider pinging the current assignee to offer to take if
+    off their plate
+- Search through Sentry for older issues that might be getting worse; see
+  [section below for details](#sentry-review)
+- Read and respond to
+  [active discussions](https://github.com/WordPress/openverse/discussions)
+- Research unknown/under-documented parts of the project; see
+  [section below for advice](#unknownunder-documented-parts-of-the-project)
+- Pick up active incident investigation
+  - Check with MSR if you need help identifying what incidents need help
+    investigating
+- Proofread documentation; see
+  [the documentation review page for advice](/meta/documentation/review.md)
+
+## Sentry review
+
+While the Openverse Mini-Support Rotation covers recording and triaging _new_
+Sentry issues, it does not include regularly checking the frequency of existing
+issues. You can review Sentry issues by frequency by visiting the following
+links:
+
+- [Django API](https://openverse.sentry.io/issues/?project=6107216&query=is%3Aunresolved&referrer=issue-list&sort=freq&statsPeriod=30d)
+- [Frontend](https://openverse.sentry.io/issues/?project=5799642&query=is%3Aunresolved&referrer=issue-list&sort=freq&statsPeriod=30d)
+- [Ingestion Server](https://openverse.sentry.io/issues/?project=4504934126059520&query=is%3Aunresolved&referrer=issue-list&sort=freq&statsPeriod=30d)
+
+If you see an issue with heaps of events and see that the GitHub issue is not
+being worked on or has been prioritised such that it will not be picked up soon,
+use your best judgement to determine whether it needs to be worked on
+immediately (it could be the next code contribution you work on) or if it's safe
+enough to just add to the weekly dev chat agenda.
+
+## Unknown/under-documented parts of the project
+
+There are a handful of issues in our backlog that request documentation for
+parts of the project. You can find those by scanning the list of
+[text-aspect issues](https://github.com/wordpress/openverse/issues?q=is%3Aopen+is%3Aissue+sort%3Acreated-asc+no%3Aassignee+label%3A%22%F0%9F%93%84+aspect%3A+text%22).
+To identify other parts of the project that might need additional documentation,
+think of the following:
+
+- Is there anything that you know particularly well that you feel other
+  maintainers might not?
+- On the other hand, is there anything that you do not know well and feel could
+  be better documented? This could be a good time to learn more about it with
+  hands on experience researching and documenting it. **This is especially
+  important if it is something that none of the maintainers know well.**
+- Is there ambient context or domain-specific knowledge that is not explicitly
+  documented that should be?
+
+If you start writing documentation, you're likely to open a PR. This is okay,
+text/documentation PRs are excluded from the list of requested reviews as they
+have a significantly lower review burden than code changes, in particular
+because the consequences of incorrect or poor documentation are usually far less
+severe than incorrect code.


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2304 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds:

- a new page to list tasks maintainers should consider doing instead of opening a new PR. It also gives helpful advice for some of these or links to other parts of the documentation that talk about that task.
- additional documentation to the contributing docs for further ways to help issue backlog maintenance. I added this here, specifically, because it is something anyone can help with effectively, not just maintainers.
- a new page to document communication aliases and their purposes. This is linked to from the issue backlog maintenance documentation and could be used elsewhere in the documentation, I think.
- a new page to give advice for proofreading documentation. This is a separate page because I wanted to put it somewhere that we could reference for our occasional documentation bug bashes and because it's pretty general information. It could apply to any contributor reviewing documentation, not just maintainers.
    - For this, I'd like to create some way of documenting the last time a particular page was reviewed. I'm not sure the best way to do this. I thought, for example, of creating a table in that document listing each page and space for a date and name of the person who reviewed it. However, that would require a PR to update and might be kind of tedious. Alternatively, we could use a Google sheet, but links would more easily go out of date if a page is removed or moved and it could easily be vandalised if we wanted to make it easier for any contributor to record that they've reviewed a page. Neither of these easily allow for sorting, though, and that is kind of a bummer, as it'd make it a lot easier if it could be sorted with the pages least recently reviewed at the top. We could maintain this on our own in a table by bumping pages to the bottom when we review them in, but that would be a big heavy. We could also write a small amount of JavaScript to automatically do this for us on that specific page. Maybe that's the best option, as far as auditability and usability goes?
    - This kind of log would probably be more important for the guides, but I think would be useful for all our pages and would make it a lot easier for someone to pick a page to go over. Otherwise, you kind of just have to choose one and it would be very easy for any given page to go a long time without someone picking it by chance.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Read the new documentation. Ensure it makes sense and accomplishes the goal. You can follow the brief advice on proofreading documentation even... dog-fooding it, perhaps :slightly_smiling_face: 

Give advice on how you think the best way to record the last time a page was reviewed or if you even think that's helpful to have at all.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
