### PR TITLE
Add assertions to the `fetchSingleMediaType does not reset images if shouldPersistMedia is true`

### DIFF
--- a/frontend/test/unit/specs/stores/media-store.spec.js
+++ b/frontend/test/unit/specs/stores/media-store.spec.js
@@ -332,19 +332,39 @@ describe("Media Store", () => {
       })
     })
 
-    // https://github.com/WordPress/openverse/issues/2223
-    // eslint-disable-next-line jest/no-disabled-tests, jest/expect-expect
-    it.skip("fetchSingleMediaType does not reset images if page is defined", async () => {
+    it("fetchSingleMediaType does not reset images if shouldPersistMedia is true", async () => {
       const mediaStore = useMediaStore()
+      const img1 = {
+        id: "123",
+        frontendMediaType: "image",
+        title: "Foo",
+        creator: "bar",
+        tags: [],
+      }
+      mediaStore.$patch({
+        results: {
+          image: {
+            page: 1,
+            count: 1,
+            pageCount: 10,
+          },
+        },
+      })
+      mediaStore.$patch((state) => {
+        state.results.image.items = { 123: img1 }
+      })
 
       const mediaType = IMAGE
       const params = {
         q: "foo",
         page: 1,
-        shouldPersistMedia: false,
+        shouldPersistMedia: true,
         mediaType,
       }
       await mediaStore.fetchSingleMediaType(params)
+      const results = mediaStore.results[mediaType]
+      expect(results.items["123"]).toEqual(img1)
+      expect(results.page).toBe(2)
     })
 
     it("clearMedia resets the results", () => {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2223 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the said test by adding the assertions, and changing the condition for not resetting the images from "page not being undefined" to "shouldPersistMedia being true".

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass. If the test without `.skip` did not have an assertion, it would fail the CI. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
