### PR TITLE
Enable "should allow changing the type" test for VInputField

### DIFF
--- a/frontend/test/unit/specs/components/InputField/input-field.spec.js
+++ b/frontend/test/unit/specs/components/InputField/input-field.spec.js
@@ -32,6 +32,7 @@ describe("VInputField", () => {
       },
       propsData: props,
     })
+
     const element = screen.getByPlaceholderText("Enter some number")
 
     expect(element).toHaveAttribute("type", "number")

--- a/frontend/test/unit/specs/components/InputField/input-field.spec.js
+++ b/frontend/test/unit/specs/components/InputField/input-field.spec.js
@@ -24,9 +24,7 @@ describe("VInputField", () => {
     expect(element).toHaveAttribute("type", "text")
   })
 
-  // https://github.com/WordPress/openverse/issues/2222
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should allow changing the type", () => {
+  it("should allow changing the type", () => {
     render(VInputField, {
       attrs: {
         placeholder: "Enter some number",
@@ -34,7 +32,6 @@ describe("VInputField", () => {
       },
       propsData: props,
     })
-
     const element = screen.getByPlaceholderText("Enter some number")
 
     expect(element).toHaveAttribute("type", "number")


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2222 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Fixes the `"should allow changing the type"` test by simply enabling it. I believe this test may have been incorrectly marked as not having an assertion. Previously it was skipped with `xit()` but enabling the test works correctly. 

The test is quite simple, it renders a VInputField and makes sure it can be switched to `type="number"`. I'm not sure of the usefulness of this test but it doesn't seem to hurt to enable it.

Apologies if I'm missing something very obvious here 😊 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
