### PR TITLE
Remove string reference to old s3 bucket

### DIFF
--- a/catalog/dags/retired/common/etl/scripts/ExtractCCLinks.py
+++ b/catalog/dags/retired/common/etl/scripts/ExtractCCLinks.py
@@ -22,7 +22,7 @@ from warcio.archiveiterator import ArchiveIterator
 
 
 BUCKET = os.environ.get("COMMONCRAWL_BUCKET", "not_set")
-COMMONSMAPPER_BUCKET = os.environ.get("COMMONSMAPPER_BUCKET", "ov-commonsmapper")
+COMMONSMAPPER_BUCKET = os.environ.get("COMMONSMAPPER_BUCKET", "not_set")
 
 class CCLinks:
     def __init__(self, _index, _ptn=2500):

--- a/catalog/dags/retired/common/etl/scripts/ExtractCCLinks.py
+++ b/catalog/dags/retired/common/etl/scripts/ExtractCCLinks.py
@@ -22,7 +22,7 @@ from warcio.archiveiterator import ArchiveIterator
 
 
 BUCKET = os.environ.get("COMMONCRAWL_BUCKET", "not_set")
-
+COMMONSMAPPER_BUCKET = os.environ.get("COMMONSMAPPER_BUCKET", "ov-commonsmapper")
 
 class CCLinks:
     def __init__(self, _index, _ptn=2500):
@@ -56,7 +56,7 @@ class CCLinks:
         self.url = "https://{}.s3.amazonaws.com/crawl-data/{}/wat.paths.gz".format(
             BUCKET, self.crawlIndex
         )
-        self.output = f"s3://commonsmapper-v2/output/{self.crawlIndex}"
+        self.output = f"s3://{COMMONSMAPPER_BUCKET}/output/{self.crawlIndex}"
 
     def loadWATFile(self):
         # load the WAT file paths


### PR DESCRIPTION
Removes a string reference to an old s3 bucket in the retired ETL pipeline script. 

This bucket has been reclaimed by another user and was flagged in a security review of the repo. This PR really only exists to prevent further warnings, even though this dead, unused code poses no actual security risk.