### PR TITLE
Check filtered index feature flag before querying in `SearchContext`

### DIFF
--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -1,6 +1,8 @@
 from dataclasses import asdict, dataclass
 from typing import Self
 
+from django.conf import settings
+
 from elasticsearch_dsl import Q, Search
 from elasticsearch_dsl.response import Hit
 
@@ -25,6 +27,9 @@ class SearchContext:
             return cls(set(), set())
 
         all_result_identifiers = {r.identifier for r in results}
+
+        if not settings.ENABLE_FILTERED_INDEX_QUERIES:
+            return cls(all_result_identifiers, set())
 
         filtered_index_search = Search(index=f"{origin_index}-filtered")
         filtered_index_search = filtered_index_search.query(

--- a/api/test/unit/utils/test_search_context.py
+++ b/api/test/unit/utils/test_search_context.py
@@ -17,7 +17,16 @@ def test_no_results(media_type_config):
     (True, False),
     ids=lambda x: "has_sensitive_text" if x else "no_sensitive_text",
 )
-def test_sensitive_text(media_type_config, has_sensitive_text):
+@pytest.mark.parametrize(
+    "setting_enabled",
+    (True, False),
+    ids=lambda x: "setting_enabled" if x else "setting_disabled",
+)
+def test_sensitive_text(
+    media_type_config, has_sensitive_text, setting_enabled, settings
+):
+    settings.ENABLE_FILTERED_INDEX_QUERIES = setting_enabled
+
     clear_results = media_type_config.model_factory.create_batch(
         # Use size 10 to force result size beyond the default ES query window
         size=10,
@@ -43,5 +52,7 @@ def test_sensitive_text(media_type_config, has_sensitive_text):
 
     assert search_context == SearchContext(
         {r.identifier for r in results},
-        {maybe_sensitive_text_model.identifier} if has_sensitive_text else set(),
+        {maybe_sensitive_text_model.identifier}
+        if has_sensitive_text and setting_enabled
+        else set(),
     )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2407  by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Checks the feature flag before querying the filtered index.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
First, confirm you know how to reproduce the issue on `main`. Checkout `main` and update `api/env` to set `ENABLE_FILTERED_INDEX_QUERIES=False` to match the live environment configuration. Next, delete the `image-filtered` alias in your local Elasticsearch cluster:

```
$ curl -X DELETE http://0.0.0.0:50292/image-init-filtered/_alias/image-filtered
```

Confirm the index is deleted by sending:

```
$ curl http://0.0.0.0:50292/image-init-filtered/_alias
```

And confirm the response matches (empty `aliases` object):

```json
{"image-init-filtered":{"aliases":{}}}
```

Now make a request to http://localhost:50280/v1/images/ and confirm you get a 500 about `image-filtered` not existing.

Now, check out this branch and `just down && just api/up` and make the same http://localhost:50280/v1/images/ request again, and you should no longer have the 500, just a successful image search.

Confirm the additional unit test sufficiently covers the changes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
