### PR TITLE
Prevent unnecessary post-process results recursion

### DIFF
--- a/api/api/utils/dead_link_mask.py
+++ b/api/api/utils/dead_link_mask.py
@@ -1,5 +1,5 @@
+import django_redis
 from deepdiff import DeepHash
-from django_redis import get_redis_connection
 from elasticsearch_dsl import Search
 
 
@@ -32,7 +32,7 @@ def get_query_mask(query_hash: str) -> list[int]:
     :param query_hash: Unique value for a particular query.
     :return: Boolean mask as a list of integers (0 or 1).
     """
-    redis = get_redis_connection("default")
+    redis = django_redis.get_redis_connection("default")
     key = f"{query_hash}:dead_link_mask"
     return list(map(int, redis.lrange(key, 0, -1)))
 
@@ -44,7 +44,7 @@ def save_query_mask(query_hash: str, mask: list):
     :param mask: Boolean mask as a list of integers (0 or 1).
     :param query_hash: Unique value to be used as key.
     """
-    redis_pipe = get_redis_connection("default").pipeline()
+    redis_pipe = django_redis.get_redis_connection("default").pipeline()
     key = f"{query_hash}:dead_link_mask"
 
     redis_pipe.delete(key)

--- a/api/test/factory/es_http.py
+++ b/api/test/factory/es_http.py
@@ -1,0 +1,79 @@
+from uuid import uuid4
+
+
+MOCK_LIVE_RESULT_URL = "https://example.com/openverse-image-result-url"
+MOCK_DEAD_RESULT_URL = f"{MOCK_LIVE_RESULT_URL}-dead"
+
+
+def create_mock_es_http_image_hit(_id: str, index: str, live: bool = True):
+    return {
+        "_index": index,
+        "_type": "_doc",
+        "_id": _id,
+        "_score": 7.607353,
+        "_source": {
+            "thumbnail": None,
+            "aspect_ratio": "wide",
+            "extension": "jpg",
+            "size": "large",
+            "authority_boost": 85,
+            "max_boost": 85,
+            "min_boost": 1,
+            "id": _id,
+            "identifier": str(uuid4()),
+            "title": "Bird Nature Photo",
+            "foreign_landing_url": "https://example.com/photo/LYTN21EBYO",
+            "creator": "Nature's Beauty",
+            "creator_url": "https://example.com/author/121424",
+            "url": MOCK_LIVE_RESULT_URL if live else MOCK_DEAD_RESULT_URL,
+            "license": "cc0",
+            "license_version": "1.0",
+            "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "provider": "example",
+            "source": "example",
+            "category": "photograph",
+            "created_on": "2022-02-26T08:48:33+00:00",
+            "tags": [{"name": "bird"}],
+            "mature": False,
+        },
+    }
+
+
+def create_mock_es_http_image_search_response(
+    index: str,
+    total_hits: int,
+    hit_count: int,
+    live_hit_count: int | None = None,
+    base_hits=None,
+):
+    live_hit_count = live_hit_count if live_hit_count is not None else hit_count
+    base_hits = base_hits or []
+
+    live_hits = [
+        create_mock_es_http_image_hit(
+            _id=len(base_hits) + i,
+            index=index,
+            live=True,
+        )
+        for i in range(live_hit_count)
+    ]
+
+    dead_hits = [
+        create_mock_es_http_image_hit(
+            _id=len(live_hits) + len(base_hits) + i,
+            index=index,
+            live=False,
+        )
+        for i in range(hit_count - live_hit_count)
+    ]
+
+    return {
+        "took": 3,
+        "timed_out": False,
+        "_shards": {"total": 18, "successful": 18, "skipped": 0, "failed": 0},
+        "hits": {
+            "total": {"value": total_hits, "relation": "eq"},
+            "max_score": 11.0007305,
+            "hits": base_hits + live_hits + dead_hits,
+        },
+    }

--- a/api/test/factory/es_http.py
+++ b/api/test/factory/es_http.py
@@ -1,8 +1,8 @@
 from uuid import uuid4
 
 
-MOCK_LIVE_RESULT_URL = "https://example.com/openverse-image-result-url"
-MOCK_DEAD_RESULT_URL = f"{MOCK_LIVE_RESULT_URL}-dead"
+MOCK_LIVE_RESULT_URL_PREFIX = "https://example.com/openverse-live-image-result-url"
+MOCK_DEAD_RESULT_URL_PREFIX = "https://example.com/openverse-dead-image-result-url"
 
 
 def create_mock_es_http_image_hit(_id: str, index: str, live: bool = True):
@@ -25,7 +25,9 @@ def create_mock_es_http_image_hit(_id: str, index: str, live: bool = True):
             "foreign_landing_url": "https://example.com/photo/LYTN21EBYO",
             "creator": "Nature's Beauty",
             "creator_url": "https://example.com/author/121424",
-            "url": MOCK_LIVE_RESULT_URL if live else MOCK_DEAD_RESULT_URL,
+            "url": f"{MOCK_LIVE_RESULT_URL_PREFIX}/{_id}"
+            if live
+            else f"{MOCK_DEAD_RESULT_URL_PREFIX}/{_id}",
             "license": "cc0",
             "license_version": "1.0",
             "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/api/test/factory/models/media.py
+++ b/api/test/factory/models/media.py
@@ -172,7 +172,7 @@ class MediaFactory(DjangoModelFactory):
             {
                 "_index": origin_index,
                 "_score": 1.0,
-                "_id": media.pk,
+                "_id": str(media.pk),
                 "_source": source_document,
             }
         )

--- a/api/test/factory/models/media.py
+++ b/api/test/factory/models/media.py
@@ -156,7 +156,7 @@ class MediaFactory(DjangoModelFactory):
         source_document = cls._create_es_source_document(media, mature)
         es.create(
             index=origin_index,
-            id=media.pk,
+            id=str(media.pk),
             document=source_document,
             refresh=True,
         )

--- a/api/test/test_dead_link_filter.py
+++ b/api/test/test_dead_link_filter.py
@@ -18,9 +18,6 @@ def redis(monkeypatch) -> FakeRedis:
     def get_redis_connection(*args, **kwargs):
         return fake_redis
 
-    monkeypatch.setattr(
-        "api.utils.dead_link_mask.get_redis_connection", get_redis_connection
-    )
     monkeypatch.setattr("django_redis.get_redis_connection", get_redis_connection)
 
     yield fake_redis

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -712,6 +712,7 @@ def test_post_process_results_recurses_as_needed(
         # The dead link ratio causes the initial query size to double
         .body(re.compile(f'size":{(page_size * page) * 2}'))
         .body(re.compile('from":0'))
+        .times(1)
         .reply(200)
         .json(mock_es_response_1)
         .mock
@@ -722,6 +723,7 @@ def test_post_process_results_recurses_as_needed(
         # Size is clamped to the total number of available hits
         .body(re.compile(f'size":{mock_total_hits}'))
         .body(re.compile('from":0'))
+        .times(1)
         .reply(200)
         .json(mock_es_response_2)
         .mock
@@ -745,7 +747,11 @@ def test_post_process_results_recurses_as_needed(
     )
 
     mock_filtered_es_request = (
-        pook.post(filtered_es_endpoint).reply(200).json(mock_filtered_es_response).mock
+        pook.post(filtered_es_endpoint)
+        .times(1)
+        .reply(200)
+        .json(mock_filtered_es_response)
+        .mock
     )
 
     pook.head(


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2415 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Stops `_post_process_results` recursion once the total available hits have been exhausted. Previously, if queries were unable to fill the page_size with live links, `_post_process_results` would continue to iterate until the ES max page depth was met.

For some reason the `Hit` `__repr__` was suddenly failing for me and causing tests to incorrectly fail (call argument mocks use `repr`, apparently). The fix for this was to ensure the document `_id` is a string. Here is the error I was seeing:

```
self = <[TypeError('sequence item 1: expected str instance, int found') raised in repr()] Hit object at 0x7f34bb326c90>

    def __repr__(self):
        return "<Hit({}): {}>".format(
>           "/".join(
                getattr(self.meta, key) for key in ("index", "id") if key in self.meta
            ),
            super(Hit, self).__repr__(),
        )
E       TypeError: sequence item 1: expected str instance, int found
```

`self.meta.id` was an `int`. Changing the factory to pass a string here (which does match ES's actual response type) fixed the issue.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Make sure you understand how to reproduce the error on `main`, follow the reproduction instructions in the issue.

Once you've done that, check out this branch and try to reproduce the issue. You should not be able to. With the example in the issue, you should see a single call to `post_process_results`.

The unit test attempts to cover the case where additional calls to `post_process_results` are needed to fill the first or last page of a query. It becomes increasingly complex to test the more calls to `post_process_results` we want to assert, but I can try to add more unit tests if we want examples of recursion depth greater than 2 in the unit tests. The unit tests are also fairly complex, if reviewers have any ideas for how to simplify (and especially how to _clarify_ them), please share.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
