### PR TITLE
Replaced get* assertions in testing library with explicit assertions

### DIFF
--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["queryByText", "getDmcaInput", "getMatureInput", "getOtherInput", "getCancelButton", "getReportButton", "getReportLink", "getDescriptionTextarea", "expect"] }] */
+
 import { fireEvent, screen } from "@testing-library/vue"
 
 import { render } from "~~/test/unit/test-utils/render"

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -82,7 +82,7 @@ describe("VContentReportForm", () => {
   })
 
   it("should render thank you note when report is sent", async () => {
-    const { getByText } = render(VContentReportForm, options)
+    const { queryByText } = render(VContentReportForm, options)
     await fireEvent.click(getMatureInput())
     await fireEvent.click(getReportButton())
 
@@ -93,7 +93,7 @@ describe("VContentReportForm", () => {
   it("should render error message if report sending fails", async () => {
     ReportService.sendReport = () => Promise.reject()
 
-    const { getByText } = render(VContentReportForm, options)
+    const { queryByText } = render(VContentReportForm, options)
     await fireEvent.click(getMatureInput())
     await fireEvent.click(getReportButton())
 
@@ -102,7 +102,7 @@ describe("VContentReportForm", () => {
   })
 
   it("should render DMCA notice", async () => {
-    const { getByText } = render(VContentReportForm, options)
+    const { queryByText } = render(VContentReportForm, options)
     await fireEvent.click(getDmcaInput())
 
     // Notice with link to provider
@@ -113,7 +113,7 @@ describe("VContentReportForm", () => {
   })
 
   it("should render other description form", async () => {
-    const { getByText } = render(VContentReportForm, options)
+    const { queryByText } = render(VContentReportForm, options)
     await fireEvent.click(getOtherInput())
 
     // Report form with a submit button

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -13,36 +13,36 @@ jest.mock("~/composables/use-analytics", () => ({
 }))
 
 const getDmcaInput = () =>
-  expect(screen.findByRole("radio", {
+  screen.getByRole("radio", {
     name: /Infringes copyright/i,
-  })).toBeInTheDocument()
+  })
 const getMatureInput = () =>
-  expect(screen.findByRole("radio", {
+  screen.getByRole("radio", {
     name: /mature/i,
-  })).toBeInTheDocument()
+  })
 const getOtherInput = () =>
-  expect(screen.findByRole("radio", {
+  screen.getByRole("radio", {
     name: /other/i,
-  })).toBeInTheDocument()
+  })
 const getCancelButton = () =>
-  expect(screen.findByRole("button", {
+  screen.getByRole("button", {
     name: /cancel/i,
-  })).toBeInTheDocument()
+  })
 const getReportButton = () =>
-  expect(screen.findByRole("button", {
+  screen.getByRole("button", {
     name: /report/i,
-  })).toBeInTheDocument()
+  })
 
 // When DMCA selected
 const getReportLink = () =>
-  expect(screen.findByRole("link", {
+  screen.getByRole("link", {
     name: /DMCA form/i,
-  })).toBeInTheDocument()
+  })
 // When other selected
 const getDescriptionTextarea = () =>
-  expect(screen.findByRole("textbox", {
+  screen.getByRole("textbox", {
     name: /Describe the issue. Required/i,
-  })).toBeInTheDocument()
+  })
 
 const mockImplementation = () => Promise.resolve()
 const mock = jest.fn().mockImplementation(mockImplementation)
@@ -87,7 +87,7 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getReportButton())
 
     // Submission successful message
-    getByText(/Thank you for reporting this content/i)
+    expect(queryByText(/Thank you for reporting this content/i)).toBeInTheDocument()
   })
 
   it("should render error message if report sending fails", async () => {
@@ -98,7 +98,7 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getReportButton())
 
     // Submission error message
-    getByText(/Something went wrong, please try again after some time./i)
+    expect(queryByText(/Something went wrong, please try again after some time./i)).toBeInTheDocument()
   })
 
   it("should render DMCA notice", async () => {
@@ -106,9 +106,9 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getDmcaInput())
 
     // Notice with link to provider
-    getByText(
+    expect(queryByText(
       /No action will be taken until this form is filled out and submitted/i
-    )
+    )).toBeInTheDocument()
     getReportLink()
   })
 
@@ -117,7 +117,7 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getOtherInput())
 
     // Report form with a submit button
-    getByText(/Describe the issue./i)
+    expect(queryByText(/Describe the issue./i)).toBeInTheDocument()
     getDescriptionTextarea()
   })
 

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,4 +1,3 @@
-
 import { fireEvent, screen } from "@testing-library/vue"
 
 import { render } from "~~/test/unit/test-utils/render"
@@ -14,34 +13,34 @@ jest.mock("~/composables/use-analytics", () => ({
 }))
 
 const getDmcaInput = () =>
-  screen.getByRole("radio", {
+  screen.queryByRole("radio", {
     name: /Infringes copyright/i,
   })
 const getMatureInput = () =>
-  screen.getByRole("radio", {
+  screen.queryByRole("radio", {
     name: /mature/i,
   })
 const getOtherInput = () =>
-  screen.getByRole("radio", {
+  screen.queryByRole("radio", {
     name: /other/i,
   })
 const getCancelButton = () =>
-  screen.getByRole("button", {
+  screen.queryByRole("button", {
     name: /cancel/i,
   })
 const getReportButton = () =>
-  screen.getByRole("button", {
+  screen.queryByRole("button", {
     name: /report/i,
   })
 
 // When DMCA selected
 const getReportLink = () =>
-  screen.getByRole("link", {
+  screen.queryByRole("link", {
     name: /DMCA form/i,
   })
 // When other selected
 const getDescriptionTextarea = () =>
-  screen.getByRole("textbox", {
+  screen.queryByRole("textbox", {
     name: /Describe the issue. Required/i,
   })
 
@@ -75,11 +74,14 @@ describe("VContentReportForm", () => {
 
   it("should contain the correct contents", async () => {
     await render(VContentReportForm, options)
-    getDmcaInput()
-    getMatureInput()
-    getOtherInput()
-    getCancelButton()
-    getReportLink()
+    expect(getDmcaInput()).toBeVisible()
+    expect(getMatureInput()).toBeVisible()
+    expect(getOtherInput()).toBeVisible()
+    expect(getCancelButton()).toBeVisible()
+    // By default, DMCA is selected, and we show a link to
+    // the report form instead of a report button.
+    expect(getReportButton()).not.toBeInTheDocument()
+    expect(getReportLink()).toBeVisible()
   })
 
   it("should render thank you note when report is sent", async () => {

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -89,7 +89,9 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getReportButton())
 
     // Submission successful message
-    expect(queryByText(/Thank you for reporting this content/i)).toBeInTheDocument()
+    expect(
+      queryByText(/Thank you for reporting this content/i)
+    ).toBeInTheDocument()
   })
 
   it("should render error message if report sending fails", async () => {
@@ -100,7 +102,9 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getReportButton())
 
     // Submission error message
-    expect(queryByText(/Something went wrong, please try again after some time./i)).toBeInTheDocument()
+    expect(
+      queryByText(/Something went wrong, please try again after some time./i)
+    ).toBeInTheDocument()
   })
 
   it("should render DMCA notice", async () => {
@@ -108,9 +112,11 @@ describe("VContentReportForm", () => {
     await fireEvent.click(getDmcaInput())
 
     // Notice with link to provider
-    expect(queryByText(
-      /No action will be taken until this form is filled out and submitted/i
-    )).toBeInTheDocument()
+    expect(
+      queryByText(
+        /No action will be taken until this form is filled out and submitted/i
+      )
+    ).toBeInTheDocument()
     getReportLink()
   })
 

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,4 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["queryByText", "getDmcaInput", "getMatureInput", "getOtherInput", "getCancelButton", "getReportButton", "getReportLink", "getDescriptionTextarea", "expect"] }] */
 
 import { fireEvent, screen } from "@testing-library/vue"
 

--- a/frontend/test/unit/specs/components/v-content-report-form.spec.js
+++ b/frontend/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["getByText", "getDmcaInput", "getMatureInput", "getOtherInput", "getCancelButton", "getReportButton", "getReportLink", "getDescriptionTextarea", "expect"] }] */
-
 import { fireEvent, screen } from "@testing-library/vue"
 
 import { render } from "~~/test/unit/test-utils/render"
@@ -15,36 +13,36 @@ jest.mock("~/composables/use-analytics", () => ({
 }))
 
 const getDmcaInput = () =>
-  screen.getByRole("radio", {
+  expect(screen.findByRole("radio", {
     name: /Infringes copyright/i,
-  })
+  })).toBeInTheDocument()
 const getMatureInput = () =>
-  screen.getByRole("radio", {
+  expect(screen.findByRole("radio", {
     name: /mature/i,
-  })
+  })).toBeInTheDocument()
 const getOtherInput = () =>
-  screen.getByRole("radio", {
+  expect(screen.findByRole("radio", {
     name: /other/i,
-  })
+  })).toBeInTheDocument()
 const getCancelButton = () =>
-  screen.getByRole("button", {
+  expect(screen.findByRole("button", {
     name: /cancel/i,
-  })
+  })).toBeInTheDocument()
 const getReportButton = () =>
-  screen.getByRole("button", {
+  expect(screen.findByRole("button", {
     name: /report/i,
-  })
+  })).toBeInTheDocument()
 
 // When DMCA selected
 const getReportLink = () =>
-  screen.getByRole("link", {
+  expect(screen.findByRole("link", {
     name: /DMCA form/i,
-  })
+  })).toBeInTheDocument()
 // When other selected
 const getDescriptionTextarea = () =>
-  screen.getByRole("textbox", {
+  expect(screen.findByRole("textbox", {
     name: /Describe the issue. Required/i,
-  })
+  })).toBeInTheDocument()
 
 const mockImplementation = () => Promise.resolve()
 const mock = jest.fn().mockImplementation(mockImplementation)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2315 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I removed a comment in `v-content-report-form.spec.js`, and replaced implicit `get` assertions in the testing library with explicit assertions.
I did this by using Jest's `expect` function along with `toBeInTheDocument` on the tests instead of `get`.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
