### PR TITLE
Fix text wrapping in watermarked images

### DIFF
--- a/api/api/utils/watermark.py
+++ b/api/api/utils/watermark.py
@@ -79,7 +79,9 @@ def _fit_in_width(text, font, max_width):
     """
 
     char_length = font.getlength("x")  # x has the closest to average width
-    max_chars = max_width // char_length
+    max_chars = int(
+        max_width // char_length
+    )  # Must be an integer to be used with `wrap` below
 
     text = "\n".join(["\n".join(wrap(line, max_chars)) for line in text.split("\n")])
 

--- a/api/test/unit/utils/test_watermark.py
+++ b/api/test/unit/utils/test_watermark.py
@@ -51,3 +51,18 @@ def test_sends_UA_header(requests):
     assert len(requests.requests) > 0
     for r in requests.requests:
         assert r.headers == HEADERS
+
+
+def test_long_title_returns_correctly(requests):
+    # Make the title 400 chars long
+    _MOCK_IMAGE_INFO_LONG_TITLE = dict(_MOCK_IMAGE_INFO)
+    _MOCK_IMAGE_INFO_LONG_TITLE["title"] = "a" * 400
+
+    watermark("http://example.com/", _MOCK_IMAGE_INFO_LONG_TITLE)
+
+    assert len(requests.requests) > 0
+    for r in requests.requests:
+        assert r.headers == HEADERS
+
+    # Assert that the content of the response is the mock image bytes
+    assert requests.requests[0].response.content == _MOCK_IMAGE_BYTES

--- a/api/test/unit/utils/test_watermark.py
+++ b/api/test/unit/utils/test_watermark.py
@@ -53,7 +53,10 @@ def test_sends_UA_header(requests):
         assert r.headers == HEADERS
 
 
-def test_long_title_returns_correctly(requests):
+# Previously, wrapped titles would throw a TypeError:
+# slice indices must be integers or None or have an __index__ method.
+# See: https://github.com/WordPress/openverse/issues/2466
+def test_long_title_wraps_correctly(requests):
     # Make the title 400 chars long
     _MOCK_IMAGE_INFO_LONG_TITLE = dict(_MOCK_IMAGE_INFO)
     _MOCK_IMAGE_INFO_LONG_TITLE["title"] = "a" * 400
@@ -63,6 +66,3 @@ def test_long_title_returns_correctly(requests):
     assert len(requests.requests) > 0
     for r in requests.requests:
         assert r.headers == HEADERS
-
-    # Assert that the content of the response is the mock image bytes
-    assert requests.requests[0].response.content == _MOCK_IMAGE_BYTES


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2466 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Fixes the watermark endpoint's ability to wrap text to multiple lines.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Make sure tests pass. Also, you could add this test to `main` and verify that it fails there:

```diff
diff --git a/api/test/unit/utils/test_watermark.py b/api/test/unit/utils/test_watermark.py
index f9a8c994d..1fb5814a3 100644
--- a/api/test/unit/utils/test_watermark.py
+++ b/api/test/unit/utils/test_watermark.py
@@ -51,3 +51,17 @@ def test_sends_UA_header(requests):
     assert len(requests.requests) > 0
     for r in requests.requests:
         assert r.headers == HEADERS
+
+def test_long_title_returns_correctly(requests):
+    # Make the title 400 chars long
+    _MOCK_IMAGE_INFO_LONG_TITLE = dict(_MOCK_IMAGE_INFO)
+    _MOCK_IMAGE_INFO_LONG_TITLE["title"] = "a" * 400
+
+    watermark("http://example.com/", _MOCK_IMAGE_INFO_LONG_TITLE)
+
+    assert len(requests.requests) > 0
+    for r in requests.requests:
+        assert r.headers == HEADERS
+
+    # Assert that the content of the response is the mock image bytes
+    assert requests.requests[0].response.content == _MOCK_IMAGE_BYTES
```

on macos copy the diff here and `pbpaste | git apply`. Otherwise save it to a file and `cat diff.patch | git apply`.

Then, run the test file with `just api/test test/unit/utils/test_watermark.py`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
