### PR TITLE
Filter single media views for hidden providers

### DIFF
--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -56,7 +56,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
             provider__in=ContentProvider.objects.filter(
                 filter_content=True
             ).values_list("provider_identifier")
-        ).all()
+        )
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -8,6 +8,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from api.controllers import search_controller
 from api.models import ContentProvider
+from api.models.media import AbstractMedia
 from api.serializers.provider_serializers import ProviderSerializer
 from api.utils import image_proxy
 from api.utils.pagination import StandardPagination
@@ -26,7 +27,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
     pagination_class = StandardPagination
 
     # Populate these in the corresponding subclass
-    model_class = None
+    model_class: AbstractMedia = None
     query_serializer_class = None
     default_index = None
 
@@ -42,7 +43,20 @@ class MediaViewSet(ReadOnlyModelViewSet):
             raise ValueError(msg)
 
     def get_queryset(self):
-        return self.model_class.objects.all()
+        # The alternative to a sub-query would be using `extra` to do a join
+        # to the content provider table and filtering `filter_content`. However,
+        # that assumes that a content provider entry exists, which is not necessarily
+        # the case. We often don't add a content provider until after works from
+        # new providers are available in the API, and sometimes not even then.
+        # Search returns results with providers that do not have a ContentProvider
+        # table entry. Therefore, to maintain that assumption, a subquery is the only
+        # workable approach, as Django's `extra` does not provide any facility for
+        # handling null relations on the join.
+        return self.model_class.objects.exclude(
+            provider__in=ContentProvider.objects.filter(
+                filter_content=True
+            ).values_list("provider_identifier")
+        ).all()
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -27,7 +27,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
     pagination_class = StandardPagination
 
     # Populate these in the corresponding subclass
-    model_class: AbstractMedia = None
+    model_class: type[AbstractMedia] = None
     query_serializer_class = None
     default_index = None
 

--- a/api/test/unit/views/test_media_views.py
+++ b/api/test/unit/views/test_media_views.py
@@ -1,7 +1,11 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 import pytest_django.asserts
+
+from api.models.models import ContentProvider
 
 
 @pytest.mark.django_db
@@ -34,5 +38,50 @@ def test_retrieve_query_count(api_client, media_type_config):
     # This number goes up without `select_related` in the viewset queryset.
     with pytest_django.asserts.assertNumQueries(1):
         res = api_client.get(f"/v1/{media_type_config.url_prefix}/{media.identifier}/")
+
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "filter_content", (True, False), ids=lambda x: "filtered" if x else "not_filtered"
+)
+@pytest.mark.django_db
+def test_get_queryset_provider_filtering(api_client, media_type_config, filter_content):
+    test_provider = "test_provider_filtering_provider"
+    media = media_type_config.model_factory.create(provider=test_provider)
+
+    ContentProvider.objects.create(
+        created_on=datetime.now(tz=timezone.utc),
+        provider_identifier=test_provider,
+        provider_name="Test Provider",
+        domain_name="https://example.com",
+        filter_content=filter_content,
+    )
+
+    res = api_client.get(f"/v1/{media_type_config.url_prefix}/{media.identifier}/")
+
+    assert res.status_code == (404 if filter_content else 200)
+
+
+@pytest.mark.django_db
+def test_get_queryset_does_not_exclude_works_without_contentprovider_entry(
+    api_client, media_type_config
+):
+    """
+    Search only excludes works when a content provider entry exists AND that
+    entry has `filter_content=True`. Critically this means it will include works
+    from providers that do not have a content provider entry. To ensure the individual
+    media views follow the same behaviour, this test retrieves a single media result
+    assigned to a provider that has no content provider entry.
+    """
+    test_provider = f"test_provider_{uuid4()}"
+    media = media_type_config.model_factory.create(provider=test_provider)
+
+    assert (
+        ContentProvider.objects.filter(provider_identifier=test_provider).exists()
+        is False
+    )
+
+    res = api_client.get(f"/v1/{media_type_config.url_prefix}/{media.identifier}/")
 
     assert res.status_code == 200


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2483 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a filter to exclude works for which the provider has `filter_content=True`. Please see the comment for why we must use a subquery rather than a join. Note that this **does not** increase the number of queries on these endpoints, as proven by the query counting tests in `test_media_views`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Reproduce the problem in the issue locally by running `just api/up` on `main`. Visit `/v1/images` and confirm you see results from flickr. Click on one of the single result views from the flickr provider and leave the tab open. Go to `/admin` in another tab (deploy/deploy are username/password) and set filter content to true on the flickr provider from the ContentProvider view. In the single result tab, refresh the page and confirm you can still access the result. Confirm that you cannot see the flickr result at `/v1/images` any more. Additionally, to reproduce search returning results for works that do not have an associated ContentProvider entry, delete the flickr view and confirm that you can now see the flickr results at `/v1/images` again.

Now checkout this branch and do the same test. You will need to add the flickr provider back again or run `just api/init` (potentially with `just down -v`) to get it back before running the manual test. Confirm that you cannot access the single result when the provider's filter content is enabled but that you can still access it if you delete the provider.

Look over the new unit tests and confirm they cover the case. Note that I did not opt to test all endpoints even though each endpoint does need to correctly use `get_object` for this approach to work. I could add a `parametrize` for it but wanted to avoid overkill. Just let me know if you think it's worth doing.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
