### PR TITLE
Add tzinfo in factory generated access tokens

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -5,5 +5,4 @@ pythonpath = .
 
 filterwarnings=
   ignore:Unverified HTTPS request
-  ignore:DateTimeField AccessToken\.expires received a naive datetime
   ignore:The default value of USE_TZ will change from False to True in Django 5.0

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -1,5 +1,7 @@
 from test.factory.faker import Faker
 
+from django.utils import timezone
+
 import factory
 from factory.django import DjangoModelFactory
 from oauth2_provider.models import AccessToken
@@ -47,5 +49,10 @@ class AccessTokenFactory(DjangoModelFactory):
         model = AccessToken
 
     token = Faker("uuid4")
-    expires = Faker("date_time_between", start_date="+1y", end_date="+2y")
+    expires = Faker(
+        "date_time_between",
+        start_date="+1y",
+        end_date="+2y",
+        tzinfo=timezone.get_current_timezone(),
+    )
     application = factory.SubFactory(ThrottledApplicationFactory)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

We suppress a warning for `DateTimeField AccessToken\.expires received a naive datetime`, that seems to be raised by tests using our `AccessTokenFactory`, which use `faker` to generate dates that do not have timezone info.

This PR adds tzinfo and removes the suppressed warning.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just api/test` and see that the tests all pass and there are no warnings that match the `DateTimeField AccessToken\.expires received a naive datetime` text.

You can also remove the change to the `oauth2.py` file, but keep the change to `pytest.ini` which stops suppressing the warning, and rerun tests. This time you should see that the warnings were not prevented and do in fact display.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
