### PR TITLE
Fix Sentry configuration for multiprocessing environment

### DIFF
--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -160,6 +160,7 @@ class TaskResource(BaseTaskResource):
         active_workers = Value("i", int(False))
         is_bad_request = Value("i", 0)
 
+        task_sentry_hub = sentry_sdk.Hub(sentry_sdk.Hub.current)
         task = Process(
             target=perform_task,
             kwargs={
@@ -178,6 +179,7 @@ class TaskResource(BaseTaskResource):
                 "destination_index_suffix": destination_index_suffix,
                 "alias": alias,
                 "force_delete": force_delete,
+                "sentry_hub": task_sentry_hub,
             },
         )
         task.start()

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -3,7 +3,10 @@
 import datetime
 import logging
 from enum import Enum, auto
+from functools import wraps
 from multiprocessing import Value
+
+import sentry_sdk
 
 from ingestion_server import slack
 from ingestion_server.constants.media_types import MediaType
@@ -153,6 +156,47 @@ class TaskTracker:
         return {"task_id": task_id} | self.serialize_task_info(task_info)
 
 
+def _with_sentry(fn):
+    """
+    Wrap the decorated function for Sentry multiprocessing.
+
+    Convenience function to wrap ``perform_task`` in such a way
+    to extract the ``sentry_hub`` kwarg passed by ``api.py``, send
+    exceptions to Sentry, and fully flush the client's Sentry
+    queue before the worker exits.
+
+    We cannot use the convenient ``ThreadingIntegration`` because it
+    does not support ``multiprocessing``, only the legacy ``threading``
+    module (we use ``multiprocessing``)
+    """
+
+    @wraps(fn)
+    def fn_with_sentry(*args, **kwargs):
+        hub = kwargs.pop("sentry_hub")
+        with hub:
+            try:
+                result = fn(*args, **kwargs)
+            except Exception as exc:
+                result = None
+                logging.error(exc, exc_info=exc)
+                sentry_sdk.capture_exception(exc)
+
+        client = hub.client
+        if client is not None:
+            # Sentry does not send events right away (it handles messages async)
+            # and because the task finishing will shut down the worker thread
+            # we need to flush the client before exiting the function.
+            # ``client.flush`` will block until all messages in Sentry's queue are sent.
+            # We do this _outside_ the try/except so that _anything_ passed to sentry
+            # (like messages, etc) also get sent before the worker thread is closed.
+            client.flush(timeout=5)
+
+        return result
+
+    return fn_with_sentry
+
+
+@_with_sentry
 def perform_task(
     task_id: str,
     model: MediaType,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2399 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Relevant Sentry docs:

- Multi-thread Sentry: https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
- Draining the client: https://docs.sentry.io/platforms/python/configuration/draining/?original_referrer=https%3A%2F%2Fdocs.sentry.io%2Fplatforms%2Fpython%2Ftroubleshooting%2F

This PR adds a wrapper function around our multiprocessing entrypoint that runs the worker's actual task wrapped inside a Sentry context. This allows the client cloned by the scheduler (in api.py) to capture messages and exceptions. We also catch any exceptions that occur and pass them to the client. Before allowing the worker to exit, the wrapper flushes the client so that all messages actually make their way to Sentry instead of being lost when the thread stops.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The best way to test this is to cause an exception locally and confirm that it sends to Sentry.

To do that, configure `SENTRY_DSN` in `ingestion_server/.env`. Please also set `ENVIRONMENT=local` to prevent alerts showing up in our production monitoring channels.

Then add something like `raise Exception("Testing sentry ingestion server")` in `process_task` and confirm that the exception is captured. You can also try using `sentry_sdk.capture_message` etc to confirm those are also sent. Check in the Sentry project for the DSN you used to confirm everything appears there.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
