### PR TITLE
Make batched_update DAG resistent to mid-update failures

### DIFF
--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -281,11 +281,11 @@ from where it left off. Manually managing this Airflow variable should not be
 necessary.
 
 It is also possible to start an entirely new DagRun using an existing temp
-table, by setting the `skip_table_creation` param to True. With this option
-enabled, the DAG will skip creating the temp table and instead attempt to run an
-update with an existing temp table matching the `query_id`. This option should
-only be used when the DagRun configuration needs to be changed after the table
-was already created: for example, if there was a problem with the `update_query`
+table, by setting the `resume_update` param to True. With this option enabled,
+the DAG will skip creating the temp table and instead attempt to run an update
+with an existing temp table matching the `query_id`. This option should only be
+used when the DagRun configuration needs to be changed after the table was
+already created: for example, if there was a problem with the `update_query`
 which caused DAG failures during the `update_batches` step.
 
 ```
@@ -551,14 +551,14 @@ be run with the `force_refresh_metrics` option to run this refresh after the fir
 of the month.
 
 Once this step is complete, the data refresh can be initiated. A data refresh
-occurs on the data refresh server in the openverse-api project. This is a task
+occurs on the Ingestion server in the openverse project. This is a task
 which imports data from the upstream Catalog database into the API, copies contents
 to a new Elasticsearch index, and finally makes the index "live". This process is
 necessary to make new content added to the Catalog by our provider DAGs available
 to the API. You can read more in the [README](
-https://github.com/WordPress/openverse-api/blob/main/ingestion_server/README.md
+https://github.com/WordPress/openverse/blob/main/ingestion_server/README.md
 ) Importantly, the data refresh TaskGroup is also configured to handle concurrency
-requirements of the data refresh server. Finally, once the origin indexes have been
+requirements of the Ingestion server. Finally, once the origin indexes have been
 refreshed, the corresponding filtered index creation DAG is triggered.
 
 You can find more background information on this process in the following

--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -256,8 +256,6 @@ Optional params:
 - batch_size: int number of records to process in each batch. By default, 10_000
 - update_timeout: int number of seconds to run an individual batch update before
   timing out. By default, 3600 (or one hour)
-- batch_start: int index into the temp table at which to start the update. By
-  default, this is 0 and all rows in the temp table are updated.
 - resume_update: boolean indicating whether to attempt to resume an update using
   an existing temp table matching the `query_id`. When True, a new temp table is
   not created.
@@ -276,310 +274,356 @@ to null would look like this:
 }
 ```
 
-It is possible to resume an update from an arbitrary starting point on an
-existing temp table, for example if a DAG succeeds in creating the temp table
-but fails midway through the update. To do so, set the `resume_update` param to
-True and select your desired `batch_start`. For instance, if the example DAG
-given above failed after processing the first 50_000 records, you might run:
+The `update_batches` task automatically keeps track of its progress in an
+Airflow variable suffixed with the `query_id`. If the task fails, when it
+resumes (either through a retry or by being manually cleared), it will pick up
+from where it left off. Manually managing this Airflow variable should not be
+necessary.
+
+It is also possible to start an entirely new DagRun using an existing temp
+table, by setting the `skip_table_creation` param to True. With this option
+enabled, the DAG will skip creating the temp table and instead attempt to run an
+update with an existing temp table matching the `query_id`. This option should
+only be used when the DagRun configuration needs to be changed after the table
+was already created: for example, if there was a problem with the `update_query`
+which caused DAG failures during the `update_batches` step.
 
 ```
-{
-    "query_id": "my_flickr_query",
-    "table_name": "image",
-    "select_query": "WHERE provider='flickr'",
-    "update_query": "SET thumbnail=null",
-    "batch_size": 10,
-    "batch_start": 50000,
-    "resume_update": true,
-    "dry_run": false
-}
-```
+
 
 ## `check_silenced_dags`
 
+
 ### Silenced DAGs check
 
-Check for DAGs that have silenced Slack alerts or skipped errors which may need
-to be turned back on.
+Check for DAGs that have silenced Slack alerts or skipped errors which may need to be
+turned back on.
 
-When a DAG has known failures, it can be ommitted from Slack error reporting by
-adding an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable.
-Similarly, errors that occur during the `pull_data` step may be configured to
-skip and allow ingestion to continue, using the `SKIPPED_INGESTION_ERRORS`
-Airflow variable. These variables are dictionaries where the key is the `dag_id`
-of the affected DAG, and the value is a list of configuration dictionaries
-mapping an error `predicate` to be skipped/silenced to an open GitHub issue.
+When a DAG has known failures, it can be ommitted from Slack error reporting by adding
+an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. Similarly, errors that
+occur during the `pull_data` step may be configured to skip and allow ingestion to
+continue, using the `SKIPPED_INGESTION_ERRORS` Airflow variable. These variables are
+dictionaries where the key is the `dag_id` of the affected DAG, and the value is a list
+of configuration dictionaries mapping an error `predicate` to be skipped/silenced to an
+open GitHub issue.
 
 The `check_silenced_dags` DAG iterates over the entries in the
 `SILENCED_SLACK_NOTIFICATIONS` and `SKIPPED_INGESTION_ERRORS` configurations and
-verifies that the associated GitHub issues are still open. If an issue has been
-closed, it is assumed that the entry should be removed, and an alert is sent to
-prompt manual update of the configuration. This prevents developers from
-forgetting to reenable Slack reporting or turnoff error skipping after the issue
-has been resolved.
+verifies that the associated GitHub issues are still open. If an issue has been closed,
+it is assumed that the entry should be removed, and an alert is sent to prompt manual
+update of the configuration. This prevents developers from forgetting to reenable Slack
+reporting or turnoff error skipping after the issue has been resolved.
 
 The DAG runs weekly.
 
+
 ## `create_filtered_audio_index`
+
 
 ### Create filtered index DAG factory
 
-This module creates the filtered index creation DAGs for each media type using a
-factory function.
+This module creates the filtered index creation DAGs for each media type
+using a factory function.
 
 Filtered index creation is handled by the ingestion server. The DAGs generated
-by the `build_create_filtered_index_dag` function in this module are responsible
-for triggering the ingestion server action to create and populate the filtered
-index for a given media type. The DAG awaits the completion of the filtered
-index creation and then points the filtered index alias for the media type to
-the newly created index.
+by the ``build_create_filtered_index_dag`` function in this module are
+responsible for triggering the ingestion server action to create and populate
+the filtered index for a given media type. The DAG awaits the completion
+of the filtered index creation and then points the filtered index alias for the
+media type to the newly created index.
 
 #### When this DAG runs
 
 The DAGs generated in this module are triggered by the data refresh DAGs.
 Maintaining this process separate from the data refresh DAGs, while still
-triggering it there, allows us to run filtered index creation independently of
-the full data refresh. This is primarily useful in two cases: for testing
+triggering it there, allows us to run filtered index creation independently
+of the full data refresh. This is primarily useful in two cases: for testing
 changes to the filtered index creation; and for re-running filtered index
 creation if an urgent change to the sensitive terms calls for an immediate
 recreation of the filtered indexes.
 
 #### Race conditions
 
-Because filtered index creation employs the `reindex` Elasticsearch API to
-derive the filtered index from an existing index, we need to be mindful of the
-race condition that potentially exists between the data refresh DAG and this
-DAG. The race condition is caused by the fact that the data refresh DAG always
-deletes the previous index once the new index for the media type is finished
-being created. Consider the situation where filtered index creation is triggered
-to run during a data refresh. The filtered index is being derived from the
-previous index for the media type. Once the data refresh is finished, it will
-delete that index, causing the reindex to halt because suddenly it has no data
-source from which to pull documents.
+Because filtered index creation employs the ``reindex`` Elasticsearch API
+to derive the filtered index from an existing index, we need to be mindful
+of the race condition that potentially exists between the data refresh DAG
+and this DAG. The race condition is caused by the fact that the data refresh
+DAG always deletes the previous index once the new index for the media type
+is finished being created. Consider the situation where filtered index creation
+is triggered to run during a data refresh. The filtered index is being derived
+from the previous index for the media type. Once the data refresh is finished,
+it will delete that index, causing the reindex to halt because suddenly it has
+no data source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh for
-   the media type is already running.
+1. The filtered index creation DAGs are not allowed to run if a data refresh
+for the media type is already running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
-   DAG runs for the media type to finish before continuing.
+DAG runs for the media type to finish before continuing.
 
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
 Because the data refresh DAG triggers the filtered index creation DAG, we do
-allow a `force` param to be passed to the DAGs generated by this module. This
-parameter is only for use by the data refresh DAG and should not be used when
-manually triggering the DAG unless you are absolutely certain of what you are
-doing.
+allow a ``force`` param to be passed to the DAGs generated by this module.
+This parameter is only for use by the data refresh DAG and should not be
+used when manually triggering the DAG unless you are absolutely certain
+of what you are doing.
+
 
 ## `create_filtered_image_index`
 
+
 ### Create filtered index DAG factory
 
-This module creates the filtered index creation DAGs for each media type using a
-factory function.
+This module creates the filtered index creation DAGs for each media type
+using a factory function.
 
 Filtered index creation is handled by the ingestion server. The DAGs generated
-by the `build_create_filtered_index_dag` function in this module are responsible
-for triggering the ingestion server action to create and populate the filtered
-index for a given media type. The DAG awaits the completion of the filtered
-index creation and then points the filtered index alias for the media type to
-the newly created index.
+by the ``build_create_filtered_index_dag`` function in this module are
+responsible for triggering the ingestion server action to create and populate
+the filtered index for a given media type. The DAG awaits the completion
+of the filtered index creation and then points the filtered index alias for the
+media type to the newly created index.
 
 #### When this DAG runs
 
 The DAGs generated in this module are triggered by the data refresh DAGs.
 Maintaining this process separate from the data refresh DAGs, while still
-triggering it there, allows us to run filtered index creation independently of
-the full data refresh. This is primarily useful in two cases: for testing
+triggering it there, allows us to run filtered index creation independently
+of the full data refresh. This is primarily useful in two cases: for testing
 changes to the filtered index creation; and for re-running filtered index
 creation if an urgent change to the sensitive terms calls for an immediate
 recreation of the filtered indexes.
 
 #### Race conditions
 
-Because filtered index creation employs the `reindex` Elasticsearch API to
-derive the filtered index from an existing index, we need to be mindful of the
-race condition that potentially exists between the data refresh DAG and this
-DAG. The race condition is caused by the fact that the data refresh DAG always
-deletes the previous index once the new index for the media type is finished
-being created. Consider the situation where filtered index creation is triggered
-to run during a data refresh. The filtered index is being derived from the
-previous index for the media type. Once the data refresh is finished, it will
-delete that index, causing the reindex to halt because suddenly it has no data
-source from which to pull documents.
+Because filtered index creation employs the ``reindex`` Elasticsearch API
+to derive the filtered index from an existing index, we need to be mindful
+of the race condition that potentially exists between the data refresh DAG
+and this DAG. The race condition is caused by the fact that the data refresh
+DAG always deletes the previous index once the new index for the media type
+is finished being created. Consider the situation where filtered index creation
+is triggered to run during a data refresh. The filtered index is being derived
+from the previous index for the media type. Once the data refresh is finished,
+it will delete that index, causing the reindex to halt because suddenly it has
+no data source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh for
-   the media type is already running.
+1. The filtered index creation DAGs are not allowed to run if a data refresh
+for the media type is already running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
-   DAG runs for the media type to finish before continuing.
+DAG runs for the media type to finish before continuing.
 
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
 Because the data refresh DAG triggers the filtered index creation DAG, we do
-allow a `force` param to be passed to the DAGs generated by this module. This
-parameter is only for use by the data refresh DAG and should not be used when
-manually triggering the DAG unless you are absolutely certain of what you are
-doing.
+allow a ``force`` param to be passed to the DAGs generated by this module.
+This parameter is only for use by the data refresh DAG and should not be
+used when manually triggering the DAG unless you are absolutely certain
+of what you are doing.
+
 
 ## `europeana_reingestion_workflow`
 
-Content Provider: Europeana
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       Europeana
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: https://pro.europeana.eu/page/search
+Output:                 TSV file containing the images and the
+                        respective meta-data.
+
+Notes:                  https://pro.europeana.eu/page/search
+
 
 ## `europeana_workflow`
 
-Content Provider: Europeana
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       Europeana
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: https://pro.europeana.eu/page/search
+Output:                 TSV file containing the images and the
+                        respective meta-data.
+
+Notes:                  https://pro.europeana.eu/page/search
+
 
 ## `finnish_museums_workflow`
 
-Content Provider: Finnish Museums
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       Finnish Museums
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: https://api.finna.fi/swagger-ui/
-https://www.finna.fi/Content/help-syntax?lng=en-gb The Finnish Museums provider
-script is a dated DAG that ingests all records that were last updated in the
-previous day. Because of this, it is not necessary to run a separate reingestion
-DAG, as updated data will be processed during regular ingestion.
+Output:                 TSV file containing the images and the
+                        respective meta-data.
+
+Notes:                  https://api.finna.fi/swagger-ui/
+                        https://www.finna.fi/Content/help-syntax?lng=en-gb
+                        The Finnish Museums provider script is a dated DAG that
+                        ingests all records that were last updated in the previous
+                        day. Because of this, it is not necessary to run a separate
+                        reingestion DAG, as updated data will be processed during
+                        regular ingestion.
+
 
 ## `flickr_audit_sub_provider_workflow`
 
+
 ### Flickr Sub Provider Audit
 
-Check the list of member institutions of the Flickr Commons for institutions
-that have cc-licensed images and are not already configured as sub-providers for
-the Flickr DAG. Report suggestions for new sub-providers to Slack.
+Check the list of member institutions of the Flickr Commons for institutions that
+have cc-licensed images and are not already configured as sub-providers for the Flickr
+DAG. Report suggestions for new sub-providers to Slack.
+
 
 ## `flickr_reingestion_workflow`
 
-Content Provider: Flickr
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       Flickr
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: https://www.flickr.com/help/terms/api Rate limit: 3600 requests per hour.
+Output:                 TSV file containing the images and the
+                        respective meta-data.
+
+Notes:                  https://www.flickr.com/help/terms/api
+                        Rate limit: 3600 requests per hour.
+
 
 ## `flickr_thumbnails_removal`
 
-One-time run DAG to remove progressively all the old Flickr thumbnails, as they
-were determined to be unsuitable for the Openverse UI requirements.
+
+One-time run DAG to remove progressively all the old Flickr thumbnails,
+as they were determined to be unsuitable for the Openverse UI requirements.
+
 
 ## `flickr_workflow`
 
-Content Provider: Flickr
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       Flickr
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: https://www.flickr.com/help/terms/api Rate limit: 3600 requests per hour.
+Output:                 TSV file containing the images and the
+                        respective meta-data.
+
+Notes:                  https://www.flickr.com/help/terms/api
+                        Rate limit: 3600 requests per hour.
+
 
 ## `freesound_workflow`
 
-Content Provider: Freesound
 
-ETL Process: Use the API to identify all CC-licensed images.
+Content Provider:       Freesound
 
-Output: TSV file containing the image, the respective meta-data.
+ETL Process:            Use the API to identify all CC-licensed images.
 
-Notes: https://freesound.org/docs/api/ Rate limit: No limit for our API key.
-This script can be run either to ingest the full dataset or as a dated DAG.
+Output:                 TSV file containing the image, the respective
+                        meta-data.
+
+Notes:                  https://freesound.org/docs/api/
+                        Rate limit: No limit for our API key.
+                        This script can be run either to ingest the full dataset or
+                        as a dated DAG.
+
 
 ## `image_data_refresh`
 
-### Data Refresh DAG Factory
 
-This file generates our data refresh DAGs using a factory function. For the
-given media type these DAGs will first refresh the popularity data, then
-initiate a data refresh on the data refresh server and await the success or
-failure of that task.
+### Data Refresh DAG Factory
+This file generates our data refresh DAGs using a factory function.
+For the given media type these DAGs will first refresh the popularity data,
+then initiate a data refresh on the data refresh server and await the
+success or failure of that task.
 
 Popularity data for each media type is collated in a materialized view. Before
 initiating a data refresh, the DAG will first refresh the view in order to
-update popularity data for records that have been ingested since the last
-refresh. On the first run of the month, the DAG will also refresh the underlying
-tables, including the percentile values and any new popularity metrics. The DAG
-can also be run with the `force_refresh_metrics` option to run this refresh
-after the first of the month.
+update popularity data for records that have been ingested since the last refresh.
+On the first run of the month, the DAG will also refresh the underlying tables,
+including the percentile values and any new popularity metrics. The DAG can also
+be run with the `force_refresh_metrics` option to run this refresh after the first
+of the month.
 
 Once this step is complete, the data refresh can be initiated. A data refresh
-occurs on the Ingestion server in the openverse project. This is a task which
-imports data from the upstream Catalog database into the API, copies contents to
-a new Elasticsearch index, and finally makes the index "live". This process is
-necessary to make new content added to the Catalog by our provider DAGs
-available to the API. You can read more in the
-[README](https://github.com/WordPress/openverse/blob/main/ingestion_server/README.md)
-Importantly, the data refresh TaskGroup is also configured to handle concurrency
-requirements of the Ingestion server. Finally, once the origin indexes have been
+occurs on the data refresh server in the openverse-api project. This is a task
+which imports data from the upstream Catalog database into the API, copies contents
+to a new Elasticsearch index, and finally makes the index "live". This process is
+necessary to make new content added to the Catalog by our provider DAGs available
+to the API. You can read more in the [README](
+https://github.com/WordPress/openverse-api/blob/main/ingestion_server/README.md
+) Importantly, the data refresh TaskGroup is also configured to handle concurrency
+requirements of the data refresh server. Finally, once the origin indexes have been
 refreshed, the corresponding filtered index creation DAG is triggered.
 
-You can find more background information on this process in the following issues
-and related PRs:
+You can find more background information on this process in the following
+issues and related PRs:
 
-- [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
-- [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
+- [[Feature] Data refresh orchestration DAG](
+https://github.com/WordPress/openverse-catalog/issues/353)
+- [[Feature] Merge popularity calculations and data refresh into a single DAG](
+https://github.com/WordPress/openverse-catalog/issues/453)
+
 
 ## `inaturalist_workflow`
 
-Provider: iNaturalist
 
-Output: Records loaded to the image catalog table.
+Provider:   iNaturalist
 
-Notes: The iNaturalist API is not intended for data scraping.
-https://api.inaturalist.org/v1/docs/ But there is a full dump intended for
-sharing on S3.
-https://github.com/inaturalist/inaturalist-open-data/tree/documentation/Metadata
-Because these are very large normalized tables, as opposed to more document
-oriented API responses, we found that bringing the data into postgres first was
-the most effective approach. More detail in slack here:
-https://wordpress.slack.com/archives/C02012JB00N/p1653145643080479?thread_ts=1653082292.714469&cid=C02012JB00N
-We use the table structure defined here,
-https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql
-except for adding ancestry tags to the taxa table.
+Output:     Records loaded to the image catalog table.
+
+Notes:      The iNaturalist API is not intended for data scraping.
+            https://api.inaturalist.org/v1/docs/
+            But there is a full dump intended for sharing on S3.
+            https://github.com/inaturalist/inaturalist-open-data/tree/documentation/Metadata
+            Because these are very large normalized tables, as opposed to more document
+            oriented API responses, we found that bringing the data into postgres first
+            was the most effective approach. More detail in slack here:
+            https://wordpress.slack.com/archives/C02012JB00N/p1653145643080479?thread_ts=1653082292.714469&cid=C02012JB00N
+            We use the table structure defined here,
+            https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql
+            except for adding ancestry tags to the taxa table.
+
 
 ## `jamendo_workflow`
 
-Content Provider: Jamendo
 
-ETL Process: Use the API to identify all CC-licensed audio.
+Content Provider:       Jamendo
 
-Output: TSV file containing the audio meta-data.
+ETL Process:            Use the API to identify all CC-licensed audio.
 
-Notes: https://api.jamendo.com/v3.0/tracks/ 35,000 requests per month for
-non-commercial apps Jamendo Music has more than 500,000 tracks shared by 40,000
-artists from over 150 countries all over the world. Audio quality: uploaded as
-WAV/ FLAC/ AIFF bit depth: 16/24 sample rate: 44.1 or 48 kHz channels: 1/2
+Output:                 TSV file containing the audio meta-data.
+
+Notes:                  https://api.jamendo.com/v3.0/tracks/
+                        35,000 requests per month for non-commercial apps
+                        Jamendo Music has more than 500,000 tracks shared by
+                        40,000 artists from over 150 countries all over
+                        the world.
+                        Audio quality: uploaded as WAV/ FLAC/ AIFF
+                        bit depth: 16/24
+                        sample rate: 44.1 or 48 kHz
+                        channels: 1/2
+
 
 ## `metropolitan_museum_reingestion_workflow`
 
-Content Provider: Metropolitan Museum of Art
 
-ETL Process: Use the API to identify all CC0 artworks.
+Content Provider:       Metropolitan Museum of Art
 
-Output: TSV file containing the image, their respective meta-data.
+ETL Process:            Use the API to identify all CC0 artworks.
 
-Notes: https://metmuseum.github.io/#search "Please limit requests to 80 requests
-per second." May need to bump up the delay (e.g. to 3 seconds), to avoid of
-blocking during local development testing.
+Output:                 TSV file containing the image, their respective
+                        meta-data.
+
+Notes:                  https://metmuseum.github.io/#search
+                        "Please limit requests to 80 requests per second." May need to
+                        bump up the delay (e.g. to 3 seconds), to avoid of blocking
+                        during local development testing.
 
                         Some analysis to improve data quality was conducted using a
                         separate csv file here: https://github.com/metmuseum/openaccess
@@ -592,18 +636,23 @@ blocking during local development testing.
                         in addition to date and public domain. It seems like it won't
                         connect with just date and license.
                         https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07
+
+
 
 ## `metropolitan_museum_workflow`
 
-Content Provider: Metropolitan Museum of Art
 
-ETL Process: Use the API to identify all CC0 artworks.
+Content Provider:       Metropolitan Museum of Art
 
-Output: TSV file containing the image, their respective meta-data.
+ETL Process:            Use the API to identify all CC0 artworks.
 
-Notes: https://metmuseum.github.io/#search "Please limit requests to 80 requests
-per second." May need to bump up the delay (e.g. to 3 seconds), to avoid of
-blocking during local development testing.
+Output:                 TSV file containing the image, their respective
+                        meta-data.
+
+Notes:                  https://metmuseum.github.io/#search
+                        "Please limit requests to 80 requests per second." May need to
+                        bump up the delay (e.g. to 3 seconds), to avoid of blocking
+                        during local development testing.
 
                         Some analysis to improve data quality was conducted using a
                         separate csv file here: https://github.com/metmuseum/openaccess
@@ -617,185 +666,223 @@ blocking during local development testing.
                         connect with just date and license.
                         https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07
 
+
+
 ## `nappy_workflow`
 
-Content Provider: Nappy
 
-ETL Process: Use the API to identify all CC0-licensed images.
+Content Provider:       Nappy
 
-Output: TSV file containing the image meta-data.
+ETL Process:            Use the API to identify all CC0-licensed images.
 
-Notes: This api was written specially for Openverse. There are no known limits
-or restrictions. https://nappy.co/
+Output:                 TSV file containing the image meta-data.
+
+Notes:                  This api was written specially for Openverse.
+                        There are no known limits or restrictions.
+                        https://nappy.co/
+
+
 
 ## `oauth2_authorization`
 
 ### OAuth Provider Authorization
 
-Iterates through all the OAuth2 providers and attempts to authorize them using
-tokens found in the in the `OAUTH2_AUTH_KEYS` Variable. Once authorization has
-been completed successfully, the auth token is removed from that Variable. The
-authorization will create an access/refresh token pair in the
-`OAUTH2_ACCESS_TOKENS` Variable.
+Iterates through all the OAuth2 providers and attempts to authorize them using tokens
+found in the in the `OAUTH2_AUTH_KEYS` Variable. Once authorization has been
+completed successfully, the auth token is removed from that Variable. The authorization
+will create an access/refresh token pair in the `OAUTH2_ACCESS_TOKENS` Variable.
 
 **Current Providers**:
 
 - Freesound
+
+
+
 
 ## `oauth2_token_refresh`
 
 ### OAuth Provider Token Refresh
 
-Iterates through all OAuth2 providers and attempts to refresh the access token
-using the refresh token stored in the `OAUTH2_ACCESS_TOKENS` Variable. This DAG
-will update the tokens stored in the Variable upon successful refresh.
+Iterates through all OAuth2 providers and attempts to refresh the access token using
+the refresh token stored in the `OAUTH2_ACCESS_TOKENS` Variable. This DAG will
+update the tokens stored in the Variable upon successful refresh.
 
 **Current Providers**:
 
 - Freesound
 
+
+
+
 ## `phylopic_reingestion_workflow`
 
-Content Provider: PhyloPic
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       PhyloPic
 
-Output: TSV file containing the image, their respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
+Output:                 TSV file containing the image,
+                        their respective meta-data.
+
+Notes:                  http://api-docs.phylopic.org/v2/
+                        No rate limit specified.
+
 
 ## `phylopic_workflow`
 
-Content Provider: PhyloPic
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:       PhyloPic
 
-Output: TSV file containing the image, their respective meta-data.
+ETL Process:            Use the API to identify all CC licensed images.
 
-Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
+Output:                 TSV file containing the image,
+                        their respective meta-data.
+
+Notes:                  http://api-docs.phylopic.org/v2/
+                        No rate limit specified.
+
 
 ## `pr_review_reminders`
 
+
 ### PR Review Reminders
 
-Iterates through open PRs in our repositories and pings assigned reviewers who
-have not yet approved the PR or explicitly requested changes.
+Iterates through open PRs in our repositories and pings assigned reviewers
+who have not yet approved the PR or explicitly requested changes.
 
 This DAG runs daily and pings on the following schedule based on priority label:
 
-| priority | days    |
-| -------- | ------- |
-| critical | 1 day   |
-| high     | >2 days |
-| medium   | >4 days |
-| low      | >7 days |
+| priority | days |
+| --- | --- |
+| critical | 1 day |
+| high | >2 days |
+| medium | >4 days |
+| low | >7 days |
 
-The DAG does not ping on Saturday and Sunday and accounts for weekend days when
-determining how much time has passed since the review.
+The DAG does not ping on Saturday and Sunday and accounts for weekend days
+when determining how much time has passed since the review.
 
 Unfortunately the DAG does not know when someone is on vacation. It is up to the
 author of the PR to re-assign review if one of the randomly selected reviewers
 is unavailable for the time period during which the PR should be reviewed.
 
+
 ## `rawpixel_workflow`
 
-Content Provider: Rawpixel
 
-ETL Process: Use the API to identify all CC-licensed images.
+Content Provider:       Rawpixel
 
-Output: TSV file containing the image meta-data.
+ETL Process:            Use the API to identify all CC-licensed images.
 
-Notes: Rawpixel has given Openverse beta access to their API. This API is
-undocumented, and we will need to contact Rawpixel directly if we run into any
-issues. The public API max results range is limited to 100,000 results, although
-the API key we've been given can circumvent this limit.
-https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100
+Output:                 TSV file containing the image meta-data.
+
+Notes:                  Rawpixel has given Openverse beta access to their API.
+                        This API is undocumented, and we will need to contact Rawpixel
+                        directly if we run into any issues.
+                        The public API max results range is limited to 100,000 results,
+                        although the API key we've been given can circumvent this limit.
+                        https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100
+
 
 ## `recreate_audio_popularity_calculation`
 
+
 This file generates Apache Airflow DAGs that, for the given media type,
 completely wipe out the PostgreSQL relations and functions involved in
-calculating our standardized popularity metric. It then recreates relations and
-functions to make the calculation, and performs an initial calculation. The
-results are available in the materialized view for that media type.
+calculating our standardized popularity metric. It then recreates relations
+and functions to make the calculation, and performs an initial calculation.
+The results are available in the materialized view for that media type.
 
-These DAGs are not on a schedule, and should only be run manually when new SQL
-code is deployed for the calculation.
+These DAGs are not on a schedule, and should only be run manually when new
+SQL code is deployed for the calculation.
+
 
 ## `recreate_image_popularity_calculation`
 
+
 This file generates Apache Airflow DAGs that, for the given media type,
 completely wipe out the PostgreSQL relations and functions involved in
-calculating our standardized popularity metric. It then recreates relations and
-functions to make the calculation, and performs an initial calculation. The
-results are available in the materialized view for that media type.
+calculating our standardized popularity metric. It then recreates relations
+and functions to make the calculation, and performs an initial calculation.
+The results are available in the materialized view for that media type.
 
-These DAGs are not on a schedule, and should only be run manually when new SQL
-code is deployed for the calculation.
+These DAGs are not on a schedule, and should only be run manually when new
+SQL code is deployed for the calculation.
+
 
 ## `report_pending_reported_media`
 
-### Report Pending Reported Media DAG
 
+### Report Pending Reported Media DAG
 This DAG checks for any user-reported media pending manual review, and alerts
 via Slack.
 
-Media may be reported for mature content or copyright infringement, for example.
-Once reported, these require manual review through the Django Admin to determine
-whether further action (such as deindexing the record) needs to be taken. If a
-record has been reported multiple times, it only needs to be reviewed once and
-so is only counted once in the reporting by this DAG.
+Media may be reported for mature content or copyright infringement, for
+example. Once reported, these require manual review through the Django Admin to
+determine whether further action (such as deindexing the record) needs to be
+taken. If a record has been reported multiple times, it only needs to be
+reviewed once and so is only counted once in the reporting by this DAG.
+
 
 ## `rotate_db_snapshots`
 
+
 Manages weekly database snapshots.
 
-RDS does not support weekly snapshots schedules on its own, so we need a DAG to
-manage this for us.
+RDS does not support weekly snapshots schedules on its own, so we need a DAG to manage
+this for us.
 
 It runs on Saturdays at 00:00 UTC in order to happen before the data refresh.
 
-The DAG will automatically delete the oldest snapshots when more snaphots exist
-than it is configured to retain.
+The DAG will automatically delete the oldest snapshots when more snaphots
+exist than it is configured to retain.
 
 Requires two variables:
 
 `CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
 `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
 
+
 ## `science_museum_workflow`
 
-Content Provider: Science Museum
 
-ETL Process: Use the API to identify all CC-licensed images.
+Content Provider:       Science Museum
 
-Output: TSV file containing the image, the respective meta-data.
+ETL Process:            Use the API to identify all CC-licensed images.
 
-Notes:
-https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API
-Rate limited, no specific rate given.
+Output:                 TSV file containing the image, the respective
+                        meta-data.
+
+Notes:                  https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API
+                        Rate limited, no specific rate given.
+
 
 ## `smithsonian_workflow`
 
-Content Provider: Smithsonian
 
-ETL Process: Use the API to identify all CC licensed images.
+Content Provider:   Smithsonian
 
-Output: TSV file containing the images and the respective meta-data.
+ETL Process:        Use the API to identify all CC licensed images.
 
-Notes: https://api.si.edu/openaccess/api/v1.0/search
+Output:             TSV file containing the images and the respective meta-data.
+
+Notes:              https://api.si.edu/openaccess/api/v1.0/search
+
 
 ## `smk_workflow`
 
-Content Provider: Statens Museum for Kunst (National Gallery of Denmark)
 
-ETL Process: Use the API to identify all openly licensed media.
+Content Provider:       Statens Museum for Kunst (National Gallery of Denmark)
 
-Output: TSV file containing the media metadata.
+ETL Process:            Use the API to identify all openly licensed media.
 
-Notes: https://www.smk.dk/en/article/smk-api/
+Output:                 TSV file containing the media metadata.
+
+Notes:                  https://www.smk.dk/en/article/smk-api/
+
 
 ## `staging_database_restore`
+
 
 ### Update the staging database
 
@@ -805,277 +892,266 @@ snapshot of the production database.
 For a full explanation of the DAG, see the implementation plan description:
 https://docs.openverse.org/projects/proposals/search_relevancy_sandbox/20230406-implementation_plan_update_staging_database.html#dag
 
-This DAG can be skipped by setting the `SKIP_STAGING_DATABASE_RESTORE` Airflow
-Variable to `true`. To change this variable, navigate to Admin > Variables in
-the Airflow UI, then click the "edit" button next to the variable and set the
-value to either `true` or `false`.
+This DAG can be skipped by setting the `SKIP_STAGING_DATABASE_RESTORE` Airflow Variable
+to `true`. To change this variable, navigate to Admin > Variables in the Airflow UI,
+then click the "edit" button next to the variable and set the value to either `true`
+or `false`.
 
-This DAG will default to using the standard AWS connection ID for the RDS
-operations. For local testing, you can set up two environment variables to have
-the RDS operations run using a different hook:
+This DAG will default to using the standard AWS connection ID for the RDS operations.
+For local testing, you can set up two environment variables to have the RDS operations
+run using a different hook:
+- `AWS_RDS_CONN_ID`: The Airflow connection ID to use for RDS operations
+  (e.g. `aws_rds`)
+- `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the above
+  example, it might be `AIRFLOW_CONN_AWS_RDS`)
 
-- `AWS_RDS_CONN_ID`: The Airflow connection ID to use for RDS operations (e.g.
-  `aws_rds`)
-- `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
-  above example, it might be `AIRFLOW_CONN_AWS_RDS`)
 
 ## `stocksnap_workflow`
 
-Content Provider: StockSnap
 
-ETL Process: Use the API to identify all CC-licensed images.
+Content Provider:       StockSnap
 
-Output: TSV file containing the image, the respective meta-data.
+ETL Process:            Use the API to identify all CC-licensed images.
 
-Notes: https://stocksnap.io/api/load-photos/date/desc/1 https://stocksnap.io/faq
-All images are licensed under CC0. No rate limits or authorization required. API
-is undocumented.
+Output:                 TSV file containing the image, the respective meta-data.
+
+Notes:                  https://stocksnap.io/api/load-photos/date/desc/1
+                        https://stocksnap.io/faq
+                        All images are licensed under CC0.
+                        No rate limits or authorization required.
+                        API is undocumented.
+
 
 ## `wikimedia_commons_workflow`
 
+
 **Content Provider:** Wikimedia Commons
 
 **ETL Process:** Use the API to identify all CC-licensed images.
 
-**Output:** TSV file containing the image, the respective meta-data.
+**Output:** TSV file containing the image, the respective
+                        meta-data.
 
 ### Notes
 
-Rate limit of no more than 200 requests/second, and we are required to set a
-unique User-Agent field
-([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+Rate limit of no more than 200 requests/second, and we are required to set a unique
+User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
 
 Wikimedia Commons uses an implementation of the
-[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
-incredibly complex in the level of configuration you can provide when querying,
-and as such it can also be quite abstruse. The most straightforward docs can be
-found on the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is incredibly
+complex in the level of configuration you can provide when querying, and as such it can
+also be quite abstruse. The most straightforward docs can be found on the
 [Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
-as these show all the parameters available. Specifications on queries can also
-be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
+as these show all the parameters available. Specifications on queries can also be found
+on the [query page](https://www.mediawiki.org/wiki/API:Query).
 
-Different kinds of queries can be made against the API using "modules", we use
-the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
-us search for images in a given time range (see `"generator": "allimages"` in
-the query params).
+Different kinds of queries can be made against the API using "modules", we use the
+[allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets us search
+for images in a given time range (see `"generator": "allimages"` in the query params).
 
-Many queries will return results in batches, with the API supplying a "continue"
-token. This token is used on subsequent calls to tell the API where to start the
-next set of results from; it functions as a page offset
-([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+Many queries will return results in batches, with the API supplying a "continue" token.
+This token is used on subsequent calls to tell the API where to start the next set of
+results from; it functions as a page offset ([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
 
-We can also specify what kinds of information we want for the query. Wikimedia
-has a massive amount of data on it, so it only returns what we ask for. The
-fields that are returned are defined by the
-[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
-parameter. Sub-properties can also be defined, with the parameter name of the
-sub-property determined by an abbreviation of the higher-level property. For
-instance, if our property is "imageinfo" and we want to set sub-property values,
-we would define those in "iiprops".
+We can also specify what kinds of information we want for the query. Wikimedia has a
+massive amount of data on it, so it only returns what we ask for. The fields that are
+returned are defined by the [properties](https://www.mediawiki.org/wiki/API:Properties)
+or "props" parameter. Sub-properties can also be defined, with the parameter name of
+the sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values, we
+would define those in "iiprops".
 
-The data within a property is paginated as well, Wikimedia will handle iteration
-through the property sub-pages using the "continue" token
+The data within a property is paginated as well, Wikimedia will handle iteration through
+the property sub-pages using the "continue" token
 ([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
 
-Depending on the kind of property data that's being returned, it's possible for
-the API to iterate extensively on a specific media item. What Wikimedia is
-iterating over in these cases can be gleaned from the "continue" token. Those
-tokens take the form of, as I understand it,
-"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
-for the property being iterated over. For example, if we're were iterating over
-a set of image properties, the token might look like:
+Depending on the kind of property data that's being returned, it's possible for the API
+to iterate extensively on a specific media item. What Wikimedia is iterating over in
+these cases can be gleaned from the "continue" token. Those tokens take the form of,
+as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
+"<XX>continue" value for the property being iterated over. For example, if we're
+were iterating over a set of image properties, the token might look like:
 
 ```
-{
-    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
-    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
-    "continue": "gaicontinue||globalusage",
-}
+
+{ "iicontinue": "The*Railway_Chronicle_1844.pdf|20221209222801", "gaicontinue":
+"20221209222614|NTUL-0527100*英國產業革命史略.pdf", "continue":
+"gaicontinue||globalusage", }
+
 ```
 
-In this case, we're iterating over the "global all images" generator
-(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
-as the secondary continue iterator. The "globalusage" property would be the next
-property to iterate over. It's also possible for multiple sub-properties to be
-iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`).
+In this case, we're iterating over the "global all images" generator (gaicontinue) as
+our primary iterator, with the "image properties" (iicontinue) as the secondary continue
+iterator. The "globalusage" property would be the next property to iterate over. It's
+also possible for multiple sub-properties to be iterated over simultaneously, in which
+case the "continue" token would not have a secondary value (e.g. `gaicontinue||`).
 
-In most runs, the "continue" key will be `gaicontinue||` after the first
-request, which means that we have more than one batch to iterate over for the
-primary iterator. Some days will have fewer images than the batch limit but
-still have multiple batches of content on the secondary iterator, which means
-the "continue" key may not have a primary iteration component (e.g.
-`||globalusage`). This token can also be seen when the first request has more
-data in the secondary iterator, before we've processed any data on the primary
-iterator.
+In most runs, the "continue" key will be `gaicontinue||` after the first request, which
+means that we have more than one batch to iterate over for the primary iterator. Some
+days will have fewer images than the batch limit but still have multiple batches of
+content on the secondary iterator, which means the "continue" key may not have a primary
+iteration component (e.g. `||globalusage`). This token can also be seen when the first
+request has more data in the secondary iterator, before we've processed any data on
+the primary iterator.
 
-Occasionally, the ingester will come across a piece of media that has many
-results for the property it's iterating over. An example of this can include an
-item being on many pages, this it would have many "global usage" results. In
-order to process the entire batch, we have to iterate over _all_ of the returned
-results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
-On numerous occasions, this iteration has been so extensive that the pull media
-task has hit the task's timeout. To avoid this, we limit the number of
-iterations we make for parsing through a sub-property's data. If we hit the
-limit, we re-issue the original query _without_ requesting properties that
-returned large amounts of data. Unfortunately, this means that we will **not**
-have that property's data for these items the second time around (e.g.
+Occasionally, the ingester will come across a piece of media that has many results for
+the property it's iterating over. An example of this can include an item being on many
+pages, this it would have many "global usage" results. In order to process the entire
+batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
+a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
+been so extensive that the pull media task has hit the task's timeout. To avoid this,
+we limit the number of iterations we make for parsing through a sub-property's data. If
+we hit the limit, we re-issue the original query *without* requesting properties that
+returned large amounts of data. Unfortunately, this means that we will
+**not** have that property's data for these items the second time around (e.g.
 popularity data if we needed to skip global usage). In the case of popularity,
-especially since the problem with these images is that they're so popular, we
-want to preserve that information where possible! So we cache the popularity
-data from previous iterations and use it in subsequent ones if we come across
-the same item again.
+especially since the problem with these images is that they're so popular, we want to
+preserve that information where possible! So we cache the popularity data from
+previous iterations and use it in subsequent ones if we come across the same
+item again.
 
-Below are some specific references to various properties, with examples for
-cases where they might exceed the limit. Technically, it's feasible for almost
-any property to exceed the limit, but these are the ones that we've seen in
-practice.
+Below are some specific references to various properties, with examples for cases where
+they might exceed the limit. Technically, it's feasible for almost any property to
+exceed the limit, but these are the ones that we've seen in practice.
 
 #### `imageinfo`
-
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
 
 [Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
 (see "Metadata" table, which may need to be expanded).
 
-For these requests, we can remove the `metadata` property from the `iiprops`
-parameter to avoid this issue on subsequent iterations.
+For these requests, we can remove the `metadata` property from the `iiprops` parameter
+to avoid this issue on subsequent iterations.
 
 #### `globalusage`
-
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
 
 [Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
 
-For these requests, we can remove the `globalusage` property from the `prop`
-parameter entirely and eschew the popularity data for these items.
+For these requests, we can remove the `globalusage` property from the `prop` parameter
+entirely and eschew the popularity data for these items.
+
 
 ## `wikimedia_reingestion_workflow`
 
+
 **Content Provider:** Wikimedia Commons
 
 **ETL Process:** Use the API to identify all CC-licensed images.
 
-**Output:** TSV file containing the image, the respective meta-data.
+**Output:** TSV file containing the image, the respective
+                        meta-data.
 
 ### Notes
 
-Rate limit of no more than 200 requests/second, and we are required to set a
-unique User-Agent field
-([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+Rate limit of no more than 200 requests/second, and we are required to set a unique
+User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
 
 Wikimedia Commons uses an implementation of the
-[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
-incredibly complex in the level of configuration you can provide when querying,
-and as such it can also be quite abstruse. The most straightforward docs can be
-found on the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is incredibly
+complex in the level of configuration you can provide when querying, and as such it can
+also be quite abstruse. The most straightforward docs can be found on the
 [Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
-as these show all the parameters available. Specifications on queries can also
-be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
+as these show all the parameters available. Specifications on queries can also be found
+on the [query page](https://www.mediawiki.org/wiki/API:Query).
 
-Different kinds of queries can be made against the API using "modules", we use
-the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
-us search for images in a given time range (see `"generator": "allimages"` in
-the query params).
+Different kinds of queries can be made against the API using "modules", we use the
+[allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets us search
+for images in a given time range (see `"generator": "allimages"` in the query params).
 
-Many queries will return results in batches, with the API supplying a "continue"
-token. This token is used on subsequent calls to tell the API where to start the
-next set of results from; it functions as a page offset
-([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+Many queries will return results in batches, with the API supplying a "continue" token.
+This token is used on subsequent calls to tell the API where to start the next set of
+results from; it functions as a page offset ([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
 
-We can also specify what kinds of information we want for the query. Wikimedia
-has a massive amount of data on it, so it only returns what we ask for. The
-fields that are returned are defined by the
-[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
-parameter. Sub-properties can also be defined, with the parameter name of the
-sub-property determined by an abbreviation of the higher-level property. For
-instance, if our property is "imageinfo" and we want to set sub-property values,
-we would define those in "iiprops".
+We can also specify what kinds of information we want for the query. Wikimedia has a
+massive amount of data on it, so it only returns what we ask for. The fields that are
+returned are defined by the [properties](https://www.mediawiki.org/wiki/API:Properties)
+or "props" parameter. Sub-properties can also be defined, with the parameter name of
+the sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values, we
+would define those in "iiprops".
 
-The data within a property is paginated as well, Wikimedia will handle iteration
-through the property sub-pages using the "continue" token
+The data within a property is paginated as well, Wikimedia will handle iteration through
+the property sub-pages using the "continue" token
 ([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
 
-Depending on the kind of property data that's being returned, it's possible for
-the API to iterate extensively on a specific media item. What Wikimedia is
-iterating over in these cases can be gleaned from the "continue" token. Those
-tokens take the form of, as I understand it,
-"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
-for the property being iterated over. For example, if we're were iterating over
-a set of image properties, the token might look like:
+Depending on the kind of property data that's being returned, it's possible for the API
+to iterate extensively on a specific media item. What Wikimedia is iterating over in
+these cases can be gleaned from the "continue" token. Those tokens take the form of,
+as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
+"<XX>continue" value for the property being iterated over. For example, if we're
+were iterating over a set of image properties, the token might look like:
 
 ```
-{
-    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
-    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
-    "continue": "gaicontinue||globalusage",
-}
+
+{ "iicontinue": "The*Railway_Chronicle_1844.pdf|20221209222801", "gaicontinue":
+"20221209222614|NTUL-0527100*英國產業革命史略.pdf", "continue":
+"gaicontinue||globalusage", }
+
 ```
 
-In this case, we're iterating over the "global all images" generator
-(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
-as the secondary continue iterator. The "globalusage" property would be the next
-property to iterate over. It's also possible for multiple sub-properties to be
-iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`).
+In this case, we're iterating over the "global all images" generator (gaicontinue) as
+our primary iterator, with the "image properties" (iicontinue) as the secondary continue
+iterator. The "globalusage" property would be the next property to iterate over. It's
+also possible for multiple sub-properties to be iterated over simultaneously, in which
+case the "continue" token would not have a secondary value (e.g. `gaicontinue||`).
 
-In most runs, the "continue" key will be `gaicontinue||` after the first
-request, which means that we have more than one batch to iterate over for the
-primary iterator. Some days will have fewer images than the batch limit but
-still have multiple batches of content on the secondary iterator, which means
-the "continue" key may not have a primary iteration component (e.g.
-`||globalusage`). This token can also be seen when the first request has more
-data in the secondary iterator, before we've processed any data on the primary
-iterator.
+In most runs, the "continue" key will be `gaicontinue||` after the first request, which
+means that we have more than one batch to iterate over for the primary iterator. Some
+days will have fewer images than the batch limit but still have multiple batches of
+content on the secondary iterator, which means the "continue" key may not have a primary
+iteration component (e.g. `||globalusage`). This token can also be seen when the first
+request has more data in the secondary iterator, before we've processed any data on
+the primary iterator.
 
-Occasionally, the ingester will come across a piece of media that has many
-results for the property it's iterating over. An example of this can include an
-item being on many pages, this it would have many "global usage" results. In
-order to process the entire batch, we have to iterate over _all_ of the returned
-results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
-On numerous occasions, this iteration has been so extensive that the pull media
-task has hit the task's timeout. To avoid this, we limit the number of
-iterations we make for parsing through a sub-property's data. If we hit the
-limit, we re-issue the original query _without_ requesting properties that
-returned large amounts of data. Unfortunately, this means that we will **not**
-have that property's data for these items the second time around (e.g.
+Occasionally, the ingester will come across a piece of media that has many results for
+the property it's iterating over. An example of this can include an item being on many
+pages, this it would have many "global usage" results. In order to process the entire
+batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
+a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
+been so extensive that the pull media task has hit the task's timeout. To avoid this,
+we limit the number of iterations we make for parsing through a sub-property's data. If
+we hit the limit, we re-issue the original query *without* requesting properties that
+returned large amounts of data. Unfortunately, this means that we will
+**not** have that property's data for these items the second time around (e.g.
 popularity data if we needed to skip global usage). In the case of popularity,
-especially since the problem with these images is that they're so popular, we
-want to preserve that information where possible! So we cache the popularity
-data from previous iterations and use it in subsequent ones if we come across
-the same item again.
+especially since the problem with these images is that they're so popular, we want to
+preserve that information where possible! So we cache the popularity data from
+previous iterations and use it in subsequent ones if we come across the same
+item again.
 
-Below are some specific references to various properties, with examples for
-cases where they might exceed the limit. Technically, it's feasible for almost
-any property to exceed the limit, but these are the ones that we've seen in
-practice.
+Below are some specific references to various properties, with examples for cases where
+they might exceed the limit. Technically, it's feasible for almost any property to
+exceed the limit, but these are the ones that we've seen in practice.
 
 #### `imageinfo`
-
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
 
 [Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
 (see "Metadata" table, which may need to be expanded).
 
-For these requests, we can remove the `metadata` property from the `iiprops`
-parameter to avoid this issue on subsequent iterations.
+For these requests, we can remove the `metadata` property from the `iiprops` parameter
+to avoid this issue on subsequent iterations.
 
 #### `globalusage`
-
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
 
 [Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
 
-For these requests, we can remove the `globalusage` property from the `prop`
-parameter entirely and eschew the popularity data for these items.
+For these requests, we can remove the `globalusage` property from the `prop` parameter
+entirely and eschew the popularity data for these items.
+
 
 ## `wordpress_workflow`
 
-Content Provider: WordPress Photo Directory
 
-ETL Process: Use the API to identify all openly licensed media.
+Content Provider:       WordPress Photo Directory
 
-Output: TSV file containing the media metadata.
+ETL Process:            Use the API to identify all openly licensed media.
 
-Notes: https://wordpress.org/photos/wp-json/wp/v2 Provide photos, media, users
-and more related resources. No rate limit specified.
+Output:                 TSV file containing the media metadata.
+
+Notes:                  https://wordpress.org/photos/wp-json/wp/v2
+                        Provide photos, media, users and more related resources.
+                        No rate limit specified.
+```

--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -288,342 +288,291 @@ used when the DagRun configuration needs to be changed after the table was
 already created: for example, if there was a problem with the `update_query`
 which caused DAG failures during the `update_batches` step.
 
-```
-
-
 ## `check_silenced_dags`
-
 
 ### Silenced DAGs check
 
-Check for DAGs that have silenced Slack alerts or skipped errors which may need to be
-turned back on.
+Check for DAGs that have silenced Slack alerts or skipped errors which may need
+to be turned back on.
 
-When a DAG has known failures, it can be ommitted from Slack error reporting by adding
-an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. Similarly, errors that
-occur during the `pull_data` step may be configured to skip and allow ingestion to
-continue, using the `SKIPPED_INGESTION_ERRORS` Airflow variable. These variables are
-dictionaries where the key is the `dag_id` of the affected DAG, and the value is a list
-of configuration dictionaries mapping an error `predicate` to be skipped/silenced to an
-open GitHub issue.
+When a DAG has known failures, it can be ommitted from Slack error reporting by
+adding an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable.
+Similarly, errors that occur during the `pull_data` step may be configured to
+skip and allow ingestion to continue, using the `SKIPPED_INGESTION_ERRORS`
+Airflow variable. These variables are dictionaries where the key is the `dag_id`
+of the affected DAG, and the value is a list of configuration dictionaries
+mapping an error `predicate` to be skipped/silenced to an open GitHub issue.
 
 The `check_silenced_dags` DAG iterates over the entries in the
 `SILENCED_SLACK_NOTIFICATIONS` and `SKIPPED_INGESTION_ERRORS` configurations and
-verifies that the associated GitHub issues are still open. If an issue has been closed,
-it is assumed that the entry should be removed, and an alert is sent to prompt manual
-update of the configuration. This prevents developers from forgetting to reenable Slack
-reporting or turnoff error skipping after the issue has been resolved.
+verifies that the associated GitHub issues are still open. If an issue has been
+closed, it is assumed that the entry should be removed, and an alert is sent to
+prompt manual update of the configuration. This prevents developers from
+forgetting to reenable Slack reporting or turnoff error skipping after the issue
+has been resolved.
 
 The DAG runs weekly.
 
-
 ## `create_filtered_audio_index`
-
 
 ### Create filtered index DAG factory
 
-This module creates the filtered index creation DAGs for each media type
-using a factory function.
+This module creates the filtered index creation DAGs for each media type using a
+factory function.
 
 Filtered index creation is handled by the ingestion server. The DAGs generated
-by the ``build_create_filtered_index_dag`` function in this module are
-responsible for triggering the ingestion server action to create and populate
-the filtered index for a given media type. The DAG awaits the completion
-of the filtered index creation and then points the filtered index alias for the
-media type to the newly created index.
+by the `build_create_filtered_index_dag` function in this module are responsible
+for triggering the ingestion server action to create and populate the filtered
+index for a given media type. The DAG awaits the completion of the filtered
+index creation and then points the filtered index alias for the media type to
+the newly created index.
 
 #### When this DAG runs
 
 The DAGs generated in this module are triggered by the data refresh DAGs.
 Maintaining this process separate from the data refresh DAGs, while still
-triggering it there, allows us to run filtered index creation independently
-of the full data refresh. This is primarily useful in two cases: for testing
+triggering it there, allows us to run filtered index creation independently of
+the full data refresh. This is primarily useful in two cases: for testing
 changes to the filtered index creation; and for re-running filtered index
 creation if an urgent change to the sensitive terms calls for an immediate
 recreation of the filtered indexes.
 
 #### Race conditions
 
-Because filtered index creation employs the ``reindex`` Elasticsearch API
-to derive the filtered index from an existing index, we need to be mindful
-of the race condition that potentially exists between the data refresh DAG
-and this DAG. The race condition is caused by the fact that the data refresh
-DAG always deletes the previous index once the new index for the media type
-is finished being created. Consider the situation where filtered index creation
-is triggered to run during a data refresh. The filtered index is being derived
-from the previous index for the media type. Once the data refresh is finished,
-it will delete that index, causing the reindex to halt because suddenly it has
-no data source from which to pull documents.
+Because filtered index creation employs the `reindex` Elasticsearch API to
+derive the filtered index from an existing index, we need to be mindful of the
+race condition that potentially exists between the data refresh DAG and this
+DAG. The race condition is caused by the fact that the data refresh DAG always
+deletes the previous index once the new index for the media type is finished
+being created. Consider the situation where filtered index creation is triggered
+to run during a data refresh. The filtered index is being derived from the
+previous index for the media type. Once the data refresh is finished, it will
+delete that index, causing the reindex to halt because suddenly it has no data
+source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh
-for the media type is already running.
+1. The filtered index creation DAGs are not allowed to run if a data refresh for
+   the media type is already running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
-DAG runs for the media type to finish before continuing.
+   DAG runs for the media type to finish before continuing.
 
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
 Because the data refresh DAG triggers the filtered index creation DAG, we do
-allow a ``force`` param to be passed to the DAGs generated by this module.
-This parameter is only for use by the data refresh DAG and should not be
-used when manually triggering the DAG unless you are absolutely certain
-of what you are doing.
-
+allow a `force` param to be passed to the DAGs generated by this module. This
+parameter is only for use by the data refresh DAG and should not be used when
+manually triggering the DAG unless you are absolutely certain of what you are
+doing.
 
 ## `create_filtered_image_index`
 
-
 ### Create filtered index DAG factory
 
-This module creates the filtered index creation DAGs for each media type
-using a factory function.
+This module creates the filtered index creation DAGs for each media type using a
+factory function.
 
 Filtered index creation is handled by the ingestion server. The DAGs generated
-by the ``build_create_filtered_index_dag`` function in this module are
-responsible for triggering the ingestion server action to create and populate
-the filtered index for a given media type. The DAG awaits the completion
-of the filtered index creation and then points the filtered index alias for the
-media type to the newly created index.
+by the `build_create_filtered_index_dag` function in this module are responsible
+for triggering the ingestion server action to create and populate the filtered
+index for a given media type. The DAG awaits the completion of the filtered
+index creation and then points the filtered index alias for the media type to
+the newly created index.
 
 #### When this DAG runs
 
 The DAGs generated in this module are triggered by the data refresh DAGs.
 Maintaining this process separate from the data refresh DAGs, while still
-triggering it there, allows us to run filtered index creation independently
-of the full data refresh. This is primarily useful in two cases: for testing
+triggering it there, allows us to run filtered index creation independently of
+the full data refresh. This is primarily useful in two cases: for testing
 changes to the filtered index creation; and for re-running filtered index
 creation if an urgent change to the sensitive terms calls for an immediate
 recreation of the filtered indexes.
 
 #### Race conditions
 
-Because filtered index creation employs the ``reindex`` Elasticsearch API
-to derive the filtered index from an existing index, we need to be mindful
-of the race condition that potentially exists between the data refresh DAG
-and this DAG. The race condition is caused by the fact that the data refresh
-DAG always deletes the previous index once the new index for the media type
-is finished being created. Consider the situation where filtered index creation
-is triggered to run during a data refresh. The filtered index is being derived
-from the previous index for the media type. Once the data refresh is finished,
-it will delete that index, causing the reindex to halt because suddenly it has
-no data source from which to pull documents.
+Because filtered index creation employs the `reindex` Elasticsearch API to
+derive the filtered index from an existing index, we need to be mindful of the
+race condition that potentially exists between the data refresh DAG and this
+DAG. The race condition is caused by the fact that the data refresh DAG always
+deletes the previous index once the new index for the media type is finished
+being created. Consider the situation where filtered index creation is triggered
+to run during a data refresh. The filtered index is being derived from the
+previous index for the media type. Once the data refresh is finished, it will
+delete that index, causing the reindex to halt because suddenly it has no data
+source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh
-for the media type is already running.
+1. The filtered index creation DAGs are not allowed to run if a data refresh for
+   the media type is already running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
-DAG runs for the media type to finish before continuing.
+   DAG runs for the media type to finish before continuing.
 
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
 Because the data refresh DAG triggers the filtered index creation DAG, we do
-allow a ``force`` param to be passed to the DAGs generated by this module.
-This parameter is only for use by the data refresh DAG and should not be
-used when manually triggering the DAG unless you are absolutely certain
-of what you are doing.
-
+allow a `force` param to be passed to the DAGs generated by this module. This
+parameter is only for use by the data refresh DAG and should not be used when
+manually triggering the DAG unless you are absolutely certain of what you are
+doing.
 
 ## `europeana_reingestion_workflow`
 
+Content Provider: Europeana
 
-Content Provider:       Europeana
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:                 TSV file containing the images and the
-                        respective meta-data.
-
-Notes:                  https://pro.europeana.eu/page/search
-
+Notes: https://pro.europeana.eu/page/search
 
 ## `europeana_workflow`
 
+Content Provider: Europeana
 
-Content Provider:       Europeana
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:                 TSV file containing the images and the
-                        respective meta-data.
-
-Notes:                  https://pro.europeana.eu/page/search
-
+Notes: https://pro.europeana.eu/page/search
 
 ## `finnish_museums_workflow`
 
+Content Provider: Finnish Museums
 
-Content Provider:       Finnish Museums
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:                 TSV file containing the images and the
-                        respective meta-data.
-
-Notes:                  https://api.finna.fi/swagger-ui/
-                        https://www.finna.fi/Content/help-syntax?lng=en-gb
-                        The Finnish Museums provider script is a dated DAG that
-                        ingests all records that were last updated in the previous
-                        day. Because of this, it is not necessary to run a separate
-                        reingestion DAG, as updated data will be processed during
-                        regular ingestion.
-
+Notes: https://api.finna.fi/swagger-ui/
+https://www.finna.fi/Content/help-syntax?lng=en-gb The Finnish Museums provider
+script is a dated DAG that ingests all records that were last updated in the
+previous day. Because of this, it is not necessary to run a separate reingestion
+DAG, as updated data will be processed during regular ingestion.
 
 ## `flickr_audit_sub_provider_workflow`
 
-
 ### Flickr Sub Provider Audit
 
-Check the list of member institutions of the Flickr Commons for institutions that
-have cc-licensed images and are not already configured as sub-providers for the Flickr
-DAG. Report suggestions for new sub-providers to Slack.
-
+Check the list of member institutions of the Flickr Commons for institutions
+that have cc-licensed images and are not already configured as sub-providers for
+the Flickr DAG. Report suggestions for new sub-providers to Slack.
 
 ## `flickr_reingestion_workflow`
 
+Content Provider: Flickr
 
-Content Provider:       Flickr
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:                 TSV file containing the images and the
-                        respective meta-data.
-
-Notes:                  https://www.flickr.com/help/terms/api
-                        Rate limit: 3600 requests per hour.
-
+Notes: https://www.flickr.com/help/terms/api Rate limit: 3600 requests per hour.
 
 ## `flickr_thumbnails_removal`
 
-
-One-time run DAG to remove progressively all the old Flickr thumbnails,
-as they were determined to be unsuitable for the Openverse UI requirements.
-
+One-time run DAG to remove progressively all the old Flickr thumbnails, as they
+were determined to be unsuitable for the Openverse UI requirements.
 
 ## `flickr_workflow`
 
+Content Provider: Flickr
 
-Content Provider:       Flickr
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:                 TSV file containing the images and the
-                        respective meta-data.
-
-Notes:                  https://www.flickr.com/help/terms/api
-                        Rate limit: 3600 requests per hour.
-
+Notes: https://www.flickr.com/help/terms/api Rate limit: 3600 requests per hour.
 
 ## `freesound_workflow`
 
+Content Provider: Freesound
 
-Content Provider:       Freesound
+ETL Process: Use the API to identify all CC-licensed images.
 
-ETL Process:            Use the API to identify all CC-licensed images.
+Output: TSV file containing the image, the respective meta-data.
 
-Output:                 TSV file containing the image, the respective
-                        meta-data.
-
-Notes:                  https://freesound.org/docs/api/
-                        Rate limit: No limit for our API key.
-                        This script can be run either to ingest the full dataset or
-                        as a dated DAG.
-
+Notes: https://freesound.org/docs/api/ Rate limit: No limit for our API key.
+This script can be run either to ingest the full dataset or as a dated DAG.
 
 ## `image_data_refresh`
 
-
 ### Data Refresh DAG Factory
-This file generates our data refresh DAGs using a factory function.
-For the given media type these DAGs will first refresh the popularity data,
-then initiate a data refresh on the data refresh server and await the
-success or failure of that task.
+
+This file generates our data refresh DAGs using a factory function. For the
+given media type these DAGs will first refresh the popularity data, then
+initiate a data refresh on the data refresh server and await the success or
+failure of that task.
 
 Popularity data for each media type is collated in a materialized view. Before
 initiating a data refresh, the DAG will first refresh the view in order to
-update popularity data for records that have been ingested since the last refresh.
-On the first run of the month, the DAG will also refresh the underlying tables,
-including the percentile values and any new popularity metrics. The DAG can also
-be run with the `force_refresh_metrics` option to run this refresh after the first
-of the month.
+update popularity data for records that have been ingested since the last
+refresh. On the first run of the month, the DAG will also refresh the underlying
+tables, including the percentile values and any new popularity metrics. The DAG
+can also be run with the `force_refresh_metrics` option to run this refresh
+after the first of the month.
 
 Once this step is complete, the data refresh can be initiated. A data refresh
-occurs on the Ingestion server in the openverse project. This is a task
-which imports data from the upstream Catalog database into the API, copies contents
-to a new Elasticsearch index, and finally makes the index "live". This process is
-necessary to make new content added to the Catalog by our provider DAGs available
-to the API. You can read more in the [README](
-https://github.com/WordPress/openverse/blob/main/ingestion_server/README.md
-) Importantly, the data refresh TaskGroup is also configured to handle concurrency
+occurs on the Ingestion server in the openverse project. This is a task which
+imports data from the upstream Catalog database into the API, copies contents to
+a new Elasticsearch index, and finally makes the index "live". This process is
+necessary to make new content added to the Catalog by our provider DAGs
+available to the API. You can read more in the
+[README](https://github.com/WordPress/openverse/blob/main/ingestion_server/README.md)
+Importantly, the data refresh TaskGroup is also configured to handle concurrency
 requirements of the Ingestion server. Finally, once the origin indexes have been
 refreshed, the corresponding filtered index creation DAG is triggered.
 
-You can find more background information on this process in the following
-issues and related PRs:
+You can find more background information on this process in the following issues
+and related PRs:
 
-- [[Feature] Data refresh orchestration DAG](
-https://github.com/WordPress/openverse-catalog/issues/353)
-- [[Feature] Merge popularity calculations and data refresh into a single DAG](
-https://github.com/WordPress/openverse-catalog/issues/453)
-
+- [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
+- [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
 
 ## `inaturalist_workflow`
 
+Provider: iNaturalist
 
-Provider:   iNaturalist
+Output: Records loaded to the image catalog table.
 
-Output:     Records loaded to the image catalog table.
-
-Notes:      The iNaturalist API is not intended for data scraping.
-            https://api.inaturalist.org/v1/docs/
-            But there is a full dump intended for sharing on S3.
-            https://github.com/inaturalist/inaturalist-open-data/tree/documentation/Metadata
-            Because these are very large normalized tables, as opposed to more document
-            oriented API responses, we found that bringing the data into postgres first
-            was the most effective approach. More detail in slack here:
-            https://wordpress.slack.com/archives/C02012JB00N/p1653145643080479?thread_ts=1653082292.714469&cid=C02012JB00N
-            We use the table structure defined here,
-            https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql
-            except for adding ancestry tags to the taxa table.
-
+Notes: The iNaturalist API is not intended for data scraping.
+https://api.inaturalist.org/v1/docs/ But there is a full dump intended for
+sharing on S3.
+https://github.com/inaturalist/inaturalist-open-data/tree/documentation/Metadata
+Because these are very large normalized tables, as opposed to more document
+oriented API responses, we found that bringing the data into postgres first was
+the most effective approach. More detail in slack here:
+https://wordpress.slack.com/archives/C02012JB00N/p1653145643080479?thread_ts=1653082292.714469&cid=C02012JB00N
+We use the table structure defined here,
+https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql
+except for adding ancestry tags to the taxa table.
 
 ## `jamendo_workflow`
 
+Content Provider: Jamendo
 
-Content Provider:       Jamendo
+ETL Process: Use the API to identify all CC-licensed audio.
 
-ETL Process:            Use the API to identify all CC-licensed audio.
+Output: TSV file containing the audio meta-data.
 
-Output:                 TSV file containing the audio meta-data.
-
-Notes:                  https://api.jamendo.com/v3.0/tracks/
-                        35,000 requests per month for non-commercial apps
-                        Jamendo Music has more than 500,000 tracks shared by
-                        40,000 artists from over 150 countries all over
-                        the world.
-                        Audio quality: uploaded as WAV/ FLAC/ AIFF
-                        bit depth: 16/24
-                        sample rate: 44.1 or 48 kHz
-                        channels: 1/2
-
+Notes: https://api.jamendo.com/v3.0/tracks/ 35,000 requests per month for
+non-commercial apps Jamendo Music has more than 500,000 tracks shared by 40,000
+artists from over 150 countries all over the world. Audio quality: uploaded as
+WAV/ FLAC/ AIFF bit depth: 16/24 sample rate: 44.1 or 48 kHz channels: 1/2
 
 ## `metropolitan_museum_reingestion_workflow`
 
+Content Provider: Metropolitan Museum of Art
 
-Content Provider:       Metropolitan Museum of Art
+ETL Process: Use the API to identify all CC0 artworks.
 
-ETL Process:            Use the API to identify all CC0 artworks.
+Output: TSV file containing the image, their respective meta-data.
 
-Output:                 TSV file containing the image, their respective
-                        meta-data.
-
-Notes:                  https://metmuseum.github.io/#search
-                        "Please limit requests to 80 requests per second." May need to
-                        bump up the delay (e.g. to 3 seconds), to avoid of blocking
-                        during local development testing.
+Notes: https://metmuseum.github.io/#search "Please limit requests to 80 requests
+per second." May need to bump up the delay (e.g. to 3 seconds), to avoid of
+blocking during local development testing.
 
                         Some analysis to improve data quality was conducted using a
                         separate csv file here: https://github.com/metmuseum/openaccess
@@ -636,23 +585,18 @@ Notes:                  https://metmuseum.github.io/#search
                         in addition to date and public domain. It seems like it won't
                         connect with just date and license.
                         https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07
-
-
 
 ## `metropolitan_museum_workflow`
 
+Content Provider: Metropolitan Museum of Art
 
-Content Provider:       Metropolitan Museum of Art
+ETL Process: Use the API to identify all CC0 artworks.
 
-ETL Process:            Use the API to identify all CC0 artworks.
+Output: TSV file containing the image, their respective meta-data.
 
-Output:                 TSV file containing the image, their respective
-                        meta-data.
-
-Notes:                  https://metmuseum.github.io/#search
-                        "Please limit requests to 80 requests per second." May need to
-                        bump up the delay (e.g. to 3 seconds), to avoid of blocking
-                        during local development testing.
+Notes: https://metmuseum.github.io/#search "Please limit requests to 80 requests
+per second." May need to bump up the delay (e.g. to 3 seconds), to avoid of
+blocking during local development testing.
 
                         Some analysis to improve data quality was conducted using a
                         separate csv file here: https://github.com/metmuseum/openaccess
@@ -666,223 +610,185 @@ Notes:                  https://metmuseum.github.io/#search
                         connect with just date and license.
                         https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07
 
-
-
 ## `nappy_workflow`
 
+Content Provider: Nappy
 
-Content Provider:       Nappy
+ETL Process: Use the API to identify all CC0-licensed images.
 
-ETL Process:            Use the API to identify all CC0-licensed images.
+Output: TSV file containing the image meta-data.
 
-Output:                 TSV file containing the image meta-data.
-
-Notes:                  This api was written specially for Openverse.
-                        There are no known limits or restrictions.
-                        https://nappy.co/
-
-
+Notes: This api was written specially for Openverse. There are no known limits
+or restrictions. https://nappy.co/
 
 ## `oauth2_authorization`
 
 ### OAuth Provider Authorization
 
-Iterates through all the OAuth2 providers and attempts to authorize them using tokens
-found in the in the `OAUTH2_AUTH_KEYS` Variable. Once authorization has been
-completed successfully, the auth token is removed from that Variable. The authorization
-will create an access/refresh token pair in the `OAUTH2_ACCESS_TOKENS` Variable.
+Iterates through all the OAuth2 providers and attempts to authorize them using
+tokens found in the in the `OAUTH2_AUTH_KEYS` Variable. Once authorization has
+been completed successfully, the auth token is removed from that Variable. The
+authorization will create an access/refresh token pair in the
+`OAUTH2_ACCESS_TOKENS` Variable.
 
 **Current Providers**:
 
 - Freesound
-
-
-
 
 ## `oauth2_token_refresh`
 
 ### OAuth Provider Token Refresh
 
-Iterates through all OAuth2 providers and attempts to refresh the access token using
-the refresh token stored in the `OAUTH2_ACCESS_TOKENS` Variable. This DAG will
-update the tokens stored in the Variable upon successful refresh.
+Iterates through all OAuth2 providers and attempts to refresh the access token
+using the refresh token stored in the `OAUTH2_ACCESS_TOKENS` Variable. This DAG
+will update the tokens stored in the Variable upon successful refresh.
 
 **Current Providers**:
 
 - Freesound
 
-
-
-
 ## `phylopic_reingestion_workflow`
 
+Content Provider: PhyloPic
 
-Content Provider:       PhyloPic
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the image, their respective meta-data.
 
-Output:                 TSV file containing the image,
-                        their respective meta-data.
-
-Notes:                  http://api-docs.phylopic.org/v2/
-                        No rate limit specified.
-
+Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
 
 ## `phylopic_workflow`
 
+Content Provider: PhyloPic
 
-Content Provider:       PhyloPic
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:            Use the API to identify all CC licensed images.
+Output: TSV file containing the image, their respective meta-data.
 
-Output:                 TSV file containing the image,
-                        their respective meta-data.
-
-Notes:                  http://api-docs.phylopic.org/v2/
-                        No rate limit specified.
-
+Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
 
 ## `pr_review_reminders`
 
-
 ### PR Review Reminders
 
-Iterates through open PRs in our repositories and pings assigned reviewers
-who have not yet approved the PR or explicitly requested changes.
+Iterates through open PRs in our repositories and pings assigned reviewers who
+have not yet approved the PR or explicitly requested changes.
 
 This DAG runs daily and pings on the following schedule based on priority label:
 
-| priority | days |
-| --- | --- |
-| critical | 1 day |
-| high | >2 days |
-| medium | >4 days |
-| low | >7 days |
+| priority | days    |
+| -------- | ------- |
+| critical | 1 day   |
+| high     | >2 days |
+| medium   | >4 days |
+| low      | >7 days |
 
-The DAG does not ping on Saturday and Sunday and accounts for weekend days
-when determining how much time has passed since the review.
+The DAG does not ping on Saturday and Sunday and accounts for weekend days when
+determining how much time has passed since the review.
 
 Unfortunately the DAG does not know when someone is on vacation. It is up to the
 author of the PR to re-assign review if one of the randomly selected reviewers
 is unavailable for the time period during which the PR should be reviewed.
 
-
 ## `rawpixel_workflow`
 
+Content Provider: Rawpixel
 
-Content Provider:       Rawpixel
+ETL Process: Use the API to identify all CC-licensed images.
 
-ETL Process:            Use the API to identify all CC-licensed images.
+Output: TSV file containing the image meta-data.
 
-Output:                 TSV file containing the image meta-data.
-
-Notes:                  Rawpixel has given Openverse beta access to their API.
-                        This API is undocumented, and we will need to contact Rawpixel
-                        directly if we run into any issues.
-                        The public API max results range is limited to 100,000 results,
-                        although the API key we've been given can circumvent this limit.
-                        https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100
-
+Notes: Rawpixel has given Openverse beta access to their API. This API is
+undocumented, and we will need to contact Rawpixel directly if we run into any
+issues. The public API max results range is limited to 100,000 results, although
+the API key we've been given can circumvent this limit.
+https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100
 
 ## `recreate_audio_popularity_calculation`
 
-
 This file generates Apache Airflow DAGs that, for the given media type,
 completely wipe out the PostgreSQL relations and functions involved in
-calculating our standardized popularity metric. It then recreates relations
-and functions to make the calculation, and performs an initial calculation.
-The results are available in the materialized view for that media type.
+calculating our standardized popularity metric. It then recreates relations and
+functions to make the calculation, and performs an initial calculation. The
+results are available in the materialized view for that media type.
 
-These DAGs are not on a schedule, and should only be run manually when new
-SQL code is deployed for the calculation.
-
+These DAGs are not on a schedule, and should only be run manually when new SQL
+code is deployed for the calculation.
 
 ## `recreate_image_popularity_calculation`
 
-
 This file generates Apache Airflow DAGs that, for the given media type,
 completely wipe out the PostgreSQL relations and functions involved in
-calculating our standardized popularity metric. It then recreates relations
-and functions to make the calculation, and performs an initial calculation.
-The results are available in the materialized view for that media type.
+calculating our standardized popularity metric. It then recreates relations and
+functions to make the calculation, and performs an initial calculation. The
+results are available in the materialized view for that media type.
 
-These DAGs are not on a schedule, and should only be run manually when new
-SQL code is deployed for the calculation.
-
+These DAGs are not on a schedule, and should only be run manually when new SQL
+code is deployed for the calculation.
 
 ## `report_pending_reported_media`
 
-
 ### Report Pending Reported Media DAG
+
 This DAG checks for any user-reported media pending manual review, and alerts
 via Slack.
 
-Media may be reported for mature content or copyright infringement, for
-example. Once reported, these require manual review through the Django Admin to
-determine whether further action (such as deindexing the record) needs to be
-taken. If a record has been reported multiple times, it only needs to be
-reviewed once and so is only counted once in the reporting by this DAG.
-
+Media may be reported for mature content or copyright infringement, for example.
+Once reported, these require manual review through the Django Admin to determine
+whether further action (such as deindexing the record) needs to be taken. If a
+record has been reported multiple times, it only needs to be reviewed once and
+so is only counted once in the reporting by this DAG.
 
 ## `rotate_db_snapshots`
 
-
 Manages weekly database snapshots.
 
-RDS does not support weekly snapshots schedules on its own, so we need a DAG to manage
-this for us.
+RDS does not support weekly snapshots schedules on its own, so we need a DAG to
+manage this for us.
 
 It runs on Saturdays at 00:00 UTC in order to happen before the data refresh.
 
-The DAG will automatically delete the oldest snapshots when more snaphots
-exist than it is configured to retain.
+The DAG will automatically delete the oldest snapshots when more snaphots exist
+than it is configured to retain.
 
 Requires two variables:
 
 `CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
 `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
 
-
 ## `science_museum_workflow`
 
+Content Provider: Science Museum
 
-Content Provider:       Science Museum
+ETL Process: Use the API to identify all CC-licensed images.
 
-ETL Process:            Use the API to identify all CC-licensed images.
+Output: TSV file containing the image, the respective meta-data.
 
-Output:                 TSV file containing the image, the respective
-                        meta-data.
-
-Notes:                  https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API
-                        Rate limited, no specific rate given.
-
+Notes:
+https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API
+Rate limited, no specific rate given.
 
 ## `smithsonian_workflow`
 
+Content Provider: Smithsonian
 
-Content Provider:   Smithsonian
+ETL Process: Use the API to identify all CC licensed images.
 
-ETL Process:        Use the API to identify all CC licensed images.
+Output: TSV file containing the images and the respective meta-data.
 
-Output:             TSV file containing the images and the respective meta-data.
-
-Notes:              https://api.si.edu/openaccess/api/v1.0/search
-
+Notes: https://api.si.edu/openaccess/api/v1.0/search
 
 ## `smk_workflow`
 
+Content Provider: Statens Museum for Kunst (National Gallery of Denmark)
 
-Content Provider:       Statens Museum for Kunst (National Gallery of Denmark)
+ETL Process: Use the API to identify all openly licensed media.
 
-ETL Process:            Use the API to identify all openly licensed media.
+Output: TSV file containing the media metadata.
 
-Output:                 TSV file containing the media metadata.
-
-Notes:                  https://www.smk.dk/en/article/smk-api/
-
+Notes: https://www.smk.dk/en/article/smk-api/
 
 ## `staging_database_restore`
-
 
 ### Update the staging database
 
@@ -892,266 +798,277 @@ snapshot of the production database.
 For a full explanation of the DAG, see the implementation plan description:
 https://docs.openverse.org/projects/proposals/search_relevancy_sandbox/20230406-implementation_plan_update_staging_database.html#dag
 
-This DAG can be skipped by setting the `SKIP_STAGING_DATABASE_RESTORE` Airflow Variable
-to `true`. To change this variable, navigate to Admin > Variables in the Airflow UI,
-then click the "edit" button next to the variable and set the value to either `true`
-or `false`.
+This DAG can be skipped by setting the `SKIP_STAGING_DATABASE_RESTORE` Airflow
+Variable to `true`. To change this variable, navigate to Admin > Variables in
+the Airflow UI, then click the "edit" button next to the variable and set the
+value to either `true` or `false`.
 
-This DAG will default to using the standard AWS connection ID for the RDS operations.
-For local testing, you can set up two environment variables to have the RDS operations
-run using a different hook:
-- `AWS_RDS_CONN_ID`: The Airflow connection ID to use for RDS operations
-  (e.g. `aws_rds`)
-- `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the above
-  example, it might be `AIRFLOW_CONN_AWS_RDS`)
+This DAG will default to using the standard AWS connection ID for the RDS
+operations. For local testing, you can set up two environment variables to have
+the RDS operations run using a different hook:
 
+- `AWS_RDS_CONN_ID`: The Airflow connection ID to use for RDS operations (e.g.
+  `aws_rds`)
+- `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
+  above example, it might be `AIRFLOW_CONN_AWS_RDS`)
 
 ## `stocksnap_workflow`
 
+Content Provider: StockSnap
 
-Content Provider:       StockSnap
+ETL Process: Use the API to identify all CC-licensed images.
 
-ETL Process:            Use the API to identify all CC-licensed images.
+Output: TSV file containing the image, the respective meta-data.
 
-Output:                 TSV file containing the image, the respective meta-data.
-
-Notes:                  https://stocksnap.io/api/load-photos/date/desc/1
-                        https://stocksnap.io/faq
-                        All images are licensed under CC0.
-                        No rate limits or authorization required.
-                        API is undocumented.
-
+Notes: https://stocksnap.io/api/load-photos/date/desc/1 https://stocksnap.io/faq
+All images are licensed under CC0. No rate limits or authorization required. API
+is undocumented.
 
 ## `wikimedia_commons_workflow`
 
-
 **Content Provider:** Wikimedia Commons
 
 **ETL Process:** Use the API to identify all CC-licensed images.
 
-**Output:** TSV file containing the image, the respective
-                        meta-data.
+**Output:** TSV file containing the image, the respective meta-data.
 
 ### Notes
 
-Rate limit of no more than 200 requests/second, and we are required to set a unique
-User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+Rate limit of no more than 200 requests/second, and we are required to set a
+unique User-Agent field
+([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
 
 Wikimedia Commons uses an implementation of the
-[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is incredibly
-complex in the level of configuration you can provide when querying, and as such it can
-also be quite abstruse. The most straightforward docs can be found on the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
+incredibly complex in the level of configuration you can provide when querying,
+and as such it can also be quite abstruse. The most straightforward docs can be
+found on the
 [Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
-as these show all the parameters available. Specifications on queries can also be found
-on the [query page](https://www.mediawiki.org/wiki/API:Query).
+as these show all the parameters available. Specifications on queries can also
+be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
 
-Different kinds of queries can be made against the API using "modules", we use the
-[allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets us search
-for images in a given time range (see `"generator": "allimages"` in the query params).
+Different kinds of queries can be made against the API using "modules", we use
+the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
+us search for images in a given time range (see `"generator": "allimages"` in
+the query params).
 
-Many queries will return results in batches, with the API supplying a "continue" token.
-This token is used on subsequent calls to tell the API where to start the next set of
-results from; it functions as a page offset ([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+Many queries will return results in batches, with the API supplying a "continue"
+token. This token is used on subsequent calls to tell the API where to start the
+next set of results from; it functions as a page offset
+([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
 
-We can also specify what kinds of information we want for the query. Wikimedia has a
-massive amount of data on it, so it only returns what we ask for. The fields that are
-returned are defined by the [properties](https://www.mediawiki.org/wiki/API:Properties)
-or "props" parameter. Sub-properties can also be defined, with the parameter name of
-the sub-property determined by an abbreviation of the higher-level property. For
-instance, if our property is "imageinfo" and we want to set sub-property values, we
-would define those in "iiprops".
+We can also specify what kinds of information we want for the query. Wikimedia
+has a massive amount of data on it, so it only returns what we ask for. The
+fields that are returned are defined by the
+[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
+parameter. Sub-properties can also be defined, with the parameter name of the
+sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values,
+we would define those in "iiprops".
 
-The data within a property is paginated as well, Wikimedia will handle iteration through
-the property sub-pages using the "continue" token
+The data within a property is paginated as well, Wikimedia will handle iteration
+through the property sub-pages using the "continue" token
 ([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
 
-Depending on the kind of property data that's being returned, it's possible for the API
-to iterate extensively on a specific media item. What Wikimedia is iterating over in
-these cases can be gleaned from the "continue" token. Those tokens take the form of,
-as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
-"<XX>continue" value for the property being iterated over. For example, if we're
-were iterating over a set of image properties, the token might look like:
+Depending on the kind of property data that's being returned, it's possible for
+the API to iterate extensively on a specific media item. What Wikimedia is
+iterating over in these cases can be gleaned from the "continue" token. Those
+tokens take the form of, as I understand it,
+"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
+for the property being iterated over. For example, if we're were iterating over
+a set of image properties, the token might look like:
 
 ```
-
-{ "iicontinue": "The*Railway_Chronicle_1844.pdf|20221209222801", "gaicontinue":
-"20221209222614|NTUL-0527100*英國產業革命史略.pdf", "continue":
-"gaicontinue||globalusage", }
-
+{
+    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
+    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
+    "continue": "gaicontinue||globalusage",
+}
 ```
 
-In this case, we're iterating over the "global all images" generator (gaicontinue) as
-our primary iterator, with the "image properties" (iicontinue) as the secondary continue
-iterator. The "globalusage" property would be the next property to iterate over. It's
-also possible for multiple sub-properties to be iterated over simultaneously, in which
-case the "continue" token would not have a secondary value (e.g. `gaicontinue||`).
+In this case, we're iterating over the "global all images" generator
+(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
+as the secondary continue iterator. The "globalusage" property would be the next
+property to iterate over. It's also possible for multiple sub-properties to be
+iterated over simultaneously, in which case the "continue" token would not have
+a secondary value (e.g. `gaicontinue||`).
 
-In most runs, the "continue" key will be `gaicontinue||` after the first request, which
-means that we have more than one batch to iterate over for the primary iterator. Some
-days will have fewer images than the batch limit but still have multiple batches of
-content on the secondary iterator, which means the "continue" key may not have a primary
-iteration component (e.g. `||globalusage`). This token can also be seen when the first
-request has more data in the secondary iterator, before we've processed any data on
-the primary iterator.
+In most runs, the "continue" key will be `gaicontinue||` after the first
+request, which means that we have more than one batch to iterate over for the
+primary iterator. Some days will have fewer images than the batch limit but
+still have multiple batches of content on the secondary iterator, which means
+the "continue" key may not have a primary iteration component (e.g.
+`||globalusage`). This token can also be seen when the first request has more
+data in the secondary iterator, before we've processed any data on the primary
+iterator.
 
-Occasionally, the ingester will come across a piece of media that has many results for
-the property it's iterating over. An example of this can include an item being on many
-pages, this it would have many "global usage" results. In order to process the entire
-batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
-a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
-been so extensive that the pull media task has hit the task's timeout. To avoid this,
-we limit the number of iterations we make for parsing through a sub-property's data. If
-we hit the limit, we re-issue the original query *without* requesting properties that
-returned large amounts of data. Unfortunately, this means that we will
-**not** have that property's data for these items the second time around (e.g.
+Occasionally, the ingester will come across a piece of media that has many
+results for the property it's iterating over. An example of this can include an
+item being on many pages, this it would have many "global usage" results. In
+order to process the entire batch, we have to iterate over _all_ of the returned
+results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
+On numerous occasions, this iteration has been so extensive that the pull media
+task has hit the task's timeout. To avoid this, we limit the number of
+iterations we make for parsing through a sub-property's data. If we hit the
+limit, we re-issue the original query _without_ requesting properties that
+returned large amounts of data. Unfortunately, this means that we will **not**
+have that property's data for these items the second time around (e.g.
 popularity data if we needed to skip global usage). In the case of popularity,
-especially since the problem with these images is that they're so popular, we want to
-preserve that information where possible! So we cache the popularity data from
-previous iterations and use it in subsequent ones if we come across the same
-item again.
+especially since the problem with these images is that they're so popular, we
+want to preserve that information where possible! So we cache the popularity
+data from previous iterations and use it in subsequent ones if we come across
+the same item again.
 
-Below are some specific references to various properties, with examples for cases where
-they might exceed the limit. Technically, it's feasible for almost any property to
-exceed the limit, but these are the ones that we've seen in practice.
+Below are some specific references to various properties, with examples for
+cases where they might exceed the limit. Technically, it's feasible for almost
+any property to exceed the limit, but these are the ones that we've seen in
+practice.
 
 #### `imageinfo`
+
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
 
 [Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
 (see "Metadata" table, which may need to be expanded).
 
-For these requests, we can remove the `metadata` property from the `iiprops` parameter
-to avoid this issue on subsequent iterations.
+For these requests, we can remove the `metadata` property from the `iiprops`
+parameter to avoid this issue on subsequent iterations.
 
 #### `globalusage`
+
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
 
 [Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
 
-For these requests, we can remove the `globalusage` property from the `prop` parameter
-entirely and eschew the popularity data for these items.
-
+For these requests, we can remove the `globalusage` property from the `prop`
+parameter entirely and eschew the popularity data for these items.
 
 ## `wikimedia_reingestion_workflow`
 
-
 **Content Provider:** Wikimedia Commons
 
 **ETL Process:** Use the API to identify all CC-licensed images.
 
-**Output:** TSV file containing the image, the respective
-                        meta-data.
+**Output:** TSV file containing the image, the respective meta-data.
 
 ### Notes
 
-Rate limit of no more than 200 requests/second, and we are required to set a unique
-User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+Rate limit of no more than 200 requests/second, and we are required to set a
+unique User-Agent field
+([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
 
 Wikimedia Commons uses an implementation of the
-[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is incredibly
-complex in the level of configuration you can provide when querying, and as such it can
-also be quite abstruse. The most straightforward docs can be found on the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
+incredibly complex in the level of configuration you can provide when querying,
+and as such it can also be quite abstruse. The most straightforward docs can be
+found on the
 [Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
-as these show all the parameters available. Specifications on queries can also be found
-on the [query page](https://www.mediawiki.org/wiki/API:Query).
+as these show all the parameters available. Specifications on queries can also
+be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
 
-Different kinds of queries can be made against the API using "modules", we use the
-[allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets us search
-for images in a given time range (see `"generator": "allimages"` in the query params).
+Different kinds of queries can be made against the API using "modules", we use
+the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
+us search for images in a given time range (see `"generator": "allimages"` in
+the query params).
 
-Many queries will return results in batches, with the API supplying a "continue" token.
-This token is used on subsequent calls to tell the API where to start the next set of
-results from; it functions as a page offset ([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+Many queries will return results in batches, with the API supplying a "continue"
+token. This token is used on subsequent calls to tell the API where to start the
+next set of results from; it functions as a page offset
+([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
 
-We can also specify what kinds of information we want for the query. Wikimedia has a
-massive amount of data on it, so it only returns what we ask for. The fields that are
-returned are defined by the [properties](https://www.mediawiki.org/wiki/API:Properties)
-or "props" parameter. Sub-properties can also be defined, with the parameter name of
-the sub-property determined by an abbreviation of the higher-level property. For
-instance, if our property is "imageinfo" and we want to set sub-property values, we
-would define those in "iiprops".
+We can also specify what kinds of information we want for the query. Wikimedia
+has a massive amount of data on it, so it only returns what we ask for. The
+fields that are returned are defined by the
+[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
+parameter. Sub-properties can also be defined, with the parameter name of the
+sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values,
+we would define those in "iiprops".
 
-The data within a property is paginated as well, Wikimedia will handle iteration through
-the property sub-pages using the "continue" token
+The data within a property is paginated as well, Wikimedia will handle iteration
+through the property sub-pages using the "continue" token
 ([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
 
-Depending on the kind of property data that's being returned, it's possible for the API
-to iterate extensively on a specific media item. What Wikimedia is iterating over in
-these cases can be gleaned from the "continue" token. Those tokens take the form of,
-as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
-"<XX>continue" value for the property being iterated over. For example, if we're
-were iterating over a set of image properties, the token might look like:
+Depending on the kind of property data that's being returned, it's possible for
+the API to iterate extensively on a specific media item. What Wikimedia is
+iterating over in these cases can be gleaned from the "continue" token. Those
+tokens take the form of, as I understand it,
+"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
+for the property being iterated over. For example, if we're were iterating over
+a set of image properties, the token might look like:
 
 ```
-
-{ "iicontinue": "The*Railway_Chronicle_1844.pdf|20221209222801", "gaicontinue":
-"20221209222614|NTUL-0527100*英國產業革命史略.pdf", "continue":
-"gaicontinue||globalusage", }
-
+{
+    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
+    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
+    "continue": "gaicontinue||globalusage",
+}
 ```
 
-In this case, we're iterating over the "global all images" generator (gaicontinue) as
-our primary iterator, with the "image properties" (iicontinue) as the secondary continue
-iterator. The "globalusage" property would be the next property to iterate over. It's
-also possible for multiple sub-properties to be iterated over simultaneously, in which
-case the "continue" token would not have a secondary value (e.g. `gaicontinue||`).
+In this case, we're iterating over the "global all images" generator
+(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
+as the secondary continue iterator. The "globalusage" property would be the next
+property to iterate over. It's also possible for multiple sub-properties to be
+iterated over simultaneously, in which case the "continue" token would not have
+a secondary value (e.g. `gaicontinue||`).
 
-In most runs, the "continue" key will be `gaicontinue||` after the first request, which
-means that we have more than one batch to iterate over for the primary iterator. Some
-days will have fewer images than the batch limit but still have multiple batches of
-content on the secondary iterator, which means the "continue" key may not have a primary
-iteration component (e.g. `||globalusage`). This token can also be seen when the first
-request has more data in the secondary iterator, before we've processed any data on
-the primary iterator.
+In most runs, the "continue" key will be `gaicontinue||` after the first
+request, which means that we have more than one batch to iterate over for the
+primary iterator. Some days will have fewer images than the batch limit but
+still have multiple batches of content on the secondary iterator, which means
+the "continue" key may not have a primary iteration component (e.g.
+`||globalusage`). This token can also be seen when the first request has more
+data in the secondary iterator, before we've processed any data on the primary
+iterator.
 
-Occasionally, the ingester will come across a piece of media that has many results for
-the property it's iterating over. An example of this can include an item being on many
-pages, this it would have many "global usage" results. In order to process the entire
-batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
-a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
-been so extensive that the pull media task has hit the task's timeout. To avoid this,
-we limit the number of iterations we make for parsing through a sub-property's data. If
-we hit the limit, we re-issue the original query *without* requesting properties that
-returned large amounts of data. Unfortunately, this means that we will
-**not** have that property's data for these items the second time around (e.g.
+Occasionally, the ingester will come across a piece of media that has many
+results for the property it's iterating over. An example of this can include an
+item being on many pages, this it would have many "global usage" results. In
+order to process the entire batch, we have to iterate over _all_ of the returned
+results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
+On numerous occasions, this iteration has been so extensive that the pull media
+task has hit the task's timeout. To avoid this, we limit the number of
+iterations we make for parsing through a sub-property's data. If we hit the
+limit, we re-issue the original query _without_ requesting properties that
+returned large amounts of data. Unfortunately, this means that we will **not**
+have that property's data for these items the second time around (e.g.
 popularity data if we needed to skip global usage). In the case of popularity,
-especially since the problem with these images is that they're so popular, we want to
-preserve that information where possible! So we cache the popularity data from
-previous iterations and use it in subsequent ones if we come across the same
-item again.
+especially since the problem with these images is that they're so popular, we
+want to preserve that information where possible! So we cache the popularity
+data from previous iterations and use it in subsequent ones if we come across
+the same item again.
 
-Below are some specific references to various properties, with examples for cases where
-they might exceed the limit. Technically, it's feasible for almost any property to
-exceed the limit, but these are the ones that we've seen in practice.
+Below are some specific references to various properties, with examples for
+cases where they might exceed the limit. Technically, it's feasible for almost
+any property to exceed the limit, but these are the ones that we've seen in
+practice.
 
 #### `imageinfo`
+
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
 
 [Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
 (see "Metadata" table, which may need to be expanded).
 
-For these requests, we can remove the `metadata` property from the `iiprops` parameter
-to avoid this issue on subsequent iterations.
+For these requests, we can remove the `metadata` property from the `iiprops`
+parameter to avoid this issue on subsequent iterations.
 
 #### `globalusage`
+
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
 
 [Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
 
-For these requests, we can remove the `globalusage` property from the `prop` parameter
-entirely and eschew the popularity data for these items.
-
+For these requests, we can remove the `globalusage` property from the `prop`
+parameter entirely and eschew the popularity data for these items.
 
 ## `wordpress_workflow`
 
+Content Provider: WordPress Photo Directory
 
-Content Provider:       WordPress Photo Directory
+ETL Process: Use the API to identify all openly licensed media.
 
-ETL Process:            Use the API to identify all openly licensed media.
+Output: TSV file containing the media metadata.
 
-Output:                 TSV file containing the media metadata.
-
-Notes:                  https://wordpress.org/photos/wp-json/wp/v2
-                        Provide photos, media, users and more related resources.
-                        No rate limit specified.
-```
+Notes: https://wordpress.org/photos/wp-json/wp/v2 Provide photos, media, users
+and more related resources. No rate limit specified.

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -120,6 +120,7 @@ def update_batches(
             dry_run=dry_run,
             sql_template=constants.UPDATE_BATCH_QUERY,
             query_id=query_id,
+            # Only log the query the first time, so as not to spam the logs
             log_sql=batch_start == initial_batch_start,
             postgres_conn_id=postgres_conn_id,
             task=task,

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -144,6 +144,11 @@ def update_batches(
 
 
 @task
+def drop_temp_airflow_variable(airflow_var: str):
+    Variable.delete(airflow_var)
+
+
+@task
 def notify_slack(text: str, dry_run: bool) -> None:
     if not dry_run:
         slack.send_message(

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -108,12 +108,11 @@ def update_batches(
     # from the start point set by this variable (defaulted to 0). This prevents the
     # task from starting over at the beginning on retries.
     initial_batch_start = Variable.get(batch_start_var, 0, deserialize_json=True)
-    expected_row_count = max(total_row_count - initial_batch_start, 0)
     logger.info(f"Starting at {initial_batch_start}")
 
     updated_count = 0
     batch_start = initial_batch_start
-    while batch_start <= expected_row_count:
+    while batch_start <= total_row_count:
         batch_end = batch_start + batch_size
 
         logger.info(f"Updating rows with id {batch_start} through {batch_end}.")
@@ -136,10 +135,9 @@ def update_batches(
 
         # Update the Airflow variable to the next value of batch_start.
         Variable.set(batch_start_var, batch_end)
-        logger.info(
-            f"Updated {updated_count} rows. {expected_row_count - updated_count}"
-            " remaining."
-        )
+
+        remaining_count = max(total_row_count - initial_batch_start - updated_count, 0)
+        logger.info(f"Updated {updated_count} rows. {remaining_count} remaining.")
 
     return updated_count
 

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -31,8 +31,6 @@ Optional params:
 * batch_size: int number of records to process in each batch. By default, 10_000
 * update_timeout: int number of seconds to run an individual batch update before timing
                   out. By default, 3600 (or one hour)
-* batch_start: int index into the temp table at which to start the update. By default,
-               this is 0 and all rows in the temp table are updated.
 * resume_update: boolean indicating whether to attempt to resume an update using an
                existing temp table matching the `query_id`. When True, a new temp
                table is not created.
@@ -51,23 +49,18 @@ null would look like this:
 }
 ```
 
-It is possible to resume an update from an arbitrary starting point on an existing
-temp table, for example if a DAG succeeds in creating the temp table but fails midway
-through the update. To do so, set the `resume_update` param to True and select your
-desired `batch_start`. For instance, if the example DAG given above failed after
-processing the first 50_000 records, you might run:
+The `update_batches` task automatically keeps track of its progress in an Airflow
+variable suffixed with the `query_id`. If the task fails, when it resumes (either
+through a retry or by being manually cleared), it will pick up from where it left
+off. Manually managing this Airflow variable should not be necessary.
 
-```
-{
-    "query_id": "my_flickr_query",
-    "table_name": "image",
-    "select_query": "WHERE provider='flickr'",
-    "update_query": "SET thumbnail=null",
-    "batch_size": 10,
-    "batch_start": 50000,
-    "resume_update": true,
-    "dry_run": false
-}
+It is also possible to start an entirely new DagRun using an existing temp table,
+by setting the `skip_table_creation` param to True. With this option enabled, the
+DAG will skip creating the temp table and instead attempt to run an update with an
+existing temp table matching the `query_id`. This option should only be used when
+the DagRun configuration needs to be changed after the table was already created:
+for example, if there was a problem with the `update_query` which caused DAG
+failures during the `update_batches` step.
 ```
 """
 
@@ -76,6 +69,7 @@ import logging
 
 from airflow.decorators import dag
 from airflow.models.param import Param
+from airflow.operators.bash import BashOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from common.constants import AUDIO, DAG_DEFAULT_ARGS, MEDIA_TYPES
@@ -102,10 +96,7 @@ logger = logging.getLogger(__name__)
     max_active_runs=10,
     dagrun_timeout=constants.DAGRUN_TIMEOUT,
     doc_md=__doc__,
-    default_args={
-        **DAG_DEFAULT_ARGS,
-        "retries": 0,
-    },
+    default_args=DAG_DEFAULT_ARGS,
     render_template_as_native_obj=True,
     params={
         "query_id": Param(
@@ -152,22 +143,12 @@ logger = logging.getLogger(__name__)
                 " should take for a single batch to be updated."
             ),
         ),
-        "batch_start": Param(
-            default=None,
-            type=["integer", "null"],
-            description=(
-                "Optionally, a row_id from which to begin updating records. By"
-                " default, all records matching the SELECT will be updated."
-            ),
-            minimum=0,
-        ),
         "resume_update": Param(
             default=False,
             type="boolean",
             description=(
-                "Whether to resume an existing update. When True, the DAG will skip"
-                " creating a temp table, and instead try to use an existing temp table"
-                " matching the `query_id`."
+                "Whether to skip creating the temp table. When enabled, the DAG will"
+                " try to use an existing temp table matching the `query_id`."
             ),
         ),
         "dry_run": Param(
@@ -181,6 +162,9 @@ logger = logging.getLogger(__name__)
     },
 )
 def batched_update():
+    # Unique Airflow variable name for tracking the batch_start for this query
+    BATCH_START_VAR = "batch_start_{{ params.query_id }}"
+
     check_for_resume_update = resume_update(
         resume_update="{{ params.resume_update }}",
     )
@@ -208,12 +192,9 @@ def batched_update():
         trigger_rule=TriggerRule.NONE_FAILED,
     )(
         query_id="{{ params.query_id }}",
-        batch_start="{{ params.batch_start }}",
+        total_row_count=select_rows_to_update,
         dry_run="{{ params.dry_run }}",
     )
-
-    check_for_resume_update >> [select_rows_to_update, expected_count]
-    select_rows_to_update >> create_index >> expected_count
 
     notify_before_update = notify_slack.override(task_id="notify_before_update")(
         text=f"Preparing to update {select_rows_to_update} rows for update:"
@@ -221,12 +202,15 @@ def batched_update():
         dry_run="{{ params.dry_run}}",
     )
 
+    check_for_resume_update >> [select_rows_to_update, expected_count]
+    select_rows_to_update >> [create_index, expected_count]
+
     perform_batched_update = update_batches.override(
         execution_timeout=constants.UPDATE_TIMEOUT
     )(
-        expected_row_count=expected_count,
+        total_row_count=expected_count,
         batch_size="{{ params.batch_size }}",
-        batch_start="{{ params.batch_start }}",
+        batch_start_var=BATCH_START_VAR,
         dry_run="{{ params.dry_run }}",
         table_name="{{ params.table_name }}",
         query_id="{{ params.query_id }}",
@@ -253,6 +237,12 @@ def batched_update():
         query_id="{{ params.query_id }}",
     )
 
+    # Clean up the variable we used for tracking the last row
+    drop_variable = BashOperator(
+        task_id="drop_temp_airflow_variables",
+        bash_command=f"airflow variables delete {BATCH_START_VAR}",
+    )
+
     # If there was an error, notify to Slack that the temporary table must be
     # dropped manually or the DAG retried.
     notify_failure = notify_slack.override(
@@ -266,6 +256,7 @@ def batched_update():
     perform_batched_update >> [
         notify_updated_count,
         drop_temporary_table,
+        drop_variable,
         notify_failure,
     ]
 

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -69,12 +69,12 @@ import logging
 
 from airflow.decorators import dag
 from airflow.models.param import Param
-from airflow.operators.bash import BashOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from common.constants import AUDIO, DAG_DEFAULT_ARGS, MEDIA_TYPES
 from database.batched_update import constants
 from database.batched_update.batched_update import (
+    drop_temp_airflow_variable,
     get_expected_update_count,
     notify_slack,
     resume_update,
@@ -238,9 +238,8 @@ def batched_update():
     )
 
     # Clean up the variable we used for tracking the last row
-    drop_variable = BashOperator(
-        task_id="drop_temp_airflow_variables",
-        bash_command=f"airflow variables delete {BATCH_START_VAR}",
+    drop_variable = drop_temp_airflow_variable(
+        airflow_var=BATCH_START_VAR,
     )
 
     # If there was an error, notify to Slack that the temporary table must be

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -55,7 +55,7 @@ through a retry or by being manually cleared), it will pick up from where it lef
 off. Manually managing this Airflow variable should not be necessary.
 
 It is also possible to start an entirely new DagRun using an existing temp table,
-by setting the `skip_table_creation` param to True. With this option enabled, the
+by setting the `resume_update` param to True. With this option enabled, the
 DAG will skip creating the temp table and instead attempt to run an update with an
 existing temp table matching the `query_id`. This option should only be used when
 the DagRun configuration needs to be changed after the table was already created:

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -163,7 +163,7 @@ logger = logging.getLogger(__name__)
 )
 def batched_update():
     # Unique Airflow variable name for tracking the batch_start for this query
-    BATCH_START_VAR = "batch_start_{{ params.query_id }}"
+    BATCH_START_VAR = "batched_update_start_{{ params.query_id }}"
 
     check_for_resume_update = resume_update(
         resume_update="{{ params.resume_update }}",

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -61,7 +61,6 @@ existing temp table matching the `query_id`. This option should only be used whe
 the DagRun configuration needs to be changed after the table was already created:
 for example, if there was a problem with the `update_query` which caused DAG
 failures during the `update_batches` step.
-```
 """
 
 

--- a/catalog/dags/database/batched_update/constants.py
+++ b/catalog/dags/database/batched_update/constants.py
@@ -26,7 +26,7 @@ CREATE_TEMP_TABLE_QUERY = """
     {select_query};
     """
 CREATE_TEMP_TABLE_INDEX_QUERY = "CREATE INDEX ON {temp_table_name}(row_id)"
-SELECT_TEMP_TABLE_QUERY = """
+SELECT_TEMP_TABLE_COUNT_QUERY = """
     SELECT COUNT(*)
     FROM {temp_table_name};
     """

--- a/catalog/tests/dags/database/test_batched_update.py
+++ b/catalog/tests/dags/database/test_batched_update.py
@@ -3,6 +3,7 @@ import uuid
 
 import psycopg2
 import pytest
+from airflow.models import Variable
 
 from catalog.tests.test_utils import sql
 from common.storage import columns as col
@@ -33,6 +34,11 @@ def identifier(request):
 
 
 @pytest.fixture
+def batch_start_var(identifier):
+    return f"test_{identifier}_batch_start"
+
+
+@pytest.fixture
 def image_table(identifier):
     # Parallelized tests need to use distinct database tables
     return f"image_{identifier}"
@@ -44,7 +50,7 @@ def temp_table(identifier):
 
 
 @pytest.fixture
-def postgres_with_image_and_temp_table(image_table, temp_table):
+def postgres_with_image_and_temp_table(batch_start_var, image_table, temp_table):
     conn = psycopg2.connect(sql.POSTGRES_TEST_URI)
     cur = conn.cursor()
     drop_table_query = f"""
@@ -61,6 +67,9 @@ def postgres_with_image_and_temp_table(image_table, temp_table):
     yield sql.PostgresRef(cursor=cur, connection=conn)
 
     cur.execute(drop_table_query)
+    # Drop the test airflow variable
+    Variable.delete(batch_start_var)
+
     cur.close()
     conn.commit()
     conn.close()
@@ -116,23 +125,23 @@ def _load_sample_data_into_image_table(image_table, postgres):
 
 
 @pytest.mark.parametrize(
-    "batch_start, expected_count",
-    [
-        (None, 3),
-        (0, 3),
-        (1, 2),
-        (2, 1),
-        # Batch start greater than the total number of records
-        (4, 0),
-    ],
+    "total_row_count",
+    (
+        # Simulate a 'normal' flow, where the total count is passed into
+        # the task via XCOM after creating the table
+        3,
+        # Simulate a DagRun that is using `resume_update` to skip creating a
+        # new table, so None is passed in from XCOM and we need to run a
+        # `SELECT COUNT(*)` on the temp table
+        None,
+    ),
 )
 def test_get_expected_update_count(
     postgres_with_image_and_temp_table,
     image_table,
     temp_table,
     identifier,
-    batch_start,
-    expected_count,
+    total_row_count,
 ):
     # Load sample data into the image table
     _load_sample_data_into_image_table(
@@ -149,10 +158,10 @@ def test_get_expected_update_count(
     postgres_with_image_and_temp_table.connection.commit()
 
     total_count = get_expected_update_count.function(
-        query_id=f"test_{identifier}", batch_start=batch_start, dry_run=False
+        query_id=f"test_{identifier}", total_row_count=total_row_count, dry_run=False
     )
 
-    assert total_count == expected_count
+    assert total_count == 3
 
 
 def test_update_batches(
@@ -160,6 +169,7 @@ def test_update_batches(
     image_table,
     temp_table,
     identifier,
+    batch_start_var,
 ):
     # Load sample data into the image table
     _load_sample_data_into_image_table(
@@ -181,10 +191,11 @@ def test_update_batches(
         dry_run=False,
         query_id=f"test_{identifier}",
         table_name=image_table,
-        expected_row_count=2,
+        total_row_count=2,
         batch_size=1,
         update_query=update_query,
         update_timeout=3600,
+        batch_start_var=batch_start_var,
         postgres_conn_id=sql.POSTGRES_CONN_ID,
     )
 
@@ -212,6 +223,7 @@ def test_update_batches_dry_run(
     image_table,
     temp_table,
     identifier,
+    batch_start_var,
 ):
     # Load sample data into the image table
     _load_sample_data_into_image_table(
@@ -232,12 +244,12 @@ def test_update_batches_dry_run(
     updated_count = update_batches.function(
         dry_run=True,
         query_id=f"test_{identifier}",
-        batch_start=None,
         table_name=image_table,
-        expected_row_count=2,
+        total_row_count=2,
         batch_size=1,
         update_query=update_query,
         update_timeout=3600,
+        batch_start_var=batch_start_var,
         postgres_conn_id=sql.POSTGRES_CONN_ID,
     )
 
@@ -252,11 +264,12 @@ def test_update_batches_dry_run(
         assert row[sql.title_idx] == OLD_TITLE
 
 
-def test_update_batches_from_batch_start(
+def test_update_batches_resuming_from_batch_start(
     postgres_with_image_and_temp_table,
     image_table,
     temp_table,
     identifier,
+    batch_start_var,
 ):
     # Load sample data into the image table
     _load_sample_data_into_image_table(
@@ -272,17 +285,20 @@ def test_update_batches_from_batch_start(
     postgres_with_image_and_temp_table.cursor.execute(create_temp_table_query)
     postgres_with_image_and_temp_table.connection.commit()
 
-    # Test update query, setting batch_start to 1
+    # Set the batch_start Airflow variable to 1, to skip the first
+    # record
+    Variable.set(batch_start_var, 1)
+
     update_query = f"SET title='{NEW_TITLE}'"
     updated_count = update_batches.function(
         dry_run=False,
         query_id=f"test_{identifier}",
         table_name=image_table,
-        expected_row_count=2,
+        total_row_count=3,
         batch_size=1,
-        batch_start=1,
         update_query=update_query,
         update_timeout=3600,
+        batch_start_var=batch_start_var,
         postgres_conn_id=sql.POSTGRES_CONN_ID,
     )
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2507 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
More context in #2507, but briefly:

Because the `batched_update` DAG is going to be used to perform potentially very long-running (multiple weeks long) updates, it needs to be able to handle the update task failing and retrying due to Catalog deployments. In the current implementation, when the update task retries it would resume _from the beginning_.

This PR takes the following approach:
* In each DagRun, we create an Airflow variable suffixed with the `query_id` that we use to keep track of the progress of the update, updating it after each batch.
* When the `update_batches` task runs, it checks to see if this variable exists and if so, resumes the update from that point. Otherwise it starts at the beginning.
* An additional clean up task is added at the end to delete the Airflow variable.

<img width="1473" alt="Screen Shot 2023-07-05 at 4 43 23 PM" src="https://github.com/WordPress/openverse/assets/63313398/7d21722d-da70-4597-b999-f912335ac1ce">

Now, if the `update_batches` task fails and retries (or is cleared manually), it will resume from the point it left off.

Notably, I also removed the `batch_start` DagRun conf option that I had previously, as it should no longer be necessary to manually choose the starting point. **If a DAG fails, you can manually find and edit this Airflow variable before retrying the DAG _if you want to_, but it should never be necessary.**

## Additional context

I chose this approach over deleting rows from the temp table as we go because it reduces the amount of error handling needed, but more importantly because I am concerned about adding an additional DELETE query to each batch when performance is already a major concern. Details about the cons to the dynamic task mapping alternative are available in the issue #2507.

I did _not_ remove the `resume_update` DagRun conf option in this PR, because this is still useful in the following scenario:
* User starts a DagRun which builds a very large temp table
* The DagRun builds the temp table successfully
* The `update_batches` task fails due to a syntax error in the user-provided `update_query`. Because this is a part of the DagRun conf, you cannot simply clear the task. You have to start a new DagRun with an updated conf, but you don't want to have to rebuild the temp table.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Setup:
Run `just init` to make sure you're starting out with our sample data in your local catalog db.

**Test a 'regular' flow**
Trigger the `batched_update` DAG with the following conf:
```
{
	"query_id": "my_query",
  	"table_name": "audio",
  	"select_query": "WHERE provider='wikimedia_audio'",
  	"update_query": "SET duration=0",
	"batch_size": 100,
	"dry_run": false
}
```
All tasks should pass (except for `notify_failure`, which is skipped).

* Run `just catalog/pgcli` to open a pgcli session
* Run `SELECT COUNT(*) FROM audio WHERE provider='wikimedia_audio' AND duration=0` to verify that you have 3992 such records after running the update

**Test clearing a DagRun**
For this we need to simulate a DAG failure. I did this by modifying the `update_batches` task to raise an Error on the 3rd batch, by adding the following code on L118[here](https://github.com/WordPress/openverse/pull/2570/files#diff-39e2cb653ee54d2523d84930ee904d9cd865f64ac4d85069aeb6da2040fe6203R118):

```
if batch_start == 300:
    raise Exception("Oops")
```

Now trigger a DagRun with this conf:

```
{
	"query_id": "my_query",
  	"table_name": "audio",
  	"select_query": "WHERE provider='wikimedia_audio'",
  	"update_query": "SET duration=100",
	"batch_size": 100,
	"dry_run": false
}
```

The `update_batches` task should fail and go `up_for_retry`. In pgcli, run `SELECT COUNT(*) FROM audio WHERE provider='wikimedia_audio' AND duration=100` and you should be able to see that 300 records were updated.

You should also be able to go to Admin > Variables in the UI and see an Airflow variable named `batch_start_my_query` which is set to 300.

Now remove the code you added to raise an Exception and clear the task. This time it should succeed. Verify in the logs that it resumed starting at row 300 and that it only updated 3692 records. (Search for the logs: `Starting at 300` and finally, `Updated 3692 rows. 0 remaining.`.)

Run the SELECT COUNT(*) command again in pgcli to verify that all records were updated.

Go to Admin > Variables and verify the Airflow variable is gone.

**Test a new DagRun using `resume_update`**

Trigger a new DagRun with this conf (note the typo in `update_query`):

```
{
	"query_id": "my_query",
  	"table_name": "audio",
  	"select_query": "WHERE provider='wikimedia_audio'",
  	"update_query": "SET durationn=500",
	"batch_size": 100,
	"dry_run": false
}
```

When the `update_batches` task fails and goes up for retry, manually mark the task as `failed` (to avoid having to wait for the retries). The whole DAG should fail. The temp table should not be dropped.

Now trigger a new DagRun with this updated conf, fixing the typo and enabling `resume_update`:

```
{
	"query_id": "my_query",
  	"table_name": "audio",
  	"select_query": "WHERE provider='wikimedia_audio'",
  	"update_query": "SET duration=500",
	"batch_size": 100,
	"dry_run": false,
        "resume_update": true
}
```

Verify that the `select_rows_to_update` and `create_index` tasks are skipped. `update_batches` should succeed, and the temp table and airflow variable should be dropped.

In pgcli, run `SELECT COUNT(*) FROM audio WHERE provider='wikimedia_audio' AND duration=500` to verify that all 3992 records were updated.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
