### PR TITLE
Add popularity refresh DAGs

### DIFF
--- a/catalog/DAGs.md
+++ b/catalog/DAGs.md
@@ -20,6 +20,7 @@ The following are DAGs grouped by their primary tag:
 1.  [Maintenance](#maintenance)
 1.  [Oauth](#oauth)
 1.  [Other](#other)
+1.  [Popularity Refresh](#popularity_refresh)
 1.  [Provider](#provider)
 1.  [Provider Reingestion](#provider-reingestion)
 
@@ -71,6 +72,13 @@ The following are DAGs grouped by their primary tag:
 | --------------------------------------------------------- | ----------------- |
 | [`flickr_thumbnails_removal`](#flickr_thumbnails_removal) | `None`            |
 
+## Popularity Refresh
+
+| DAG ID                                                  | Schedule Interval |
+| ------------------------------------------------------- | ----------------- |
+| [`audio_popularity_refresh`](#audio_popularity_refresh) | `None`            |
+| [`image_popularity_refresh`](#image_popularity_refresh) | `None`            |
+
 ## Provider
 
 | DAG ID                                                          | Schedule Interval | Dated   | Media Type(s) |
@@ -113,6 +121,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`add_license_url`](#add_license_url)
 1.  [`airflow_log_cleanup`](#airflow_log_cleanup)
 1.  [`audio_data_refresh`](#audio_data_refresh)
+1.  [`audio_popularity_refresh`](#audio_popularity_refresh)
 1.  [`batched_update`](#batched_update)
 1.  [`check_silenced_dags`](#check_silenced_dags)
 1.  [`create_filtered_audio_index`](#create_filtered_audio_index)
@@ -126,6 +135,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`flickr_workflow`](#flickr_workflow)
 1.  [`freesound_workflow`](#freesound_workflow)
 1.  [`image_data_refresh`](#image_data_refresh)
+1.  [`image_popularity_refresh`](#image_popularity_refresh)
 1.  [`inaturalist_workflow`](#inaturalist_workflow)
 1.  [`jamendo_workflow`](#jamendo_workflow)
 1.  [`metropolitan_museum_reingestion_workflow`](#metropolitan_museum_reingestion_workflow)
@@ -220,6 +230,29 @@ and related PRs:
 
 - [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
+
+## `audio_popularity_refresh`
+
+### Popularity Refresh DAG Factory
+
+This file generates our popularity refresh DAGs using a factory function.
+
+For the given media type these DAGs will first update the popularity metrics
+table, adding any new metrics and updating the percentile that is used in
+calculating the popularity constants. It then refreshes the popularity constants
+view, which recalculates the popularity constant for each provider.
+
+Once the constants have been updated, the DAG will trigger a `batched_update`
+DagRun for each provider of this media_type that is configured to support
+popularity data. The batched update recalculates standardized popularity scores
+for all records, using the new constant. When the updates are complete, all
+records have up-to-date popularity data. This DAG can be run concurrently with
+data refreshes and regular ingestion.
+
+You can find more background information on this process in the following
+implementation plan:
+
+- [[Implementation Plan] Decoupling Popularity Calculations from the Data Refresh](https://docs.openverse.org/projects/proposals/popularity_optimizations/20230420-implementation_plan_popularity_optimizations.html)
 
 ## `batched_update`
 
@@ -537,6 +570,29 @@ and related PRs:
 
 - [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
+
+## `image_popularity_refresh`
+
+### Popularity Refresh DAG Factory
+
+This file generates our popularity refresh DAGs using a factory function.
+
+For the given media type these DAGs will first update the popularity metrics
+table, adding any new metrics and updating the percentile that is used in
+calculating the popularity constants. It then refreshes the popularity constants
+view, which recalculates the popularity constant for each provider.
+
+Once the constants have been updated, the DAG will trigger a `batched_update`
+DagRun for each provider of this media_type that is configured to support
+popularity data. The batched update recalculates standardized popularity scores
+for all records, using the new constant. When the updates are complete, all
+records have up-to-date popularity data. This DAG can be run concurrently with
+data refreshes and regular ingestion.
+
+You can find more background information on this process in the following
+implementation plan:
+
+- [[Implementation Plan] Decoupling Popularity Calculations from the Data Refresh](https://docs.openverse.org/projects/proposals/popularity_optimizations/20230420-implementation_plan_popularity_optimizations.html)
 
 ## `inaturalist_workflow`
 

--- a/catalog/dags/common/constants.py
+++ b/catalog/dags/common/constants.py
@@ -37,3 +37,4 @@ POSTGRES_API_STAGING_CONN_ID = os.getenv(
 AWS_CONN_ID = os.getenv("AWS_CONN_ID", "aws_conn_id")
 AWS_RDS_CONN_ID = os.environ.get("AWS_RDS_CONN_ID", AWS_CONN_ID)
 ES_PROD_HTTP_CONN_ID = "elasticsearch_http_production"
+REFRESH_POKE_INTERVAL = int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 30))

--- a/catalog/dags/data_refresh/dag_factory.py
+++ b/catalog/dags/data_refresh/dag_factory.py
@@ -42,6 +42,13 @@ from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.settings import SASession
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
+from popularity.refresh_popularity_metrics_task_factory import (
+    GROUP_ID as REFRESH_POPULARITY_METRICS_GROUP_ID,
+)
+from popularity.refresh_popularity_metrics_task_factory import (
+    UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID,
+    create_refresh_popularity_metrics_task_group,
+)
 
 from common.constants import (
     DAG_DEFAULT_ARGS,
@@ -56,13 +63,6 @@ from data_refresh.recreate_view_data_task_factory import (
     GROUP_ID as RECREATE_MATVIEW_GROUP_ID,
 )
 from data_refresh.recreate_view_data_task_factory import create_recreate_view_data_task
-from data_refresh.refresh_popularity_metrics_task_factory import (
-    GROUP_ID as REFRESH_POPULARITY_METRICS_GROUP_ID,
-)
-from data_refresh.refresh_popularity_metrics_task_factory import (
-    UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID,
-    create_refresh_popularity_metrics_task_group,
-)
 from data_refresh.reporting import report_record_difference, report_status
 
 

--- a/catalog/dags/data_refresh/data_refresh_task_factory.py
+++ b/catalog/dags/data_refresh/data_refresh_task_factory.py
@@ -56,7 +56,7 @@ from airflow.utils.state import State
 from airflow.utils.task_group import TaskGroup
 
 from common import ingestion_server
-from common.constants import XCOM_PULL_TEMPLATE
+from common.constants import REFRESH_POKE_INTERVAL, XCOM_PULL_TEMPLATE
 from common.sensors.single_run_external_dags_sensor import SingleRunExternalDAGsSensor
 from common.sensors.utils import get_most_recent_dag_run
 from data_refresh.data_refresh_types import DataRefresh
@@ -98,7 +98,6 @@ def create_data_refresh_task_group(
                       will not run concurrently with any dependent DAG.
     """
 
-    poke_interval = int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 15))
     target_alias = data_refresh.media_type  # TODO: Change when using versioned aliases
 
     with TaskGroup(group_id="data_refresh") as data_refresh_group:
@@ -108,7 +107,7 @@ def create_data_refresh_task_group(
             task_id="wait_for_data_refresh",
             external_dag_ids=external_dag_ids,
             check_existence=True,
-            poke_interval=poke_interval,
+            poke_interval=REFRESH_POKE_INTERVAL,
             mode="reschedule",
             pool=DATA_REFRESH_POOL,
         )
@@ -131,7 +130,7 @@ def create_data_refresh_task_group(
             # Wait for the whole DAG, not just a part of it
             external_task_id=None,
             check_existence=False,
-            poke_interval=poke_interval,
+            poke_interval=REFRESH_POKE_INTERVAL,
             execution_date_fn=lambda _: get_most_recent_dag_run(
                 create_filtered_index_dag_id
             ),

--- a/catalog/dags/popularity/dag_factory.py
+++ b/catalog/dags/popularity/dag_factory.py
@@ -1,0 +1,179 @@
+"""
+# Popularity Refresh DAG Factory
+
+This file generates our popularity refresh DAGs using a factory function.
+
+For the given media type these DAGs will first update the popularity metrics table,
+adding any new metrics and updating the percentile that is used in calculating the
+popularity constants. It then refreshes the popularity constants view, which
+recalculates the popularity constant for each provider.
+
+Once the constants have been updated, the DAG will trigger a `batched_update`
+DagRun for each provider of this media_type that is configured to support popularity
+data. The batched update recalculates standardized popularity scores for all
+records, using the new constant. When the updates are complete, all records have
+up-to-date popularity data. This DAG can be run concurrently with data refreshes
+and regular ingestion.
+
+
+You can find more background information on this process in the following
+implementation plan:
+
+- [[Implementation Plan] Decoupling Popularity Calculations from the Data Refresh](
+https://docs.openverse.org/projects/proposals/popularity_optimizations/20230420-implementation_plan_popularity_optimizations.html)
+"""
+import datetime
+import logging
+import os
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from popularity.popularity_refresh_types import (
+    POPULARITY_REFRESH_CONFIGS,
+    PopularityRefresh,
+)
+from popularity.refresh_popularity_metrics_task_factory import (
+    create_refresh_popularity_metrics_task_group,
+)
+
+from common import slack
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
+from common.popularity import sql
+from database.batched_update.constants import DAG_ID as BATCHED_UPDATE_DAG_ID
+
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def notify_slack(text: str, media_type: str, dag_id: str) -> None:
+    slack.send_message(
+        text,
+        username=f"{media_type} Popularity Refresh",
+        icon_emoji=":database:",
+        dag_id=dag_id,
+    )
+
+
+@task
+def get_providers_update_confs(
+    postgres_conn_id: str, popularity_refresh: PopularityRefresh
+):
+    """
+    Build a list of DagRun confs for each provider of this media type. The confs will
+    be used by the `batched_update` DAG to perform a batched update of all existing
+    records, to recalculate their standardized_popularity with the new popularity
+    constant. Providers that do not support popularity data are omitted.
+    """
+    # For the media type, get a list of the providers who support popularity data
+    providers = sql.get_providers_with_popularity_data_for_media_type(
+        postgres_conn_id, popularity_refresh.media_type
+    )
+
+    # Once the new popularity constants are calculated, they will automatically be used
+    # to calculate popularity scores at ingestion. The popularity refresh need only
+    # update the scores for records which were last updated before this time.
+    last_updated_time = datetime.datetime.utcnow()
+
+    # For each provider, create a conf that will be used by the batched_update to
+    # refresh standardized popularity scores.
+    return [
+        {
+            # Uniquely identify the query
+            "query_id": (
+                f"{provider}_popularity_refresh_{last_updated_time.strftime('%Y%m%d')}"
+            ),
+            "table_name": popularity_refresh.media_type,
+            # Query used to select records that should be refreshed
+            "select_query": (
+                f"WHERE provider='{provider}' AND updated_on <"
+                f"'{last_updated_time.strftime('%Y-%m-%d %H:%M:%S')}'"
+            ),
+            # Query used to update the standardized_popularity
+            "update_query": sql.format_update_standardized_popularity_query(
+                popularity_refresh.media_type
+            ),
+            "batch_size": 10_000,
+            "update_timeout": popularity_refresh.refresh_popularity_batch_timeout,
+            "dry_run": False,
+            "resume_update": False,
+        }
+        for provider in providers
+    ]
+
+
+def create_popularity_refresh_dag(popularity_refresh: PopularityRefresh):
+    """
+    Instantiate a DAG for a popularity refresh.
+
+    For the given media type, this DAG will recalculate the popularity constants and
+    then refresh all existing standardized popularity scores with the new constant.
+
+    Required Arguments:
+
+    popularity_refresh: dataclass containing configuration information for the DAG
+    """
+    default_args = {
+        **DAG_DEFAULT_ARGS,
+        **popularity_refresh.default_args,
+    }
+
+    dag = DAG(
+        dag_id=popularity_refresh.dag_id,
+        default_args=default_args,
+        start_date=popularity_refresh.start_date,
+        schedule=popularity_refresh.schedule,
+        max_active_runs=1,
+        catchup=False,
+        doc_md=__doc__,
+        tags=["popularity_refresh"],
+    )
+
+    with dag:
+        poke_interval = int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 30))
+
+        # Refresh the underlying popularity tables. This step recalculates the
+        # popularity constants, which will later be used to calculate updated
+        # standardized popularity scores.
+        refresh_popularity_metrics = create_refresh_popularity_metrics_task_group(
+            popularity_refresh
+        )
+
+        # For each provider that supports popularity data for this media type, trigger a
+        # batched_update to recalculate all old standardized popularity scores using the
+        # newly refreshed constant.
+        refresh_popularity_scores = TriggerDagRunOperator.partial(
+            task_id="refresh_popularity",
+            trigger_dag_id=BATCHED_UPDATE_DAG_ID,
+            # Wait for all the dagruns to finish
+            wait_for_completion=True,
+            # Release the worker slot while waiting
+            deferrable=True,
+            poke_interval=poke_interval,
+            retries=0,
+        ).expand(
+            # Build the conf for each provider
+            conf=get_providers_update_confs(POSTGRES_CONN_ID, popularity_refresh)
+        )
+
+        notify_complete = notify_slack(
+            text=(
+                f"{popularity_refresh.media_type.capitalize()} Popularity Refresh"
+                " Complete"
+            ),
+            media_type=popularity_refresh.media_type,
+            dag_id=popularity_refresh.dag_id,
+        )
+
+        # Set up task dependencies
+        refresh_popularity_metrics >> refresh_popularity_scores >> notify_complete
+
+    return dag
+
+
+# Generate a popularity refresh DAG for each media type.
+for popularity_refresh in POPULARITY_REFRESH_CONFIGS:
+    globals()[popularity_refresh.dag_id] = create_popularity_refresh_dag(
+        popularity_refresh
+    )

--- a/catalog/dags/popularity/dag_factory.py
+++ b/catalog/dags/popularity/dag_factory.py
@@ -95,7 +95,9 @@ def get_providers_update_confs(
                 popularity_refresh.media_type
             ),
             "batch_size": 10_000,
-            "update_timeout": popularity_refresh.refresh_popularity_batch_timeout,
+            "update_timeout": (
+                popularity_refresh.refresh_popularity_batch_timeout.total_seconds()
+            ),
             "dry_run": False,
             "resume_update": False,
         }

--- a/catalog/dags/popularity/popularity_refresh_types.py
+++ b/catalog/dags/popularity/popularity_refresh_types.py
@@ -37,7 +37,7 @@ class PopularityRefresh:
     """
 
     dag_id: str = field(init=False)
-    media_type: str  # TODO
+    media_type: str
     start_date: datetime = datetime(2023, 1, 1)
     # The default schedule is initially set to None while we assess the performance
     # of refreshes. The schedule will be updated in

--- a/catalog/dags/popularity/popularity_refresh_types.py
+++ b/catalog/dags/popularity/popularity_refresh_types.py
@@ -33,18 +33,16 @@ class PopularityRefresh:
     refresh_metrics_timeout:           timedelta expressing amount of time the
                                        refresh popularity metrics and constants
                                        may take.
-    doc_md:                            str used for the DAG's documentation markdown
     """
 
     dag_id: str = field(init=False)
     media_type: str
+    default_args: dict | None = field(default_factory=dict)
     start_date: datetime = datetime(2023, 1, 1)
     # The default schedule is initially set to None while we assess the performance
     # of refreshes. The schedule will be updated in
     # https://github.com/WordPress/openverse/issues/2092
     schedule: str | None = None
-    default_args: dict | None = field(default_factory=dict)
-
     # Initial timeouts are generous; they should be updated after assessing the
     # performance in https://github.com/WordPress/openverse/issues/2092
     refresh_popularity_batch_timeout: timedelta = timedelta(hours=1)

--- a/catalog/dags/popularity/popularity_refresh_types.py
+++ b/catalog/dags/popularity/popularity_refresh_types.py
@@ -1,0 +1,63 @@
+"""
+# Popularity Refresh DAG Configuration
+This file defines the type for the `PopularityRefresh`, a dataclass containing
+configuration for a Popularity Refresh DAG, and defines the actual
+`POPULARITY_REFRESH_CONFIGS` for each of our media types. This configuration info
+is used to generate the dynamic Popularity Refresh dags.
+"""
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+
+@dataclass
+class PopularityRefresh:
+    """
+    Configuration object for a popularity refresh DAG.
+
+    Required Constructor Arguments:
+
+    media_type: str describing the media type to be refreshed.
+
+    Optional Constructor Arguments:
+
+    default_args:                      dictionary which is passed to the
+                                       airflow.dag.DAG __init__ method.
+    start_date:                        datetime.datetime giving the
+                                       first valid logical date of the DAG.
+    schedule:                          string giving the schedule on which the DAG
+                                       should be run.  Passed to the
+                                       airflow.dag.DAG __init__ method.
+    refresh_popularity_batch_timeout:  timedelta expressing the amount of time
+                                       refreshing popularity scores for an individual
+                                       batch of records may take.
+    refresh_metrics_timeout:           timedelta expressing amount of time the
+                                       refresh popularity metrics and constants
+                                       may take.
+    doc_md:                            str used for the DAG's documentation markdown
+    """
+
+    dag_id: str = field(init=False)
+    media_type: str  # TODO
+    start_date: datetime = datetime(2023, 1, 1)
+    # The default schedule is initially set to None while we assess the performance
+    # of refreshes. The schedule will be updated in
+    # https://github.com/WordPress/openverse/issues/2092
+    schedule: str | None = None
+    default_args: dict | None = field(default_factory=dict)
+
+    # Initial timeouts are generous; they should be updated after assessing the
+    # performance in https://github.com/WordPress/openverse/issues/2092
+    refresh_popularity_batch_timeout: timedelta = timedelta(hours=1)
+    refresh_metrics_timeout: timedelta = timedelta(hours=1)
+
+    def __post_init__(self):
+        self.dag_id = f"{self.media_type}_popularity_refresh"
+
+
+POPULARITY_REFRESH_CONFIGS = [
+    PopularityRefresh(
+        media_type="image",
+        refresh_metrics_timeout=timedelta(hours=24),
+    ),
+    PopularityRefresh(media_type="audio"),
+]

--- a/catalog/tests/dags/common/popularity/test_dag_factory.py
+++ b/catalog/tests/dags/common/popularity/test_dag_factory.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import pytest
+from airflow.models import DagRun
+from airflow.models.dag import DAG
+from airflow.utils.session import create_session
+from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
+from popularity.dag_factory import get_providers_update_confs
+from popularity.popularity_refresh_types import PopularityRefresh
+
+from catalog.tests.test_utils.sql import POSTGRES_CONN_ID
+
+
+TEST_DAG_ID = "popularity_refresh_dag_factory_test_dag"
+TEST_DAG = DAG(TEST_DAG_ID, default_args={"owner": "airflow"})
+TEST_DAY = datetime(2023, 1, 1)
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    with create_session() as session:
+        session.query(DagRun).filter(DagRun.dag_id == TEST_DAG_ID).delete()
+
+
+def _create_dagrun(start_date, dag_state, conf={}):
+    return TEST_DAG.create_dagrun(
+        start_date=start_date,
+        execution_date=start_date,
+        data_interval=(start_date, start_date),
+        state=dag_state,
+        run_type=DagRunType.MANUAL,
+        conf=conf,
+    )
+
+
+@pytest.mark.parametrize(
+    "providers, media_type, expected_confs",
+    [
+        # No providers for this media type
+        ([], "image", []),
+        (
+            ["foo_provider"],
+            "image",
+            [
+                {
+                    "query_id": "foo_provider_popularity_refresh_20230101",
+                    "table_name": "image",
+                    "select_query": "WHERE provider='foo_provider' AND updated_on < '2023-01-01 00:00:00'",
+                    "update_query": "SET standardized_popularity = standardized_image_popularity(image.provider, image.meta_data)",
+                    "batch_size": 10000,
+                    "update_timeout": 3600.0,
+                    "dry_run": False,
+                    "resume_update": False,
+                },
+            ],
+        ),
+        (
+            ["my_provider", "your_provider"],
+            "audio",
+            [
+                {
+                    "query_id": "my_provider_popularity_refresh_20230101",
+                    "table_name": "audio",
+                    "select_query": "WHERE provider='my_provider' AND updated_on < '2023-01-01 00:00:00'",
+                    "update_query": "SET standardized_popularity = standardized_audio_popularity(audio.provider, audio.meta_data)",
+                    "batch_size": 10000,
+                    "update_timeout": 3600.0,
+                    "dry_run": False,
+                    "resume_update": False,
+                },
+                {
+                    "query_id": "your_provider_popularity_refresh_20230101",
+                    "table_name": "audio",
+                    "select_query": "WHERE provider='your_provider' AND updated_on < '2023-01-01 00:00:00'",
+                    "update_query": "SET standardized_popularity = standardized_audio_popularity(audio.provider, audio.meta_data)",
+                    "batch_size": 10000,
+                    "update_timeout": 3600.0,
+                    "dry_run": False,
+                    "resume_update": False,
+                },
+            ],
+        ),
+    ],
+)
+def test_get_providers_update_confs(providers, media_type, expected_confs):
+    with mock.patch(
+        "common.popularity.sql.get_providers_with_popularity_data_for_media_type",
+        return_value=providers,
+    ):
+        actual_confs = get_providers_update_confs.function(
+            POSTGRES_CONN_ID, PopularityRefresh(media_type=media_type), TEST_DAY
+        )
+
+        assert actual_confs == expected_confs

--- a/catalog/tests/dags/common/popularity/test_sql.py
+++ b/catalog/tests/dags/common/popularity/test_sql.py
@@ -382,6 +382,47 @@ def test_constants_view_handles_zeros_and_missing(
         assert expect_row == pytest.approx(sorted_row)
 
 
+def test_get_providers_with_popularity_data_for_media_type(
+    postgres_with_image_table, table_info, mock_pg_hook_task
+):
+    data_query = dedent(
+        f"""
+        INSERT INTO {table_info.image} (
+          created_on, updated_on, provider, foreign_identifier, url,
+          meta_data, license, removed_from_source
+        )
+        VALUES
+          (
+            NOW(), NOW(), 'my_provider', 'fid_a', 'https://test.com/a.jpg',
+            '{{"views": 0, "description": "cats"}}', 'cc0', false
+          ),
+          (
+            NOW(), NOW(), 'diff_provider', 'fid_b', 'https://test.com/b.jpg',
+            '{{"views": 50, "description": "cats"}}', 'cc0', false
+          ),
+          (
+            NOW(), NOW(), 'provider_without_popularity', 'fid_b', 'https://test.com/b.jpg',
+            '{{"views": 50, "description": "cats"}}', 'cc0', false
+          )
+        ;
+        """
+    )
+    metrics = {
+        "my_provider": {"metric": "views", "percentile": 0.8},
+        "diff_provider": {"metric": "comments", "percentile": 0.8},
+    }
+    _set_up_popularity_constants(
+        postgres_with_image_table, data_query, metrics, table_info, mock_pg_hook_task
+    )
+
+    expected_providers = ["diff_provider", "my_provider"]
+    actual_providers = sql.get_providers_with_popularity_data_for_media_type(
+        POSTGRES_CONN_ID, media_type="image", constants_view=table_info.constants
+    )
+
+    assert actual_providers == expected_providers
+
+
 def test_standardized_popularity_function_calculates(
     postgres_with_image_table, table_info, mock_pg_hook_task
 ):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,16 @@ services:
       _AIRFLOW_WWW_USER_LASTNAME: Flow
       _AIRFLOW_WWW_USER_EMAIL: airflow@example.com
 
+  # Dev changes for the triggerer
+  triggerer:
+    <<: *airflow-common
+    depends_on:
+      - upstream_db
+      - s3
+    expose:
+      - "8794" # Used for logs
+    command: triggerer
+
   # Dev changes for the webserver container
   webserver:
     <<: *airflow-common
@@ -127,6 +137,7 @@ services:
       - upstream_db
       - s3
       - scheduler
+      - triggerer
     command: webserver
     ports:
       - "${AIRFLOW_PORT}:8080"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2089 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a popularity refresh DAG factory that generates `audio_popularity_refresh` and `image_popularity_refresh` DAGs. Each DAG:
* refreshes popularity metrics and constants (recalculating the popularity constants)
* then, triggers a `batched_update` DagRun for each of the providers of this media type that support popularity data
* waits for the batched updates to complete and notifies Slack

<img width="1558" alt="Screen Shot 2023-07-19 at 5 13 21 PM" src="https://github.com/WordPress/openverse/assets/63313398/baa3eee4-9888-4852-9bd7-510963922b62">


* It is currently on a `None` schedule, so must be triggered manually, and has very generous timeouts. These will be revisited in follow-up PRs after testing is done in production.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The `TriggerDagRunOperator` we're using to trigger the `batched_update`s is put in `deferrable` mode, in order to free the worker slot while waiting for the batched updates to complete. This requires a Triggerer to be running. ~Locally, I did this by running `just catalog/shell` and then `airflow triggerer` to start the Triggerer.~ Run `just down -v && just up` to start the triggerer.

You'll also want to make sure you have `DATA_REFRESH_POKE_INTERVAL=5` in your `catalog/.env` so that you don't have to wait 30 minutes for the TriggerDagRunOperator to re-run.

Then run `just init` to get sample data in your local environment. The sample data all have null popularity scores, which you can verify by running `just catalog/pgcli` to open a pgcli session and then running:

```
SELECT COUNT(*) FROM image WHERE standardized_popularity is null;

SELECT COUNT(*) FROM audio WHERE standardized_popularity is null;
```

In both cases the result should be `5000`.

Now, simply run the `audio_popularity_refresh` and `image_popularity_refresh` DAGs locally. Both should pass with no task failures. You should go to `http://localhost:9090/dags/batched_update/grid` and verify that you see a separate DagRun for each provider that supports popularity data. You can inspect the logs for the `notify_updated_count` for each, and should see:
* INFO - Updated 3992 records for update: wikimedia_audio_popularity_refresh_20230707
* INFO - Updated 828 records for update: freesound_popularity_refresh_20230707
* INFO - Updated 180 records for update: jamendo_popularity_refresh_20230707
* INFO - Updated 0 records for update: nappy_popularity_refresh_20230707
* INFO - Updated 0 records for update: rawpixel_popularity_refresh_20230707
* INFO - Updated 0 records for update: wikimedia_popularity_refresh_20230707
* INFO - Updated 2500 records for update: flickr_popularity_refresh_20230707
* INFO - Updated 2500 records for update: stocksnap_popularity_refresh_20230707

Where 0 records were updated, this is because there are no records for that provider in our sample data. Your `query_id`s will differ in the date suffix.

____

Because this PR also moves some popularity task factories around, also run both data refreshes to ensure they pass.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
