### PR TITLE
Blur sensitive search results

### DIFF
--- a/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
+++ b/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- Should be wrapped by a fixed-width parent -->
-  <div class="relative h-0 w-full bg-yellow pt-full" :title="helpText">
+  <div
+    class="relative h-0 w-full overflow-hidden bg-yellow pt-full"
+    :title="helpText"
+  >
     <!-- Programmatic thumbnail -->
-    <svg class="absolute inset-0" :viewBox="`0 0 ${canvasSize} ${canvasSize}`">
+    <svg
+      class="absolute inset-0"
+      :class="{ hidden: shouldBlur && isOk }"
+      :viewBox="`0 0 ${canvasSize} ${canvasSize}`"
+    >
       <template v-for="i in dotCount">
         <circle
           v-for="j in dotCount"
@@ -19,6 +26,7 @@
       <img
         ref="imgEl"
         class="h-full w-full overflow-clip object-cover object-center"
+        :class="{ 'scale-150 blur': shouldBlur }"
         :src="audio.thumbnail"
         :alt="helpText"
         @load="handleLoad"
@@ -28,12 +36,13 @@
 </template>
 
 <script lang="ts">
-import { ref, onMounted, defineComponent, PropType } from "vue"
+import { ref, onMounted, computed, defineComponent, PropType } from "vue"
 
 import { rand, hash } from "~/utils/prng"
 import { lerp, dist, bezier, Point } from "~/utils/math"
 import type { AudioDetail } from "~/types/media"
 import { useI18n } from "~/composables/use-i18n"
+import { useUiStore } from "~/stores/ui"
 
 /**
  * Displays the cover art for the audio in a square aspect ratio.
@@ -96,6 +105,11 @@ export default defineComponent({
       return lerp(maxRadius, minRadius, distance / maxFeasibleDistance)
     }
 
+    const uiStore = useUiStore()
+    const shouldBlur = computed(
+      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
+    )
+
     return {
       imgEl,
       isOk,
@@ -106,6 +120,8 @@ export default defineComponent({
       offset,
       radius,
       helpText,
+
+      shouldBlur,
     }
   },
 })

--- a/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
+++ b/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
@@ -26,7 +26,7 @@
       <img
         ref="imgEl"
         class="h-full w-full overflow-clip object-cover object-center"
-        :class="{ 'scale-150 blur': shouldBlur }"
+        :class="{ 'scale-150 blur-image': shouldBlur }"
         :src="audio.thumbnail"
         :alt="helpText"
         @load="handleLoad"

--- a/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
+++ b/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
@@ -60,13 +60,20 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const uiStore = useUiStore()
+    const shouldBlur = computed(
+      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
+    )
+
     const i18n = useI18n()
-    const helpText = i18n
-      .t("audioThumbnail.alt", {
-        title: props.audio.title,
-        creator: props.audio.creator,
-      })
-      ?.toString()
+    const helpText = (
+      shouldBlur.value
+        ? i18n.t("sensitiveContent.title.audio")
+        : i18n.t("audioThumbnail.alt", {
+            title: props.audio.title,
+            creator: props.audio.creator,
+          })
+    )?.toString()
 
     /* Switching */
 
@@ -104,11 +111,6 @@ export default defineComponent({
       const maxFeasibleDistance = canvasSize * ((dotCount - 1) / (dotCount + 1))
       return lerp(maxRadius, minRadius, distance / maxFeasibleDistance)
     }
-
-    const uiStore = useUiStore()
-    const shouldBlur = computed(
-      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
-    )
 
     return {
       imgEl,

--- a/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -8,7 +8,7 @@
         <div class="info flex flex-grow flex-col justify-between p-4">
           <h2
             class="font-heading line-clamp-3 text-base font-semibold leading-snug"
-            :class="{ 'blur-sm': shouldBlur }"
+            :class="{ 'blur-text': shouldBlur }"
           >
             {{ shouldBlur ? $t("sensitiveContent.title.audio") : audio.title }}
           </h2>

--- a/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -8,6 +8,7 @@
         <div class="info flex flex-grow flex-col justify-between p-4">
           <h2
             class="font-heading line-clamp-3 text-base font-semibold leading-snug"
+            :class="{ 'blur-sm': shouldBlur }"
           >
             {{ audio.title }}
           </h2>
@@ -43,6 +44,7 @@ import { computed, defineComponent, PropType } from "vue"
 import type { AudioDetail } from "~/types/media"
 import type { AudioSize } from "~/constants/audio"
 import { useI18n } from "~/composables/use-i18n"
+import { useUiStore } from "~/stores/ui"
 
 import VLicense from "~/components/VLicense/VLicense.vue"
 
@@ -78,8 +80,14 @@ export default defineComponent({
       i18n.t(`filters.audioCategories.${props.audio.category}`).toString()
     )
 
+    const uiStore = useUiStore()
+    const shouldBlur = computed(
+      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
+    )
+
     return {
       isSmall,
+      shouldBlur,
 
       width,
       categoryLabel,

--- a/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -10,7 +10,7 @@
             class="font-heading line-clamp-3 text-base font-semibold leading-snug"
             :class="{ 'blur-sm': shouldBlur }"
           >
-            {{ audio.title }}
+            {{ shouldBlur ? $t("sensitiveContent.title.audio") : audio.title }}
           </h2>
           <div class="info">
             <VLicense

--- a/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -27,6 +27,7 @@
           :class="{
             'text-2xl': isMedium || isLarge,
             'leading-snug': isSmall,
+            'blur-sm': shouldBlur,
           }"
         >
           {{ audio.title }}
@@ -42,7 +43,11 @@
           }"
         >
           <div class="part-a">
-            <i18n tag="span" path="audioTrack.creator">
+            <i18n
+              tag="span"
+              path="audioTrack.creator"
+              :class="{ 'blur-sm': shouldBlur }"
+            >
               <template #creator>{{ audio.creator }}</template> </i18n
             ><span v-show="isLarge" class="mx-2" aria-hidden="true">{{
               $t("interpunct")
@@ -101,6 +106,7 @@ import { computed, defineComponent, PropType } from "vue"
 import { timeFmt } from "~/utils/time-fmt"
 import type { AudioDetail } from "~/types/media"
 import type { AudioSize } from "~/constants/audio"
+import { useUiStore } from "~/stores/ui"
 
 import VAudioThumbnail from "~/components/VAudioThumbnail/VAudioThumbnail.vue"
 import VLicense from "~/components/VLicense/VLicense.vue"
@@ -133,6 +139,11 @@ export default defineComponent({
     const isMedium = computed(() => props.size === "m")
     const isLarge = computed(() => props.size === "l")
 
+    const uiStore = useUiStore()
+    const shouldBlur = computed(
+      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
+    )
+
     return {
       timeFmt,
 
@@ -142,6 +153,8 @@ export default defineComponent({
       isSmall,
       isMedium,
       isLarge,
+
+      shouldBlur,
     }
   },
 })

--- a/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -30,7 +30,7 @@
             'blur-sm': shouldBlur,
           }"
         >
-          {{ audio.title }}
+          {{ shouldBlur ? $t("sensitiveContent.title.audio") : audio.title }}
         </div>
 
         <div
@@ -48,7 +48,9 @@
               path="audioTrack.creator"
               :class="{ 'blur-sm': shouldBlur }"
             >
-              <template #creator>{{ audio.creator }}</template> </i18n
+              <template #creator>{{
+                shouldBlur ? $t("sensitiveContent.creator") : audio.creator
+              }}</template> </i18n
             ><span v-show="isLarge" class="mx-2" aria-hidden="true">{{
               $t("interpunct")
             }}</span>

--- a/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -27,7 +27,7 @@
           :class="{
             'text-2xl': isMedium || isLarge,
             'leading-snug': isSmall,
-            'blur-sm': shouldBlur,
+            'blur-text': shouldBlur,
           }"
         >
           {{ shouldBlur ? $t("sensitiveContent.title.audio") : audio.title }}
@@ -46,7 +46,7 @@
             <i18n
               tag="span"
               path="audioTrack.creator"
-              :class="{ 'blur-sm': shouldBlur }"
+              :class="{ 'blur-text': shouldBlur }"
             >
               <template #creator>{{
                 shouldBlur ? $t("sensitiveContent.creator") : audio.creator

--- a/frontend/src/components/VSearchResultsGrid/VImageCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCell.vue
@@ -24,7 +24,11 @@
             isSquare ? 'h-full' : 'margin-auto',
             { 'scale-105 blur': shouldBlur },
           ]"
-          :alt="image.title"
+          :alt="
+            shouldBlur
+              ? $t('sensitiveContent.title.image').toString()
+              : image.title
+          "
           :src="imageUrl"
           :width="imgWidth"
           :height="imgHeight"
@@ -35,7 +39,13 @@
         <figcaption
           class="invisible absolute bottom-0 left-0 bg-white p-1 text-dark-charcoal group-hover:visible group-focus:visible"
         >
-          <h2 class="sr-only">{{ image.title }}</h2>
+          <h2 class="sr-only">
+            {{
+              shouldBlur
+                ? $t("sensitiveContent.title.image").toString()
+                : image.title
+            }}
+          </h2>
           <VLicense :license="image.license" :hide-name="true" />
         </figcaption>
       </figure>
@@ -146,9 +156,11 @@ export default defineComponent({
     }
 
     const contextSensitiveTitle = computed(() => {
-      return i18n.t("browsePage.aria.imageTitle", {
-        title: props.image.title,
-      })
+      return shouldBlur.value
+        ? i18n.t("sensitiveContent.title.image")
+        : i18n.t("browsePage.aria.imageTitle", {
+            title: props.image.title,
+          })
     })
 
     const { sendCustomEvent } = useAnalytics()

--- a/frontend/src/components/VSearchResultsGrid/VImageCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCell.vue
@@ -22,7 +22,7 @@
           class="block w-full rounded-sm object-cover"
           :class="[
             isSquare ? 'h-full' : 'margin-auto',
-            { 'scale-105 blur': shouldBlur },
+            { 'scale-150 blur-image': shouldBlur },
           ]"
           :alt="
             shouldBlur

--- a/frontend/src/components/VSearchResultsGrid/VImageCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCell.vue
@@ -20,7 +20,10 @@
           ref="img"
           loading="lazy"
           class="block w-full rounded-sm object-cover"
-          :class="isSquare ? 'h-full' : 'margin-auto'"
+          :class="[
+            isSquare ? 'h-full' : 'margin-auto',
+            { 'scale-105 blur': shouldBlur },
+          ]"
           :alt="image.title"
           :src="imageUrl"
           :width="imgWidth"
@@ -47,8 +50,8 @@ import { computed, defineComponent, PropType } from "vue"
 import type { AspectRatio, ImageDetail } from "~/types/media"
 import { useImageCellSize } from "~/composables/use-image-cell-size"
 import { useI18n } from "~/composables/use-i18n"
-
 import { useAnalytics } from "~/composables/use-analytics"
+import { useUiStore } from "~/stores/ui"
 
 import { IMAGE } from "~/constants/media"
 
@@ -159,6 +162,11 @@ export default defineComponent({
       })
     }
 
+    const uiStore = useUiStore()
+    const shouldBlur = computed(
+      () => uiStore.shouldBlurSensitive && props.image.isSensitive
+    )
+
     return {
       styles,
       imgWidth,
@@ -166,6 +174,7 @@ export default defineComponent({
       imageUrl,
       imageLink,
       contextSensitiveTitle,
+      shouldBlur,
 
       getImageForeignUrl,
       onImageLoadError,

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -743,4 +743,9 @@
   report: {
     imageDetails: "See image details",
   },
+  sensitiveContent: {
+    title: {
+      image: "This image may contain sensitive content.",
+    },
+  },
 }

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -746,6 +746,8 @@
   sensitiveContent: {
     title: {
       image: "This image may contain sensitive content.",
+      audio: "This audio track may contain sensitive content.",
     },
+    creator: "Creator",
   },
 }

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -42,6 +42,10 @@ export interface UiState {
    */
   isMobileUa: boolean
   dismissedBanners: BannerId[]
+  /**
+   * whether to blur sensitive content in search and single result pages
+   */
+  shouldBlurSensitive: boolean
 }
 
 export const breakpoints = Object.keys(ALL_SCREEN_SIZES)
@@ -55,6 +59,7 @@ export const useUiStore = defineStore("ui", {
     breakpoint: "sm",
     isMobileUa: true,
     dismissedBanners: [],
+    shouldBlurSensitive: true,
   }),
 
   getters: {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -197,6 +197,10 @@ module.exports = {
       serif: [...defaultTheme.fontFamily.serif],
     },
     extend: {
+      blur: {
+        image: "60px",
+        text: "4px",
+      },
       lineHeight: {
         loose: "2.0",
         larger: "1.9",

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -107,7 +107,7 @@ describe("AudioTrack", () => {
     options.propsData.layout = "box"
     const { getByText } = render(VAudioTrack, options, configureVue)
     const h2 = getByText("This audio track may contain sensitive content.")
-    expect(h2).toHaveClass("blur-sm")
+    expect(h2).toHaveClass("blur-text")
   })
 
   it("has blurred info in row layout when audio is sensitive", async () => {
@@ -116,10 +116,10 @@ describe("AudioTrack", () => {
     const { getByText } = render(VAudioTrack, options, configureVue)
 
     const h2 = getByText("This audio track may contain sensitive content.")
-    expect(h2).toHaveClass("blur-sm")
+    expect(h2).toHaveClass("blur-text")
 
     const creator = getByText("by Creator")
-    expect(creator).toHaveClass("blur-sm")
+    expect(creator).toHaveClass("blur-text")
   })
 
   it("is does not contain title or creator anywhere when the audio is sensitive", async () => {

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -101,4 +101,35 @@ describe("AudioTrack", () => {
     expect(getByText(/Reproduction not allowed./i)).toBeVisible()
     // It's not possible to get the vm to test that Sentry has been called
   })
+
+  it("has blurred title in box layout when audio is sensitive", async () => {
+    options.propsData.audio.isSensitive = true
+    options.propsData.layout = "box"
+    const { getByText } = render(VAudioTrack, options, configureVue)
+    const h2 = getByText("This audio track may contain sensitive content.")
+    expect(h2).toHaveClass("blur-sm")
+  })
+
+  it("has blurred info in row layout when audio is sensitive", async () => {
+    options.propsData.audio.isSensitive = true
+    options.propsData.layout = "row"
+    const { getByText } = render(VAudioTrack, options, configureVue)
+
+    const h2 = getByText("This audio track may contain sensitive content.")
+    expect(h2).toHaveClass("blur-sm")
+
+    const creator = getByText("by Creator")
+    expect(creator).toHaveClass("blur-sm")
+  })
+
+  it("is does not contain title or creator anywhere when the audio is sensitive", async () => {
+    options.propsData.audio.isSensitive = true
+    options.propsData.layout = "row"
+    const screen = render(VAudioTrack, options, configureVue)
+    let { title, creator } = options.propsData.audio
+    let match = RegExp(`(${title}|${creator})`)
+    expect(screen.queryAllByText(match)).toEqual([])
+    expect(screen.queryAllByTitle(match)).toEqual([])
+    expect(screen.queryAllByAltText(match)).toEqual([])
+  })
 })

--- a/frontend/test/unit/specs/components/VSearchResultsGrid/v-image-cell.spec.js
+++ b/frontend/test/unit/specs/components/VSearchResultsGrid/v-image-cell.spec.js
@@ -50,7 +50,7 @@ describe("VImageCell", () => {
     options.props.image.isSensitive = true
     const { getByAltText } = render(VImageCell, options)
     const img = getByAltText("This image may contain sensitive content.")
-    expect(img).toHaveClass("blur")
+    expect(img).toHaveClass("blur-image")
   })
 
   it("is does not contain title anywhere when the image is sensitive", async () => {

--- a/frontend/test/unit/specs/components/VSearchResultsGrid/v-image-cell.spec.js
+++ b/frontend/test/unit/specs/components/VSearchResultsGrid/v-image-cell.spec.js
@@ -45,4 +45,20 @@ describe("VImageCell", () => {
       relatedTo: null,
     })
   })
+
+  it("is blurred when the image is sensitive", async () => {
+    options.props.image.isSensitive = true
+    const { getByAltText } = render(VImageCell, options)
+    const img = getByAltText("This image may contain sensitive content.")
+    expect(img).toHaveClass("blur")
+  })
+
+  it("is does not contain title anywhere when the image is sensitive", async () => {
+    options.props.image.isSensitive = true
+    const screen = render(VImageCell, options)
+    let match = RegExp(image.title)
+    expect(screen.queryAllByText(match)).toEqual([])
+    expect(screen.queryAllByTitle(match)).toEqual([])
+    expect(screen.queryAllByAltText(match)).toEqual([])
+  })
 })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2369 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds logic to the image and audio result components to blur their content if their media item has been flagged as sensitive. It also replaces title and creator strings from the DOM with placeholders to prevent any sensitive information from leaking through assistive technology that bypasses CSS and interacts with the DOM. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR and run the dev server.
1. Enable the `fake_sensitive` toggle in the `/preferences` page.
2. Search for something like 'cat'.
3. Observe blurring of fake-sensitive results in all three views:
   - mixed media
   - only images
   - only audio

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
