### PR TITLE
Check readiness against filtered index

### DIFF
--- a/catalog/dags/data_refresh/create_filtered_index_dag.py
+++ b/catalog/dags/data_refresh/create_filtered_index_dag.py
@@ -213,7 +213,7 @@ def filtered_index_creation_dag_factory(data_refresh: DataRefresh):
         # Await healthy results from the newly created elasticsearch index.
         index_readiness_check = ingestion_server.index_readiness_check(
             media_type=media_type,
-            index_suffix=destination_index_suffix,
+            index_suffix=f"{destination_index_suffix}-filtered",
         )
 
         do_point_alias = point_alias(destination_index_suffix=destination_index_suffix)


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes an issue wherein the filtered index creation DAG was checking for the readiness of the unfiltered index rather than the produced, filtered index. In most normal runs this would never raise an issue, because the indices are usually uniform (e.g. `image-12345` and `image-12345-filtered`, so checking against `image-12345` passes). When the create filtered index DAG is run manually, it generates a different suffix for the filtered index, one which doesn't have a matching unfiltered index (e.g. `image-98765-filtered`, which was made from `image-12345`, is trying to check for `image-98765` which does not exist).

This is rectified by running the check against the produced filtered index (suffix + `-filtered`) rather than the index just referenced with the suffix.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Checkout `main`
1. Enable the `image_data_refresh` and `create_filtered_image_index` DAGs locally
1. Observe both DAGs complete successfully
1. Trigger a manual run of the latter DAG (without params)
1. Observe that it gets stuck on the `index_readiness` task with the log messages `[2023-07-13, 18:24:52 UTC] {http.py:182} ERROR - {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [image-ebea3ea3c04e4d369c8f5f6c614e893d]","resource.type":"index_or_alias","resource.id":"image-ebea3ea3c04e4d369c8f5f6c614e893d","index_uuid":"_na_","index":"image-ebea3ea3c04e4d369c8f5f6c614e893d"}],"type":"index_not_found_exception","reason":"no such index [image-ebea3ea3c04e4d369c8f5f6c614e893d]","resource.type":"index_or_alias","resource.id":"image-ebea3ea3c04e4d369c8f5f6c614e893d","index_uuid":"_na_","index":"image-ebea3ea3c04e4d369c8f5f6c614e893d"},"status":404}` (with the equivalent suffix that was produced during the run)
1. Mark that task as succeeded so the DAG can complete
1. Checkout this branch
1. Trigger another manual run (no params) of the `create_filtered_image_index` DAG
1. Observe that this one completes successfully without intervention


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
