### PR TITLE
Update back to results button area

### DIFF
--- a/frontend/src/pages/audio/_id/index.vue
+++ b/frontend/src/pages/audio/_id/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main :id="skipToContentTargetId" tabindex="-1">
-    <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
+    <div v-if="backToSearchPath" class="w-full px-4 pb-4 md:px-8">
       <VBackToSearchResultsLink
         :id="$route.params.id"
         :href="backToSearchPath"

--- a/frontend/src/pages/image/_id/index.vue
+++ b/frontend/src/pages/image/_id/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main :id="skipToContentTargetId" tabindex="-1">
-    <div v-if="backToSearchPath" class="w-full px-2 py-2 md:px-6">
+    <div v-if="backToSearchPath" class="w-full px-4 pb-4 md:px-8">
       <VBackToSearchResultsLink
         :id="$route.params.id"
         :href="backToSearchPath"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes [#2657](https://github.com/WordPress/openverse/issues/2657) by @fcoveram 

## Description
<!-- Concisely describe what the pull request does. -->
#### this PR:
- updates padding around "Back to results" button area, per [figma designs](https://www.figma.com/file/niWnCgB7K0Y4e4mgxMrnRC/Additional-search-views?type=design&node-id=1263%3A62834&mode=design&t=jTbJqJAStXoIpH4F-1)

<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Image page
![image](https://github.com/WordPress/openverse/assets/44593294/2a71240e-3183-46f3-8df4-c53fa36ccee4)
![image](https://github.com/WordPress/openverse/assets/44593294/ae1ead21-8910-473a-912e-429110d7133f)


Audio page
![image](https://github.com/WordPress/openverse/assets/44593294/e794d6da-c305-4b98-baea-bcb862f1c2ab)
![image](https://github.com/WordPress/openverse/assets/44593294/2b80c2f1-fd0c-4b62-ac22-41c17cafca32)



#### ⚠️ this PR does not: ⚠️
- update the styling of the buttons as mentioned in the original issue description. the buttons in prod already match the expected changes. please see [this comment](https://github.com/WordPress/openverse/issues/2657#issuecomment-1644346446) for more information


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
- navigate to an image or audio page from the search results. verify that the padding updates reflects the Figma design in viewport below and above the medium breakpoint (768px)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
