### PR TITLE
useSensitiveMedia composable

### DIFF
--- a/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
+++ b/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
@@ -36,13 +36,13 @@
 </template>
 
 <script lang="ts">
-import { ref, onMounted, computed, defineComponent, PropType } from "vue"
+import { ref, onMounted, defineComponent, PropType } from "vue"
 
 import { rand, hash } from "~/utils/prng"
 import { lerp, dist, bezier, Point } from "~/utils/math"
 import type { AudioDetail } from "~/types/media"
 import { useI18n } from "~/composables/use-i18n"
-import { useUiStore } from "~/stores/ui"
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 /**
  * Displays the cover art for the audio in a square aspect ratio.
@@ -60,10 +60,7 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const uiStore = useUiStore()
-    const shouldBlur = computed(
-      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
-    )
+    const { isHidden: shouldBlur } = useSensitiveMedia(props.audio)
 
     const i18n = useI18n()
     const helpText = (

--- a/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -44,7 +44,8 @@ import { computed, defineComponent, PropType } from "vue"
 import type { AudioDetail } from "~/types/media"
 import type { AudioSize } from "~/constants/audio"
 import { useI18n } from "~/composables/use-i18n"
-import { useUiStore } from "~/stores/ui"
+
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 import VLicense from "~/components/VLicense/VLicense.vue"
 
@@ -80,11 +81,7 @@ export default defineComponent({
       i18n.t(`filters.audioCategories.${props.audio.category}`).toString()
     )
 
-    const uiStore = useUiStore()
-    const shouldBlur = computed(
-      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
-    )
-
+    const { isHidden: shouldBlur } = useSensitiveMedia(props.audio)
     return {
       isSmall,
       shouldBlur,

--- a/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -108,7 +108,8 @@ import { computed, defineComponent, PropType } from "vue"
 import { timeFmt } from "~/utils/time-fmt"
 import type { AudioDetail } from "~/types/media"
 import type { AudioSize } from "~/constants/audio"
-import { useUiStore } from "~/stores/ui"
+
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 import VAudioThumbnail from "~/components/VAudioThumbnail/VAudioThumbnail.vue"
 import VLicense from "~/components/VLicense/VLicense.vue"
@@ -141,10 +142,7 @@ export default defineComponent({
     const isMedium = computed(() => props.size === "m")
     const isLarge = computed(() => props.size === "l")
 
-    const uiStore = useUiStore()
-    const shouldBlur = computed(
-      () => uiStore.shouldBlurSensitive && props.audio.isSensitive
-    )
+    const { isHidden: shouldBlur } = useSensitiveMedia(props.audio)
 
     return {
       timeFmt,

--- a/frontend/src/components/VSafeBrowsing/VSafeBrowsing.vue
+++ b/frontend/src/components/VSafeBrowsing/VSafeBrowsing.vue
@@ -80,7 +80,7 @@ export default defineComponent({
     const uiStore = useUiStore()
     let blurSensitive = computed(() => uiStore.shouldBlurSensitive)
     let setBlurSensitive = ({ checked }: { checked: boolean }) => {
-      uiStore.shouldBlurSensitive = checked
+      uiStore.setShouldBlurSensitive(checked)
     }
 
     const toggles = [

--- a/frontend/src/components/VSearchResultsGrid/VImageCell.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCell.vue
@@ -61,9 +61,10 @@ import type { AspectRatio, ImageDetail } from "~/types/media"
 import { useImageCellSize } from "~/composables/use-image-cell-size"
 import { useI18n } from "~/composables/use-i18n"
 import { useAnalytics } from "~/composables/use-analytics"
-import { useUiStore } from "~/stores/ui"
 
 import { IMAGE } from "~/constants/media"
+
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 import VLicense from "~/components/VLicense/VLicense.vue"
 import VLink from "~/components/VLink.vue"
@@ -174,10 +175,7 @@ export default defineComponent({
       })
     }
 
-    const uiStore = useUiStore()
-    const shouldBlur = computed(
-      () => uiStore.shouldBlurSensitive && props.image.isSensitive
-    )
+    const { isHidden: shouldBlur } = useSensitiveMedia(props.image)
 
     return {
       styles,

--- a/frontend/src/composables/use-sensitive-media.ts
+++ b/frontend/src/composables/use-sensitive-media.ts
@@ -20,7 +20,7 @@ export function useSensitiveMedia(
   const uiStore = useUiStore()
 
   /**
-   * The current state of a single sentive media item.
+   * The current state of a single sensitive media item.
    * Respects defaults from the site's filters and is
    * updated by user interactions.
    */

--- a/frontend/src/composables/use-sensitive-media.ts
+++ b/frontend/src/composables/use-sensitive-media.ts
@@ -5,7 +5,7 @@ import type { Media } from "~/types/media"
 import { useUiStore } from "~/stores/ui"
 
 type SensitiveVisibilityState =
-  | "insensitive"
+  | "non-sensitive"
   | "sensitive-shown"
   | "sensitive-hidden"
 
@@ -26,7 +26,7 @@ export function useSensitiveMedia(
    */
   const visibility = computed<SensitiveVisibilityState>(() => {
     if (!media) {
-      return "insensitive"
+      return "non-sensitive"
     } else if (media.isSensitive) {
       if (uiStore.revealedSensitiveResults.includes(media.id)) {
         return "sensitive-shown"
@@ -36,7 +36,7 @@ export function useSensitiveMedia(
           : "sensitive-shown"
       }
     } else {
-      return "insensitive"
+      return "non-sensitive"
     }
   })
 

--- a/frontend/src/composables/use-sensitive-media.ts
+++ b/frontend/src/composables/use-sensitive-media.ts
@@ -1,0 +1,83 @@
+import { computed, watch } from "vue"
+
+import type { Media } from "~/types/media"
+
+import { useUiStore } from "~/stores/ui"
+
+type SensitiveVisibilityState =
+  | "insensitive"
+  | "sensitive-shown"
+  | "sensitive-hidden"
+
+/**
+ * A helper composable for working with sensitive media.
+ * Provides the current visibility of a sensitive media,
+ * along with toggles for hiding/revealing the media.
+ */
+export function useSensitiveMedia(
+  media: Pick<Media, "id" | "isSensitive"> | null
+) {
+  const uiStore = useUiStore()
+
+  // Clear out previously-revealed results when the toggle is switched.
+  watch(
+    () => uiStore.shouldBlurSensitive,
+    () => {
+      uiStore.revealedSensitiveResults = []
+    },
+    { deep: true }
+  )
+
+  /**
+   * The current state of a single sentive media item.
+   * Respects defaults from the site's filters and is
+   * updated by user interactions.
+   */
+  const visibility = computed<SensitiveVisibilityState>(() => {
+    if (!media) {
+      return "insensitive"
+    } else if (media.isSensitive) {
+      if (uiStore.revealedSensitiveResults.includes(media.id)) {
+        return "sensitive-shown"
+      } else {
+        return uiStore.shouldBlurSensitive
+          ? "sensitive-hidden"
+          : "sensitive-shown"
+      }
+    } else {
+      return "insensitive"
+    }
+  })
+
+  function reveal() {
+    if (media && !uiStore.revealedSensitiveResults.includes(media.id)) {
+      uiStore.revealedSensitiveResults.push(media.id)
+    }
+  }
+
+  function hide() {
+    if (!media) return
+    const index = uiStore.revealedSensitiveResults.indexOf(media.id)
+    if (index > -1) {
+      uiStore.revealedSensitiveResults.splice(index, 1)
+    }
+  }
+
+  const isHidden = computed(
+    () =>
+      media &&
+      uiStore.shouldBlurSensitive &&
+      media.isSensitive &&
+      visibility.value === "sensitive-hidden"
+  )
+
+  const canBeHidden = computed(
+    () =>
+      media &&
+      uiStore.shouldBlurSensitive &&
+      media.isSensitive &&
+      visibility.value === "sensitive-shown"
+  )
+
+  return { visibility, reveal, hide, isHidden, canBeHidden }
+}

--- a/frontend/src/composables/use-sensitive-media.ts
+++ b/frontend/src/composables/use-sensitive-media.ts
@@ -4,10 +4,7 @@ import type { Media } from "~/types/media"
 
 import { useUiStore } from "~/stores/ui"
 
-type SensitiveVisibilityState =
-  | "non-sensitive"
-  | "sensitive-shown"
-  | "sensitive-hidden"
+import type { SensitiveMediaVisibility } from "~/constants/content-safety"
 
 /**
  * A helper composable for working with sensitive media.
@@ -24,7 +21,7 @@ export function useSensitiveMedia(
    * Respects defaults from the site's filters and is
    * updated by user interactions.
    */
-  const visibility = computed<SensitiveVisibilityState>(() => {
+  const visibility = computed<SensitiveMediaVisibility>(() => {
     if (!media) {
       return "non-sensitive"
     } else if (media.isSensitive) {

--- a/frontend/src/composables/use-sensitive-media.ts
+++ b/frontend/src/composables/use-sensitive-media.ts
@@ -1,4 +1,4 @@
-import { computed, watch } from "vue"
+import { computed } from "vue"
 
 import type { Media } from "~/types/media"
 
@@ -18,15 +18,6 @@ export function useSensitiveMedia(
   media: Pick<Media, "id" | "isSensitive"> | null
 ) {
   const uiStore = useUiStore()
-
-  // Clear out previously-revealed results when the toggle is switched.
-  watch(
-    () => uiStore.shouldBlurSensitive,
-    () => {
-      uiStore.revealedSensitiveResults = []
-    },
-    { deep: true }
-  )
 
   /**
    * The current state of a single sentive media item.

--- a/frontend/src/constants/content-safety.ts
+++ b/frontend/src/constants/content-safety.ts
@@ -3,6 +3,7 @@
  * different types of sensitivities.
  */
 
+// Reasons why a piece of media is designated sensitive
 export const USER_REPORTED = "user_reported_sensitive"
 export const PROVIDER_SUPPLIED = "provider_supplied_sensitive"
 export const TEXT_FILTERED = "sensitive_text"
@@ -14,3 +15,15 @@ export const SENSITIVITIES = [
 ] as const
 
 export type Sensitivity = (typeof SENSITIVITIES)[number]
+
+// Various UI states of a piece of media, sensitive or otherwise
+export const NON_SENSITIVE = "non-sensitive"
+export const SENSITIVE_HIDDEN = "sensitive-hidden"
+export const SENSITIVE_SHOWN = "sensitive-shown"
+export const SENSITIVE_MEDIA_STATES = [
+  NON_SENSITIVE,
+  SENSITIVE_HIDDEN,
+  SENSITIVE_SHOWN,
+] as const
+
+export type SensitiveMediaVisibility = (typeof SENSITIVE_MEDIA_STATES)[number]

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -41,7 +41,9 @@ export interface UiState {
   isMobileUa: boolean
   dismissedBanners: BannerId[]
   /**
-   * whether to blur sensitive content in search and single result pages
+   * Whether to blur sensitive content in search and single result pages.
+   * Value should *not* be set directly, use setShouldBlurSensitive(value: boolean)
+   * to ensure necessary side-effects are executed.
    */
   shouldBlurSensitive: boolean
   /* A list of sensitive single result UUIDs the user has opted-into seeing */
@@ -254,6 +256,10 @@ export const useUiStore = defineStore("ui", {
       return (
         breakpoints.indexOf(breakpoint) >= breakpoints.indexOf(this.breakpoint)
       )
+    },
+    setShouldBlurSensitive(value: boolean) {
+      this.shouldBlurSensitive = value
+      this.revealedSensitiveResults = []
     },
   },
 })

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -44,6 +44,8 @@ export interface UiState {
    * whether to blur sensitive content in search and single result pages
    */
   shouldBlurSensitive: boolean
+  /* A list of sensitive single result UUIDs the user has opted-into seeing */
+  revealedSensitiveResults: string[]
 }
 
 export const breakpoints = Object.keys(ALL_SCREEN_SIZES)
@@ -58,6 +60,7 @@ export const useUiStore = defineStore("ui", {
     isMobileUa: true,
     dismissedBanners: [],
     shouldBlurSensitive: true,
+    revealedSensitiveResults: [],
   }),
 
   getters: {

--- a/frontend/test/unit/fixtures/audio.js
+++ b/frontend/test/unit/fixtures/audio.js
@@ -47,6 +47,7 @@ export const getAudioObj = (overrides = {}) =>
       related_url:
         "http://localhost:8000/v1/audio/e19345b8-6937-49f7-a0fd-03bf057efc28/recommendations",
       peaks: [],
+      isSensitive: false,
     },
     overrides
   )

--- a/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
+++ b/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
@@ -1,11 +1,12 @@
 import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
-// Mock the ~/stores/ui import
+let mockUseUiStore = {
+  shouldBlurSensitive: true,
+  revealedSensitiveResults: [],
+}
+
 jest.mock("~/stores/ui", () => ({
-  useUiStore: () => ({
-    shouldBlurSensitive: true,
-    revealedSensitiveResults: [],
-  }),
+  useUiStore: () => mockUseUiStore,
 }))
 
 describe("useSensitiveMedia composable", () => {
@@ -15,6 +16,10 @@ describe("useSensitiveMedia composable", () => {
     mockMedia = {
       id: "mock-id",
       isSensitive: false,
+    }
+    mockUseUiStore = {
+      shouldBlurSensitive: true,
+      revealedSensitiveResults: [],
     }
   })
 
@@ -36,6 +41,8 @@ describe("useSensitiveMedia composable", () => {
 
   it("should return sensitive-shown when media is sensitive and shouldBlurSensitive is false", () => {
     mockMedia.isSensitive = true
+    mockUseUiStore.shouldBlurSensitive = false
+
     const { visibility } = useSensitiveMedia(mockMedia)
     expect(visibility.value).toBe("sensitive-shown")
   })
@@ -65,6 +72,8 @@ describe("useSensitiveMedia composable", () => {
 
   it("should correctly report if a media can be hidden", () => {
     mockMedia.isSensitive = true
+    mockUseUiStore.shouldBlurSensitive = false
+
     const { reveal, canBeHidden } = useSensitiveMedia(mockMedia)
     reveal()
     expect(canBeHidden.value).toBe(false)

--- a/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
+++ b/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
@@ -23,14 +23,14 @@ describe("useSensitiveMedia composable", () => {
     }
   })
 
-  it("should return insensitive when media is null", () => {
+  it("should return non-sensitive when media is null", () => {
     const { visibility } = useSensitiveMedia(null)
-    expect(visibility.value).toBe("insensitive")
+    expect(visibility.value).toBe("non-sensitive")
   })
 
-  it("should return insensitive when media is not sensitive", () => {
+  it("should return non-sensitive when media is not sensitive", () => {
     const { visibility } = useSensitiveMedia(mockMedia)
-    expect(visibility.value).toBe("insensitive")
+    expect(visibility.value).toBe("non-sensitive")
   })
 
   it("should return sensitive-hidden when media is sensitive and shouldBlurSensitive is true", () => {

--- a/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
+++ b/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
@@ -35,6 +35,7 @@ describe("useSensitiveMedia composable", () => {
 
   it("should return sensitive-hidden when media is sensitive and shouldBlurSensitive is true", () => {
     mockMedia.isSensitive = true
+
     const { visibility } = useSensitiveMedia(mockMedia)
     expect(visibility.value).toBe("sensitive-hidden")
   })
@@ -49,24 +50,30 @@ describe("useSensitiveMedia composable", () => {
 
   it("should reveal sensitive media", () => {
     mockMedia.isSensitive = true
+
     const { reveal, visibility } = useSensitiveMedia(mockMedia)
     reveal()
+
     expect(visibility.value).toBe("sensitive-shown")
   })
 
   it("should hide sensitive media", () => {
     mockMedia.isSensitive = true
+
     const { reveal, hide, visibility } = useSensitiveMedia(mockMedia)
     reveal()
     hide()
+
     expect(visibility.value).toBe("sensitive-hidden")
   })
 
   it("should correctly report if a media is hidden", () => {
     mockMedia.isSensitive = true
+
     const { reveal, hide, isHidden } = useSensitiveMedia(mockMedia)
     reveal()
     hide()
+
     expect(isHidden.value).toBe(true)
   })
 
@@ -76,6 +83,7 @@ describe("useSensitiveMedia composable", () => {
 
     const { reveal, canBeHidden } = useSensitiveMedia(mockMedia)
     reveal()
+
     expect(canBeHidden.value).toBe(false)
   })
 })

--- a/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
+++ b/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
@@ -1,0 +1,75 @@
+import { reactive } from "vue"
+
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
+
+// Mock the ~/stores/ui import
+jest.mock("~/stores/ui", () => ({
+  useUiStore: () =>
+    reactive({
+      shouldBlurSensitive: true,
+      revealedSensitiveResults: [],
+    }),
+}))
+
+describe("useSensitiveMedia composable", () => {
+  let mockMedia: { id: string; isSensitive: boolean }
+
+  beforeEach(() => {
+    mockMedia = {
+      id: "mock-id",
+      isSensitive: false,
+    }
+  })
+
+  it("should return insensitive when media is null", () => {
+    const { visibility } = useSensitiveMedia(null)
+    expect(visibility.value).toBe("insensitive")
+  })
+
+  it("should return insensitive when media is not sensitive", () => {
+    const { visibility } = useSensitiveMedia(mockMedia)
+    expect(visibility.value).toBe("insensitive")
+  })
+
+  it("should return sensitive-hidden when media is sensitive and shouldBlurSensitive is true", () => {
+    mockMedia.isSensitive = true
+    const { visibility } = useSensitiveMedia(mockMedia)
+    expect(visibility.value).toBe("sensitive-hidden")
+  })
+
+  it("should return sensitive-shown when media is sensitive and shouldBlurSensitive is false", () => {
+    mockMedia.isSensitive = true
+    const { visibility } = useSensitiveMedia(mockMedia)
+    expect(visibility.value).toBe("sensitive-shown")
+  })
+
+  it("should reveal sensitive media", () => {
+    mockMedia.isSensitive = true
+    const { reveal, visibility } = useSensitiveMedia(mockMedia)
+    reveal()
+    expect(visibility.value).toBe("sensitive-shown")
+  })
+
+  it("should hide sensitive media", () => {
+    mockMedia.isSensitive = true
+    const { reveal, hide, visibility } = useSensitiveMedia(mockMedia)
+    reveal()
+    hide()
+    expect(visibility.value).toBe("sensitive-hidden")
+  })
+
+  it("should correctly report if a media is hidden", () => {
+    mockMedia.isSensitive = true
+    const { reveal, hide, isHidden } = useSensitiveMedia(mockMedia)
+    reveal()
+    hide()
+    expect(isHidden.value).toBe(true)
+  })
+
+  it("should correctly report if a media can be hidden", () => {
+    mockMedia.isSensitive = true
+    const { reveal, canBeHidden } = useSensitiveMedia(mockMedia)
+    reveal()
+    expect(canBeHidden.value).toBe(false)
+  })
+})

--- a/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
+++ b/frontend/test/unit/specs/composables/use-sensitive-media.spec.ts
@@ -1,14 +1,11 @@
-import { reactive } from "vue"
-
 import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 // Mock the ~/stores/ui import
 jest.mock("~/stores/ui", () => ({
-  useUiStore: () =>
-    reactive({
-      shouldBlurSensitive: true,
-      revealedSensitiveResults: [],
-    }),
+  useUiStore: () => ({
+    shouldBlurSensitive: true,
+    revealedSensitiveResults: [],
+  }),
 }))
 
 describe("useSensitiveMedia composable", () => {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #2462 by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR creates a new `useSensitiveMedia` composable for working with sensitive media, and updates the blurring logic to use this composable. This composable is fully tested with a unit test, and forms the basis of the "backend" work for the single result sensitivity UI. It includes hide/reveal methods that aren't used by this PR but will be for the VSafetyWall.

This PR also adds revealedSensitiveResults, a list of UUIDs of revealed sensitive media, to the UI store.

It was extracted into a standalone PR for ease of reviewing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Check that blurring still works as-expected in the frontend search results, when all relevant `/preferences` toggles are enabled. Check that you like the `useSensitiveMedia` implementation and that test coverage is sufficient.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
