### PR TITLE
Re-add request ID tracking to API middleware

### DIFF
--- a/api/conf/settings/logging.py
+++ b/api/conf/settings/logging.py
@@ -17,6 +17,8 @@ DJANGO_DB_LOGGING = config("DJANGO_DB_LOGGING", cast=bool, default=False)
 # https://github.com/dabapps/django-log-request-id#logging-all-requests
 LOG_REQUESTS = True
 
+# https://github.com/dabapps/django-log-request-id
+MIDDLEWARE.insert(0, "log_request_id.middleware.RequestIDMiddleware")
 # https://github.com/dabapps/django-log-request-id#installation-and-usage
 REQUEST_ID_RESPONSE_HEADER = "X-Request-Id"
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2638 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR re-adds the request ID tracking middleware, which allows us to see request IDs across log lines in the API. This was erroneously removed in 098925afa90b26881b4b4d3e2baffa69049692c0. I've added it in a similar manner to how the CORS middleware is currently inserted:

https://github.com/WordPress/openverse/blob/8afb04bc81429cda3f0aa3f8be1d22ad4bd8cbc7/api/conf/settings/security.py#L43-L45

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. `j build && j down -v`
1. `j api/init`
1. Run `j logs web` in the terminal and then submit some requests to the API locally. You should see something like the following (note `[<hash>]` across requests rather than `[none]`):

```
openverse-web-1  | [2023-07-26 22:54:03,277 - log_request_id.middleware -  55][INFO] [afd412a869274145abb82d2c56334262] method=GET path=/healthcheck/ status=200
openverse-web-1  | [2023-07-26 22:54:52,820 - oauthlib.oauth2.rfc6749.endpoints.resource -  70][DEBUG] [8ce0201eafce40e09cf38ba2067ffe0a] Dispatching token_type Bearer request to <oauthlib.oauth2.rfc6749.tokens.BearerToken object at 0x7f82e89cbbc0>.
openverse-web-1  | [2023-07-26 22:54:52,822 - api.views.media_views - 104][INFO] [8ce0201eafce40e09cf38ba2067ffe0a] Using default index for media.
openverse-web-1  | [2023-07-26 22:54:52,836 - django.db.backends - 131][DEBUG] [8ce0201eafce40e09cf38ba2067ffe0a] (0.001) SELECT "content_provider"."provider_identifier" FROM "content_provider" WHERE "content_provider"."filter_content"; args=(); alias=default
openverse-web-1  | [2023-07-26 22:54:52,941 - urllib3.connectionpool - 473][DEBUG] [8ce0201eafce40e09cf38ba2067ffe0a] http://es:9200 "POST /image-filtered/_search?preference=3190171526554244283 HTTP/1.1" 200 50792
openverse-web-1  | [2023-07-26 22:54:52,941 - elasticsearch - 265][INFO] [8ce0201eafce40e09cf38ba2067ffe0a] POST http://es:9200/image-filtered/_search?preference=3190171526554244283 [status:200 request:0.102s]
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
