### PR TITLE
Block crawling on search results views

### DIFF
--- a/frontend/src/server-middleware/robots.js
+++ b/frontend/src/server-middleware/robots.js
@@ -8,7 +8,14 @@ export default function robots(_, res) {
 
   const contents =
     deployEnv === PRODUCTION
-      ? `# This file is intentionally left blank`
+      ? `# Block search result pages
+User-agent: *
+Disallow: /search/audio/
+Disallow: /search/image/
+Disallow: /search/
+Disallow: /image/
+Disallow: /audio/
+      `
       : `# Block crawlers from the staging site
 User-agent: *
 Disallow: /


### PR DESCRIPTION
This PR restricts all bot traffic to our search result endpoints. This is a temporary experiment to see if this kind of traffic is impacting our API performance.