### PR TITLE
Clean up Popularity Refresh notifications and adjust poke interval

### DIFF
--- a/catalog/dags/data_refresh/reporting.py
+++ b/catalog/dags/data_refresh/reporting.py
@@ -11,7 +11,7 @@ def report_status(media_type: str, message: str, dag_id: str):
     slack.send_message(
         text=message,
         dag_id=dag_id,
-        username="Data Refresh Notification",
+        username=f"{dag_id.replace('_', ' ').title()} Notification",
         icon_emoji="arrows_counterclockwise",
     )
     return message

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -151,7 +151,7 @@ def drop_temp_airflow_variable(airflow_var: str):
 
 
 @task
-def notify_slack(text: str, dry_run: bool, count: int | None = None) -> None:
+def notify_slack(text: str, dry_run: bool, count: int | None = None) -> str:
     """
     Send a message to Slack, or simply log if this is a dry run.
     If a `count` is supplied, it is formatted and inserted into the text. This is
@@ -172,3 +172,5 @@ def notify_slack(text: str, dry_run: bool, count: int | None = None) -> None:
         )
     else:
         logger.info(text)
+
+    return text

--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -196,9 +196,9 @@ def batched_update():
     )
 
     notify_before_update = notify_slack.override(task_id="notify_before_update")(
-        text=f"Preparing to update {select_rows_to_update} rows for update:"
-        " {{ params.query_id }}",
+        text="Preparing to update {count} rows for query: {{ params.query_id }}",
         dry_run="{{ params.dry_run}}",
+        count=select_rows_to_update,
     )
 
     check_for_resume_update >> [select_rows_to_update, expected_count]
@@ -220,9 +220,9 @@ def batched_update():
     expected_count >> [notify_before_update, perform_batched_update]
 
     notify_updated_count = notify_slack.override(task_id="notify_updated_count")(
-        text=f"Updated {perform_batched_update} records for update:"
-        " {{ params.query_id }}",
+        text="Updated {count} records for query: {{ params.query_id }}",
         dry_run="{{ params.dry_run}}",
+        count=perform_batched_update,
     )
 
     # The temporary table is only dropped if all updates were successful; this

--- a/catalog/dags/popularity/dag_factory.py
+++ b/catalog/dags/popularity/dag_factory.py
@@ -37,7 +37,7 @@ from popularity.refresh_popularity_metrics_task_factory import (
 )
 
 from common import slack
-from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID, REFRESH_POKE_INTERVAL
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
 from common.popularity import sql
 from database.batched_update.constants import DAG_ID as BATCHED_UPDATE_DAG_ID
 
@@ -165,7 +165,8 @@ def create_popularity_refresh_dag(popularity_refresh: PopularityRefresh):
             wait_for_completion=True,
             # Release the worker slot while waiting
             deferrable=True,
-            poke_interval=REFRESH_POKE_INTERVAL,
+            poke_interval=popularity_refresh.poke_interval,
+            execution_timeout=popularity_refresh.refresh_popularity_timeout,
             retries=0,
         ).expand(
             # Build the conf for each provider

--- a/catalog/dags/popularity/dag_factory.py
+++ b/catalog/dags/popularity/dag_factory.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 def notify_slack(text: str, media_type: str, dag_id: str) -> None:
     slack.send_message(
         text,
-        username=f"{media_type} Popularity Refresh",
+        username=f"{media_type.capitalize()} Popularity Refresh",
         icon_emoji=":database:",
         dag_id=dag_id,
     )

--- a/catalog/tests/dags/database/test_batched_update.py
+++ b/catalog/tests/dags/database/test_batched_update.py
@@ -11,6 +11,7 @@ from common.storage.db_columns import IMAGE_TABLE_COLUMNS
 from database.batched_update import constants
 from database.batched_update.batched_update import (
     get_expected_update_count,
+    notify_slack,
     update_batches,
 )
 
@@ -318,3 +319,24 @@ def test_update_batches_resuming_from_batch_start(
     assert actual_rows[1][sql.title_idx] == NEW_TITLE
     assert actual_rows[2][sql.fid_idx] == FID_C
     assert actual_rows[2][sql.title_idx] == NEW_TITLE
+
+
+@pytest.mark.parametrize(
+    "text, count, expected_message",
+    [
+        ("Updated {count} records", 1000000, "Updated 1,000,000 records"),
+        (
+            "Updated {count} records",
+            2,
+            "Updated 2 records",
+        ),
+        (
+            "A message without a count",
+            None,
+            "A message without a count",
+        ),
+    ],
+)
+def test_notify_slack(text, count, expected_message):
+    actual_message = notify_slack.function(text, True, count)
+    assert actual_message == expected_message


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Some fast-follows after turning on the popularity refresh DAGs in production.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
A few quick fast-follows:

- Updates the poke interval for the audio refresh to 1 minute: in production, it took around 5 minutes for the entire audio refresh to complete, so the 30 minute poke interval is much too high
- Updates the `execution_timeout` on the `TriggerDagRunOperator` to 30 days to match the timeout of the batched updates. (In production, the image batched updates are proceeding well, but the image refresh DAG timed out at this step)
- In the `batched_update` DAG, instead of logging the number of rows completed _and the number remaining_, it now logs the number of rows completed and _the percent completed_, which is more useful for large DAGs like Flickr.
- Formats all the `count`s given in the various log messages and slack notifications to use comma separators (e.g. "Updating 123,456,789 records" instead of "Updating 123456789 records")
- Capitalizes the media type in slack notifications
- Updates the Slack notifications during the popularity constant recalculation steps to read "<Media> Data Refresh Notification" when coming from a data refresh, and "<Media> Popularity Refresh Notification" when coming from the popularity refresh.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the audio and image popularity refreshes locally. Inspect the `update_batches` task to see it has the correct timeout and poke interval (to test the audio poke interval, you may need to remove your own `DATA_REFRESH_POKE_INTERVAL` env variable if you have one, as this will always override defaults). Check that the slack notifications and logs are formatted properly.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
