### PR TITLE
Stop converting timeout error to an object in Nuxt API requests

### DIFF
--- a/frontend/src/data/api-service.ts
+++ b/frontend/src/data/api-service.ts
@@ -125,12 +125,9 @@ export const createApiService = ({
     (response) => response,
     (error) => {
       if (error.code === "ECONNABORTED") {
-        return Promise.reject({
-          message: `timeout of ${
-            DEFAULT_REQUEST_TIMEOUT / 1000
-          } seconds exceeded`,
-          ...error,
-        })
+        error.message = `timeout of ${
+          DEFAULT_REQUEST_TIMEOUT / 1000
+        } seconds exceeded`
       }
       return Promise.reject(error)
     }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2746 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR stops the conversion of the error into an object. This will allow us to handle timeout errors correctly.
A follow-up to this PR should be the fix for #632 that actually shows the timeout error page instead of the generic yellow error page as it does not.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To easily simulate timeouts, change the default timeout to 30:
https://github.com/WordPress/openverse/blob/61c7abdeaed0450558859ff949846f9a1497ad13/frontend/src/data/api-service.ts#L8
From the logs it's not clear that the error was converted to an object because it's causing the Promise to reject, and is handled in the same `catch` block.
However, you will see the warning in the console saying "There was an error fetching media providers for image: ECONNABORTED", which means that the error is recognized as the AxiosError in the store code:
https://github.com/WordPress/openverse/blob/61c7abdeaed0450558859ff949846f9a1497ad13/frontend/src/stores/provider.ts#L138-L141 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
