### PR TITLE
Set API Dockerfile run to production config

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -117,8 +117,8 @@ EXPOSE 8000 3000
 # Wait for ES to accept connections
 ENTRYPOINT ["./run.sh"]
 
-# Run Django dev server, can be overridden from Docker Compose
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# gunicorn configuration in gunicorn.conf.py
+CMD ["gunicorn"]
 
 #########
 # NGINX #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,6 @@ services:
       - ./api:/api
     ports:
       - "50280:8000" # Django
-      - "50230:3000" # Sphinx (unused by default; see `sphinx-live` recipe)
     depends_on:
       - db
       - es
@@ -229,6 +228,7 @@ services:
       MEDIA_ROOT: ${MEDIA_ROOT:-}
     stdin_open: true
     tty: true
+    command: python manage.py runserver 0.0.0.0:8000
 
   ingestion_server:
     profiles:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2785 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Switches the API image to have `gunicorn` as the run command, rather than the development command. See the issue for rationale. The development run command is now just in the docker-compose file, which is the primary place for development configuration.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `just down && just build web && just api/up` and confirm that the API is accessible. Remember to `just api/init` if you're working on a fresh clone. 

To test the production configuration, comment out the `command` on the `web` service of docker-compose.yml and confirm that it's still accessible. Note that static files will _not_ work in this configuration because in production we rely on Nginx to serve them and we do not have that configured locally! As long as you can access the API and see unstyled DRF pages when making requests, things should be working as expected.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
