### PR TITLE
Adjust the date filter in Europeana to pull updates rather than created records

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/catalog/dags/providers/provider_api_scripts/europeana.py
@@ -199,7 +199,7 @@ class EuropeanaDataIngester(ProviderDataIngester):
         start_timestamp = start_timestamp.replace("+00:00", "Z")
         end_timestamp = end_timestamp.replace("+00:00", "Z")
 
-        return f"timestamp_created:[{start_timestamp} TO {end_timestamp}]"
+        return f"timestamp_update:[{start_timestamp} TO {end_timestamp}]"
 
     def get_next_query_params(self, prev_query_params) -> dict:
         if not prev_query_params:

--- a/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
@@ -33,7 +33,7 @@ def test_derive_timestamp_pair(ingester):
     # The timestamps below depend on the ``FROZEN_DATE`` constant
     # defined above.
     assert ingester.base_request_body["query"] == (
-        "timestamp_created:[2018-01-15T00:00:00Z TO 2018-01-16T00:00:00Z]"
+        "timestamp_update:[2018-01-15T00:00:00Z TO 2018-01-16T00:00:00Z]"
     )
 
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes

Fixes #1268  by @stacimc 

## Description
We've been filtering on image create date, rather than update date. Hopefully this switch will both smooth out the number of records processed in regular dag runs, and make re-ingestion either unnecessary or substantially less necessary. 

I thought it would be helpful to have this in place for testing https://github.com/WordPress/openverse/pull/2782

## Testing Instructions
- `just catalog/shell` and `pytest`
- [get a europeana api key](https://pro.europeana.eu/page/get-api) if you don't have one already, and put it in your `catalog/.env` file
- maybe set a more recent [start date](https://github.com/WordPress/openverse/blob/f3232315128c01c97493f673ce00f3353c8f260a/catalog/dags/providers/provider_workflows.py#L205), and then try running the dag on http://localhost:9090/
- check out the results in `just catalog/pgcli`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
