### PR TITLE
Prevent < and > in commit titles from breaking dag-sync slack message

### DIFF
--- a/dag-sync.sh
+++ b/dag-sync.sh
@@ -30,10 +30,10 @@ have_dag=$(git log -p -1 "$new" --pretty=format: --name-only | grep "catalog/dag
 
 # Pull out the subject from the new commit
 subject=$(git log -1 --format='%s')
-# Swap the < & > characters for more complex unicode variants so they don't get
+# Swap the < & > characters for their HTML entities so they aren't
 # interpreted as delimiters by Slack
-subject=${subject//>/≻}
-subject=${subject//</≺}
+subject=${subject//>/&gt;}
+subject=${subject//</&lt;}
 
 if [ -z "$SLACK_URL" ]; then
   echo "Slack hook was not supplied! Updates will not be posted"

--- a/dag-sync.sh
+++ b/dag-sync.sh
@@ -30,6 +30,10 @@ have_dag=$(git log -p -1 "$new" --pretty=format: --name-only | grep "catalog/dag
 
 # Pull out the subject from the new commit
 subject=$(git log -1 --format='%s')
+# Swap the < & > characters for more complex unicode variants so they don't get
+# interpreted as delimiters by Slack
+subject=${subject//>/≻}
+subject=${subject//</≺}
 
 if [ -z "$SLACK_URL" ]; then
   echo "Slack hook was not supplied! Updates will not be posted"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes an issue that arose when #2817 was merged: the commit title `timestamp_created -> timestamp_update (#2817)` broke the Slack message component of the DAG sync since the `>` character was interpreted by Slack as the end of the link definition.

This change adds a step to replace the `<` and `>` character with two variants (`≺` and `≻` respectively). These characters, though they look roughly similar, don't register in Slack as delimiters and thus don't break the message syntax when merged!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This was tested in our Slack instance:

**Before**
![image](https://github.com/WordPress/openverse/assets/10214785/4b3f6b49-c776-4059-b71d-586e579400e6)


**After**
![image](https://github.com/WordPress/openverse/assets/10214785/c8f9909b-7f00-4566-a57e-1793c1abf3d8)



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
