### PR TITLE
Drop and recreate pop constants instead of refreshing

### DIFF
--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -83,6 +83,21 @@ def drop_media_matview(
     postgres.run(f"DROP MATERIALIZED VIEW IF EXISTS public.{db_view} CASCADE;")
 
 
+def drop_media_popularity_constants(
+    postgres_conn_id,
+    media_type=IMAGE,
+    constants=IMAGE_POPULARITY_CONSTANTS_VIEW,
+    pg_timeout: float = timedelta(minutes=10).total_seconds(),
+):
+    if media_type == AUDIO:
+        constants = AUDIO_POPULARITY_CONSTANTS_VIEW
+
+    postgres = PostgresHook(
+        postgres_conn_id=postgres_conn_id, default_statement_timeout=pg_timeout
+    )
+    postgres.run(f"DROP MATERIALIZED VIEW IF EXISTS public.{constants} CASCADE;")
+
+
 def drop_media_popularity_relations(
     postgres_conn_id,
     media_type=IMAGE,

--- a/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
+++ b/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
@@ -76,7 +76,7 @@ def create_refresh_popularity_metrics_task_group(
                 "media_type": media_type,
             },
             execution_timeout=execution_timeout,
-            doc=("Drops the popularity constants view."),
+            doc="Drops the popularity constants view.",
         )
 
         create_constants = PythonOperator(


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In production, we've seen the step to refresh the popularity constants view time out. This PR updates the data refresh and popularity refresh DAGs (both of which currently refresh popularity constants) to instead drop and recreate the view. This approach fixed a similar problem with the matview, so we expect it to help now.

<img width="917" alt="Screenshot 2023-08-17 at 11 41 52 AM" src="https://github.com/WordPress/openverse/assets/63313398/45b7ea55-40d1-40f9-9992-955782f213d6">

**Note**: We will need to make sure that the data refresh and popularity refresh for a given media type are not running the popularity steps simultaneously, since now the data refresh might try to drop the constants view while the popularity refresh is in the middle of recreating it for example. **This will not be a problem long term, because the popularity steps are in the process of being removed from the data refresh in #2818 (which is just blocked on #2803 but should be ready soon).** This will only be a problem if the data refreshes are turned back on, the popularity refreshes are turned onto their monthly schedule (#2819), **and** a monthly run and weekly run begin close enough together to overlap (which does not look to be the case for September). Therefore I don't think it's worth adding any logic to address this.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the data refreshes and popularity refreshes and ensure they work. Observe the DAG graphs and see that the popularity constants views are dropped and then recreated.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
