### PR TITLE
Add API routes and controllers for additional search views

### DIFF
--- a/api/api/constants/media_types.py
+++ b/api/api/constants/media_types.py
@@ -6,7 +6,9 @@ AUDIO_TYPE = "audio"
 IMAGE_TYPE = "image"
 
 MEDIA_TYPES = [AUDIO_TYPE, IMAGE_TYPE]
+MediaType = Literal["audio", "image"]
 
 MEDIA_TYPE_CHOICES = [(AUDIO_TYPE, "Audio"), (IMAGE_TYPE, "Image")]
 
-OriginIndex = Literal["image", "audio"]
+OriginIndex = MediaType
+SearchIndex = Literal["image", "image-filtered", "audio", "audio-filtered"]

--- a/api/api/constants/search.py
+++ b/api/api/constants/search.py
@@ -1,0 +1,5 @@
+from typing import Literal
+
+
+SEARCH_STRATEGIES = ["search", "collection"]
+SearchStrategy = Literal["search", "collection"]

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -347,7 +347,7 @@ def build_collection_query(
         # Collection filters allow a single value.
         ("tag", "tags.name.keyword"),
         ("source", None),
-        ("creator", None),
+        ("creator", "creator.keyword"),
     ]
     for serializer_field, es_field in filters:
         if serializer_field in collection_params:

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -354,6 +354,7 @@ def build_collection_query(
     )
     if not include_sensitive_by_params:
         search_query["must_not"].append({"term": {"mature": True}})
+
     if excluded_providers_query := get_excluded_providers_query():
         search_query["must_not"].append(excluded_providers_query)
 

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -29,11 +29,19 @@ from api.utils.check_dead_links import check_dead_links
 from api.utils.dead_link_mask import get_query_hash
 from api.utils.search_context import SearchContext
 
+
+# Using TYPE_CHECKING to avoid circular imports when importing types
 if TYPE_CHECKING:
     from api.serializers.audio_serializers import AudioCollectionRequestSerializer
     from api.serializers.media_serializers import (
         MediaSearchRequestSerializer,
         PaginatedRequestSerializer,
+    )
+
+    MediaListRequestSerializer = (
+        AudioCollectionRequestSerializer
+        | MediaSearchRequestSerializer
+        | PaginatedRequestSerializer
     )
 
 module_logger = logging.getLogger(__name__)

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -337,7 +337,7 @@ def build_collection_query(
     # names are identical.
     filters = [
         # Collection filters allow a single value.
-        ("tag", "tags.name"),
+        ("tag", "tags.name.keyword"),
         ("source", None),
         ("creator", None),
     ]

--- a/api/api/docs/audio_docs.py
+++ b/api/api/docs/audio_docs.py
@@ -39,7 +39,7 @@ search = custom_extend_schema(
 
         By using this endpoint, you can obtain search results based on specified
         query and optionally filter results by
-        {fields_to_md(AudioSearchRequestSerializer.fields_names)}.
+        {fields_to_md(AudioSearchRequestSerializer.field_names)}.
 
         Results are ranked in order of relevance and paginated on the basis of the
         `page` param. The `page_size` param controls the total number of pages.

--- a/api/api/docs/audio_docs.py
+++ b/api/api/docs/audio_docs.py
@@ -1,6 +1,6 @@
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 
-from api.docs.base_docs import custom_extend_schema, fields_to_md
+from api.docs.base_docs import collection_schema, custom_extend_schema, fields_to_md
 from api.examples import (
     audio_complain_201_example,
     audio_complain_curl,
@@ -115,4 +115,17 @@ waveform = custom_extend_schema(
         404: (NotFoundErrorSerializer, audio_waveform_404_example),
     },
     eg=[audio_waveform_curl],
+)
+
+source_collection = collection_schema(
+    media_type="audio",
+    collection="source",
+)
+creator_collection = collection_schema(
+    media_type="audio",
+    collection="creator",
+)
+tag_collection = collection_schema(
+    media_type="audio",
+    collection="tag",
 )

--- a/api/api/docs/base_docs.py
+++ b/api/api/docs/base_docs.py
@@ -140,11 +140,27 @@ def get_collection_description(media_type, collection):
         return f"""
 Get a collection of {media_type} with a specific tag.
 
-This endpoint returns only the exact matches, case-insensitive matches for the
-specified tag. For example, 'birds' and 'birding' are not matches for 'bird'.
-To search within the tag values, or to match several tags, use the `search` endpoint
-with `tags` query parameter instead of `q` parameter. In this case, the matches will
- not be exact, so 'cat' would match both 'cat' and 'cats'.
+This endpoint matches a single tag, exactly and entirely.
+
+Differences that will cause tags to not match are:
+- upper and lower case letters
+- diacritical marks
+- hyphenation
+- spacing
+- multi-word tags where the query is only one of the words in the tag
+- multi-word tags where the words are in a different order
+
+Examples of tags that **do not** match:
+- "Low-Quality" and "low-quality"
+- "jalapeño" and "jalapeno"
+- "Saint Pierre des Champs" and "Saint-Pierre-des-Champs"
+- "dog walking" and "dog  walking" (where the latter has two spaces between the
+last two words, as in a typographical error)
+- "runner" and "marathon runner"
+- "exclaiming loudly" and "loudly exclaiming"
+
+For non-exact or multi-tag matching, using the `search` endpoint's `tags` query
+parameter.
 
 The returned results are ordered based on the time when they were added to Openverse.
     """

--- a/api/api/docs/base_docs.py
+++ b/api/api/docs/base_docs.py
@@ -140,13 +140,13 @@ def get_collection_description(media_type, collection):
         return f"""
 Get a collection of {media_type} with a specific tag.
 
-This endpoint returns only the exact matches. To search within the
-tag values, or to match several tags, use the `search` endpoint
-with `tags` query parameter instead of `q` parameter.
+This endpoint returns only the exact matches, case-insensitive matches for the
+specified tag. For example, 'birds' and 'birding' are not matches for 'bird'.
+To search within the tag values, or to match several tags, use the `search` endpoint
+with `tags` query parameter instead of `q` parameter. In this case, the matches will
+ not be exact, so 'cat' would match both 'cat' and 'cats'.
 
-The returned results are ordered primarily based on their popularity
-and authority. However, note that the exact order may vary over time
-or across requests.
+The returned results are ordered based on the time when they were added to Openverse.
     """
     elif collection == "source":
         return f"""
@@ -168,8 +168,7 @@ this endpoint only returns the items from the specified source. To search within
 the creator value, use the `search` endpoint with `source` query parameter
 instead of `q`.
 
-The order in the results is not guaranteed to stay the same. Most likely, the images
-in the collection will be sorted by the order in which they were added to Openverse.
+The items will be sorted by the date when they were added to Openverse.
     """
 
 

--- a/api/api/docs/base_docs.py
+++ b/api/api/docs/base_docs.py
@@ -1,8 +1,23 @@
 from http.client import responses as http_responses
 from textwrap import dedent
+from typing import Literal
 
-from drf_spectacular.openapi import AutoSchema, OpenApiResponse
-from drf_spectacular.utils import OpenApiExample, extend_schema
+from drf_spectacular.openapi import AutoSchema
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
+
+from api.constants.media_types import MediaType
+from api.serializers.audio_serializers import (
+    AudioCollectionRequestSerializer,
+    AudioSerializer,
+)
+from api.serializers.error_serializers import NotFoundErrorSerializer
+from api.serializers.image_serializers import ImageSerializer
+from api.serializers.media_serializers import PaginatedRequestSerializer
 
 
 def fields_to_md(field_names):
@@ -77,3 +92,123 @@ class MediaSchema(AutoSchema):
             else:
                 operation_tokens.append("detail")
         return "_".join(operation_tokens)
+
+
+source_404_message = "Invalid source 'name'. Valid sources are ..."
+source_404_response = OpenApiResponse(
+    NotFoundErrorSerializer,
+    examples=[
+        OpenApiExample(
+            name="404",
+            value={"detail": source_404_message},
+        )
+    ],
+)
+
+
+def build_source_path_parameter(media_type: MediaType):
+    valid_description = (
+        f"Valid values are source_names from the stats endpoint: "
+        f"https://api.openverse.engineering/v1/{media_type}/stats/."
+    )
+
+    return OpenApiParameter(
+        name="source",
+        type=str,
+        location=OpenApiParameter.PATH,
+        description=f"The source of {media_type}. {valid_description}",
+    )
+
+
+creator_path_parameter = OpenApiParameter(
+    name="creator",
+    type=str,
+    location=OpenApiParameter.PATH,
+    description="The name of the media creator. This parameter "
+    "is case-sensitive, and matches exactly.",
+)
+tag_path_parameter = OpenApiParameter(
+    name="tag",
+    type=str,
+    location=OpenApiParameter.PATH,
+    description="The tag of the media. Not case-sensitive, matches exactly.",
+)
+
+
+def get_collection_description(media_type, collection):
+    if collection == "tag":
+        return f"""
+Get a collection of {media_type} with a specific tag.
+
+This endpoint returns only the exact matches. To search within the
+tag values, or to match several tags, use the `search` endpoint
+with `tags` query parameter instead of `q` parameter.
+
+The returned results are ordered primarily based on their popularity
+and authority. However, note that the exact order may vary over time
+or across requests.
+    """
+    elif collection == "source":
+        return f"""
+Get a collection of {media_type} from a specific source.
+
+This endpoint returns only the exact matches. To search within the source value,
+use the `search` endpoint with `source` query parameter.
+
+The results in the collection will be sorted by the order in which they
+were added to Openverse.
+    """
+    elif collection == "creator":
+        return f"""
+Get a collection of {media_type} by a specific creator from the specified source.
+
+This endpoint returns only the exact matches both on the creator and the source.
+Notice that a single creator's media items can be found on several sources, but
+this endpoint only returns the items from the specified source. To search within
+the creator value, use the `search` endpoint with `source` query parameter
+instead of `q`.
+
+The order in the results is not guaranteed to stay the same. Most likely, the images
+in the collection will be sorted by the order in which they were added to Openverse.
+    """
+
+
+COLLECTION_TO_OPERATION_ID = {
+    ("images", "source"): "images_by_source",
+    ("images", "creator"): "images_by_source_and_creator",
+    ("images", "tag"): "images_by_tag",
+    ("audio", "source"): "audio_by_source",
+    ("audio", "creator"): "audio_by_source_and_creator",
+    ("audio", "tag"): "audio_by_tag",
+}
+
+
+def collection_schema(
+    media_type: Literal["images", "audio"],
+    collection: Literal["source", "creator", "tag"],
+):
+    if media_type == "images":
+        request_serializer = PaginatedRequestSerializer
+        serializer = ImageSerializer
+    else:
+        request_serializer = AudioCollectionRequestSerializer
+        serializer = AudioSerializer
+
+    if collection == "tag":
+        responses = {200: serializer(many=True)}
+        path_parameters = [tag_path_parameter]
+    else:
+        responses = {200: serializer(many=True), 404: source_404_response}
+        path_parameters = [build_source_path_parameter(media_type)]
+        if collection == "creator":
+            path_parameters.append(creator_path_parameter)
+    operation_id = COLLECTION_TO_OPERATION_ID[(media_type, collection)]
+    description = get_collection_description(media_type, collection)
+    return extend_schema(
+        operation_id=operation_id,
+        summary=operation_id,
+        auth=[],
+        description=description,
+        responses=responses,
+        parameters=[request_serializer, *path_parameters],
+    )

--- a/api/api/docs/image_docs.py
+++ b/api/api/docs/image_docs.py
@@ -1,6 +1,6 @@
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 
-from api.docs.base_docs import custom_extend_schema, fields_to_md
+from api.docs.base_docs import collection_schema, custom_extend_schema, fields_to_md
 from api.examples import (
     image_complain_201_example,
     image_complain_curl,
@@ -121,4 +121,17 @@ oembed = custom_extend_schema(
 
 watermark = custom_extend_schema(
     deprecated=True,
+)
+
+source_collection = collection_schema(
+    media_type="images",
+    collection="source",
+)
+creator_collection = collection_schema(
+    media_type="images",
+    collection="creator",
+)
+tag_collection = collection_schema(
+    media_type="images",
+    collection="tag",
 )

--- a/api/api/docs/image_docs.py
+++ b/api/api/docs/image_docs.py
@@ -40,7 +40,7 @@ search = custom_extend_schema(
 
         By using this endpoint, you can obtain search results based on specified
         query and optionally filter results by
-        {fields_to_md(ImageSearchRequestSerializer.fields_names)}.
+        {fields_to_md(ImageSearchRequestSerializer.field_names)}.
 
         Results are ranked in order of relevance and paginated on the basis of the
         `page` param. The `page_size` param controls the total number of pages.

--- a/api/api/serializers/audio_serializers.py
+++ b/api/api/serializers/audio_serializers.py
@@ -48,8 +48,8 @@ class AudioSearchRequestSerializer(
 ):
     """Parse and validate search query string parameters."""
 
-    fields_names = [
-        *MediaSearchRequestSerializer.fields_names,
+    field_names = [
+        *MediaSearchRequestSerializer.field_names,
         *AudioSearchRequestSourceSerializer.field_names,
         "category",
         "length",

--- a/api/api/serializers/image_serializers.py
+++ b/api/api/serializers/image_serializers.py
@@ -33,8 +33,8 @@ class ImageSearchRequestSerializer(
 ):
     """Parse and validate search query string parameters."""
 
-    fields_names = [
-        *MediaSearchRequestSerializer.fields_names,
+    field_names = [
+        *MediaSearchRequestSerializer.field_names,
         *ImageSearchRequestSourceSerializer.field_names,
         "category",
         "aspect_ratio",

--- a/api/api/serializers/media_serializers.py
+++ b/api/api/serializers/media_serializers.py
@@ -36,7 +36,9 @@ class PaginatedRequestSerializer(serializers.Serializer):
     page_size = serializers.IntegerField(
         label="page_size",
         help_text=f"Number of results to return per page. "
-        f"Maximum for unauthenticated requests is {settings.MAX_ANONYMOUS_PAGE_SIZE}.",
+        f"Maximum is {settings.MAX_AUTHED_PAGE_SIZE} for authenticated "
+        f"requests, and {settings.MAX_ANONYMOUS_PAGE_SIZE} for "
+        f"unauthenticated requests.",
         required=False,
         default=settings.MAX_ANONYMOUS_PAGE_SIZE,
         min_value=1,
@@ -148,19 +150,30 @@ class MediaSearchRequestSerializer(PaginatedRequestSerializer):
     )
     creator = serializers.CharField(
         label="creator",
-        help_text="Search by creator only. Cannot be used with `q`.",
+        help_text="Search by creator only. Cannot be used with `q`. The search "
+        "is fuzzy, so `creator=john` will match any value that includes the "
+        "word `john`. If the value contains space, items that contain any of "
+        "the words in the value will match. To search for several values, "
+        "join them with a comma.",
         required=False,
         max_length=200,
     )
     tags = serializers.CharField(
         label="tags",
-        help_text="Search by tag only. Cannot be used with `q`.",
+        help_text="Search by tag only. Cannot be used with `q`. The search "
+        "is fuzzy, so `tags=cat` will match any value that includes the word "
+        "`cat`. If the value contains space, items that contain any of the "
+        "words in the value will match. To search for several values, join "
+        "them with a comma.",
         required=False,
         max_length=200,
     )
     title = serializers.CharField(
         label="title",
-        help_text="Search by title only. Cannot be used with `q`.",
+        help_text="Search by title only. Cannot be used with `q`. The search is fuzzy,"
+        " so `title=photo` will match any value that includes the word `photo`. "
+        "If the value contains space, items that contain any of the words in the "
+        "value will match. To search for several values, join them with a comma.",
         required=False,
         max_length=200,
     )

--- a/api/api/serializers/media_serializers.py
+++ b/api/api/serializers/media_serializers.py
@@ -106,7 +106,7 @@ class MediaSearchRequestSerializer(PaginatedRequestSerializer):
         DeprecatedParam("pagesize", "page_size"),
         DeprecatedParam("provider", "source"),
     ]
-    fields_names = [
+    field_names = [
         "q",
         "license",
         "license_type",

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -3,7 +3,12 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import APIException, NotFound
 from rest_framework.response import Response
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 
 from api.constants.media_types import AUDIO_TYPE
 from api.docs.audio_docs import (
@@ -17,11 +22,13 @@ from api.docs.audio_docs import (
 )
 from api.models import Audio
 from api.serializers.audio_serializers import (
+    AudioCollectionRequestSerializer,
     AudioReportRequestSerializer,
     AudioSearchRequestSerializer,
     AudioSerializer,
     AudioWaveformSerializer,
 )
+from api.serializers.error_serializers import NotFoundErrorSerializer
 from api.serializers.media_serializers import MediaThumbnailRequestSerializer
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 from api.views.media_views import MediaViewSet
@@ -38,15 +45,103 @@ class AudioViewSet(MediaViewSet):
     """Viewset for all endpoints pertaining to audio."""
 
     model_class = Audio
+    media_type = AUDIO_TYPE
     query_serializer_class = AudioSearchRequestSerializer
     default_index = settings.MEDIA_INDEX_MAPPING[AUDIO_TYPE]
 
     serializer_class = AudioSerializer
+    collection_serializer_class = AudioCollectionRequestSerializer
 
     def get_queryset(self):
         return super().get_queryset().select_related("mature_audio", "audioset")
 
     # Extra actions
+    @extend_schema(
+        operation_id="audio_by_creator",
+        summary="audio_by_creator_at_source",
+        responses={
+            200: AudioSerializer(many=True),
+            404: OpenApiResponse(
+                NotFoundErrorSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="404",
+                        value={
+                            "detail": "Invalid source 'source_name'. "
+                            "Valid sources are ..."
+                        },
+                    )
+                ],
+            ),
+        },
+        parameters=[AudioCollectionRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="source/(?P<source>[^/.]+)/creator/(?P<creator>.+)",
+    )
+    def creator_collection(self, request, source, creator):
+        """
+        Get a collection of audio items by a specific creator from the specified source.
+
+        The items in the collection will be sorted by the order in which they were
+        added to Openverse.
+        """
+        return super().creator_collection(request, source, creator)
+
+    @extend_schema(
+        operation_id="audio_by_source",
+        summary="audio_by_source",
+        responses={
+            200: AudioSerializer(many=True),
+            404: OpenApiResponse(
+                NotFoundErrorSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="404",
+                        value={
+                            "detail": "Invalid source 'source_name'. "
+                            "Valid sources are ..."
+                        },
+                    )
+                ],
+            ),
+        },
+        parameters=[AudioCollectionRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="source/(?P<source>[^/.]+)",
+    )
+    def source_collection(self, request, source):
+        """
+        Get a collection of audio items from a specific source.
+
+        The items in the collection will be sorted by the order in which they were
+        added to Openverse.
+        """
+        return super().source_collection(request, source)
+
+    @extend_schema(
+        operation_id="audio_by_tag",
+        summary="audio_by_tag",
+        responses={200: AudioSerializer(many=True)},
+        parameters=[AudioCollectionRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="tag/(?P<tag>[^/.]+)",
+    )
+    def tag_collection(self, request, tag, *_, **__):
+        """
+        Get a collection of audio items with a specific tag.
+
+        The items will be ranked by their popularity and authority.
+        """
+        return super().tag_collection(request, tag, *_, **__)
 
     @thumbnail
     @action(

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -8,7 +8,12 @@ from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 import requests
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from PIL import Image as PILImage
 
 from api.constants.media_types import IMAGE_TYPE
@@ -23,6 +28,7 @@ from api.docs.image_docs import (
 )
 from api.docs.image_docs import watermark as watermark_doc
 from api.models import Image
+from api.serializers.error_serializers import NotFoundErrorSerializer
 from api.serializers.image_serializers import (
     ImageReportRequestSerializer,
     ImageSearchRequestSerializer,
@@ -31,7 +37,10 @@ from api.serializers.image_serializers import (
     OembedSerializer,
     WatermarkRequestSerializer,
 )
-from api.serializers.media_serializers import MediaThumbnailRequestSerializer
+from api.serializers.media_serializers import (
+    MediaThumbnailRequestSerializer,
+    PaginatedRequestSerializer,
+)
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 from api.utils.watermark import watermark
 from api.views.media_views import MediaViewSet
@@ -48,6 +57,7 @@ class ImageViewSet(MediaViewSet):
     """Viewset for all endpoints pertaining to images."""
 
     model_class = Image
+    media_type = IMAGE_TYPE
     query_serializer_class = ImageSearchRequestSerializer
     default_index = settings.MEDIA_INDEX_MAPPING[IMAGE_TYPE]
 
@@ -61,6 +71,92 @@ class ImageViewSet(MediaViewSet):
         return super().get_queryset().select_related("mature_image")
 
     # Extra actions
+    @extend_schema(
+        operation_id="image_by_creator_at_source",
+        summary="image_by_creator_at_source",
+        responses={
+            200: ImageSerializer(many=True),
+            404: OpenApiResponse(
+                NotFoundErrorSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="404",
+                        value={
+                            "detail": "Invalid source 'source_name'. "
+                            "Valid sources are ..."
+                        },
+                    )
+                ],
+            ),
+        },
+        parameters=[PaginatedRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="source/(?P<source>[^/.]+)/creator/(?P<creator>.+)",
+    )
+    def creator_collection(self, request, source, creator):
+        """
+        Get a collection of images by a specific creator from the specified source.
+
+        The images in the collection will be sorted by the order in which they were
+        added to Openverse.
+        """
+        return super().creator_collection(request, source, creator)
+
+    @extend_schema(
+        operation_id="image_by_source",
+        summary="image_by_source",
+        responses={
+            200: ImageSerializer(many=True),
+            404: OpenApiResponse(
+                NotFoundErrorSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="404",
+                        value={
+                            "detail": "Invalid source 'source_name'. "
+                            "Valid sources are ..."
+                        },
+                    )
+                ],
+            ),
+        },
+        parameters=[PaginatedRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="source/(?P<source>[^/.]+)",
+    )
+    def source_collection(self, request, source, *_, **__):
+        """
+        Get a collection of images from a specific source.
+
+        The images in the collection will be sorted by the order in which they were
+        added to Openverse.
+        """
+        return super().source_collection(request, source)
+
+    @extend_schema(
+        operation_id="images_by_tag",
+        summary="images_by_tag",
+        responses={200: ImageSerializer(many=True)},
+        parameters=[PaginatedRequestSerializer],
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="tag/(?P<tag>[^/.]+)",
+    )
+    def tag_collection(self, request, tag, *_, **__):
+        """
+        Get a collection of images with a specific tag.
+
+        The images in the collection will be ranked by their popularity and authority.
+        """
+        return super().tag_collection(request, tag, *_, **__)
 
     @oembed
     @action(

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -26,6 +26,46 @@ def search_by_category(media_path, category, fixture):
     assert all(audio_item["category"] == category for audio_item in results)
 
 
+def tag_collection(media_path):
+    response = requests.get(f"{API_URL}/v1/{media_path}/tag/cat")
+    assert response.status_code == 200
+
+    results = response.json()["results"]
+    for r in results:
+        tag_names = [tag["name"] for tag in r["tags"]]
+        assert "cat" in tag_names
+
+
+def source_collection(media_path):
+    source = requests.get(f"{API_URL}/v1/{media_path}/stats").json()[0]["source_name"]
+
+    response = requests.get(f"{API_URL}/v1/{media_path}/source/{source}")
+    assert response.status_code == 200
+
+    results = response.json()["results"]
+    assert all(result["source"] == source for result in results)
+
+
+def creator_collection(media_path):
+    source = requests.get(f"{API_URL}/v1/{media_path}/stats").json()[0]["source_name"]
+
+    first_res = requests.get(f"{API_URL}/v1/{media_path}/source/{source}").json()[
+        "results"
+    ][0]
+    if not (creator := first_res.get("creator")):
+        raise AttributeError(f"No creator in {first_res}")
+
+    response = requests.get(
+        f"{API_URL}/v1/{media_path}/source/{source}/creator/{creator}"
+    )
+    assert response.status_code == 200
+
+    results = response.json()["results"]
+    assert all(
+        r["creator"] == "creator" and results["source"] == source for r in results
+    )
+
+
 def search_all_excluded(media_path, excluded_source):
     response = requests.get(
         f"{API_URL}/v1/{media_path}?q=test&excluded_source={','.join(excluded_source)}"

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -62,9 +62,9 @@ def creator_collection(media_path):
     assert response.status_code == 200
 
     results = response.json()["results"]
-    assert all(
-        r["creator"] == "creator" and results["source"] == source for r in results
-    )
+    for result in results:
+        assert result["source"] == source, f"{result['source']} != {source}"
+        assert result["creator"] == creator, f"{result['creator']} != {creator}"
 
 
 def search_all_excluded(media_path, excluded_source):

--- a/api/test/test_audio_integration.py
+++ b/api/test/test_audio_integration.py
@@ -8,6 +8,7 @@ Run with the `pytest -s` command from this directory.
 import json
 from test.constants import API_URL
 from test.media_integration import (
+    creator_collection,
     detail,
     license_filter_case_insensitivity,
     related,
@@ -21,7 +22,9 @@ from test.media_integration import (
     search_source_and_excluded,
     search_special_chars,
     sensitive_search_and_detail,
+    source_collection,
     stats,
+    tag_collection,
     uuid_validation,
 )
 
@@ -158,6 +161,18 @@ def test_audio_uuid_validation():
 
 def test_audio_related(audio_fixture):
     related(audio_fixture)
+
+
+def test_audio_tag_collection():
+    tag_collection("audio")
+
+
+def test_audio_source_collection():
+    source_collection("audio")
+
+
+def test_audio_creator_collection():
+    creator_collection("audio")
 
 
 def test_audio_sensitive_search_and_detail():

--- a/api/test/test_image_integration.py
+++ b/api/test/test_image_integration.py
@@ -8,6 +8,7 @@ Run with the `pytest -s` command from this directory.
 import json
 from test.constants import API_URL
 from test.media_integration import (
+    creator_collection,
     detail,
     license_filter_case_insensitivity,
     related,
@@ -20,7 +21,9 @@ from test.media_integration import (
     search_source_and_excluded,
     search_special_chars,
     sensitive_search_and_detail,
+    source_collection,
     stats,
+    tag_collection,
     uuid_validation,
 )
 from urllib.parse import urlencode
@@ -143,6 +146,18 @@ def test_image_uuid_validation():
     uuid_validation("images", "123456789123456789123456789123456789")
     uuid_validation("images", "12345678-1234-5678-1234-1234567891234")
     uuid_validation("images", "abcd")
+
+
+def test_image_tag_collection():
+    tag_collection("images")
+
+
+def test_image_source_collection():
+    source_collection("images")
+
+
+def test_image_creator_collection():
+    creator_collection("images")
 
 
 def test_image_related(image_fixture):

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -16,12 +16,10 @@ from uuid import uuid4
 import pook
 import pytest
 from django_redis import get_redis_connection
-from elasticsearch_dsl import Q, Search
+from elasticsearch_dsl import Search
 
 from api.controllers import search_controller
 from api.controllers.elasticsearch import helpers as es_helpers
-from api.controllers.search_controller import build_collection_query
-from api.serializers import image_serializers
 from api.utils import tallies
 from api.utils.dead_link_mask import get_query_hash, save_query_mask
 from api.utils.search_context import SearchContext
@@ -463,6 +461,7 @@ def test_search_tallies_pages_less_than_5(
     search_controller.query_media(
         strategy="search",
         search_params=serializer,
+        collection_params=None,
         ip=0,
         origin_index=media_type_config.origin_index,
         exact_index=False,
@@ -503,6 +502,7 @@ def test_search_tallies_handles_empty_page(
     search_controller.query_media(
         strategy="search",
         search_params=serializer,
+        collection_params=None,
         ip=0,
         origin_index=media_type_config.origin_index,
         exact_index=False,
@@ -547,6 +547,7 @@ def test_resolves_index(
     search_controller.query_media(
         strategy="search",
         search_params=serializer,
+        collection_params=None,
         ip=0,
         origin_index=origin_index,
         exact_index=False,
@@ -615,6 +616,7 @@ def test_no_post_process_results_recursion(
     results, _, _, _ = search_controller.query_media(
         strategy="search",
         search_params=serializer,
+        collection_params=None,
         ip=0,
         origin_index=image_media_type_config.origin_index,
         exact_index=True,
@@ -754,6 +756,7 @@ def test_post_process_results_recurses_as_needed(
     results, _, _, _ = search_controller.query_media(
         strategy="search",
         search_params=serializer,
+        collection_params=None,
         ip=0,
         origin_index=image_media_type_config.origin_index,
         exact_index=True,

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -273,7 +273,7 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
             {"source": "flickr", "creator": "nasa"},
             [
                 {"term": {"source": "flickr"}},
-                {"term": {"creator": "nasa"}},
+                {"term": {"creator.keyword": "nasa"}},
             ],
             id="filter_by_creator",
         ),

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -256,12 +256,12 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
     [
         pytest.param(
             {"tag": "art"},
-            [{"term": {"tags.name": "art"}}],
+            [{"term": {"tags.name.keyword": "art"}}],
             id="filter_by_tag",
         ),
         pytest.param(
             {"tag": "art, photography"},
-            [{"term": {"tags.name": "art, photography"}}],
+            [{"term": {"tags.name.keyword": "art, photography"}}],
             id="filter_by_tag_treats_punctuation_as_part_of_tag",
         ),
         pytest.param(

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -1,6 +1,7 @@
 from django.core.cache import cache
 
 import pytest
+from elasticsearch_dsl import Q
 
 from api.controllers import search_controller
 
@@ -23,7 +24,7 @@ def excluded_providers_cache():
 def test_create_search_query_empty(media_type_config):
     serializer = media_type_config.search_request_serializer(data={})
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -39,7 +40,7 @@ def test_create_search_query_empty_no_ranking(media_type_config, settings):
     settings.USE_RANK_FEATURES = False
     serializer = media_type_config.search_request_serializer(data={})
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -51,7 +52,7 @@ def test_create_search_query_empty_no_ranking(media_type_config, settings):
 def test_create_search_query_q_search_no_filters(media_type_config):
     serializer = media_type_config.search_request_serializer(data={"q": "cat"})
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -83,7 +84,7 @@ def test_create_search_query_q_search_with_quotes_adds_exact_suffix(media_type_c
         data={"q": '"The cutest cat"'}
     )
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -127,7 +128,7 @@ def test_create_search_query_q_search_with_filters(image_media_type_config):
         }
     )
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -169,7 +170,7 @@ def test_create_search_query_non_q_query(image_media_type_config):
         }
     )
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     assert actual_query_clauses == {
@@ -200,7 +201,7 @@ def test_create_search_query_q_search_license_license_type_creates_2_terms_filte
         }
     )
     serializer.is_valid(raise_exception=True)
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
     first_license_terms_filter = actual_query_clauses["filter"][0]
@@ -235,7 +236,7 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
     serializer = image_media_type_config.search_request_serializer(data={})
     serializer.is_valid(raise_exception=True)
 
-    search_query = search_controller.create_search_query(serializer)
+    search_query = search_controller.build_search_query(serializer)
 
     actual_query_clauses = search_query.to_dict()["bool"]
     assert actual_query_clauses == {
@@ -248,3 +249,44 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
             {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}
         ],
     }
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_query_filter"),
+    [
+        pytest.param(
+            {"tag": "art"},
+            [{"term": {"tags.name": "art"}}],
+            id="filter_by_tag",
+        ),
+        pytest.param(
+            {"tag": "art, photography"},
+            [{"term": {"tags.name": "art, photography"}}],
+            id="filter_by_tag_treats_punctuation_as_part_of_tag",
+        ),
+        pytest.param(
+            {"source": "flickr"},
+            [{"term": {"source": "flickr"}}],
+            id="filter_by_source",
+        ),
+        pytest.param(
+            {"source": "flickr", "creator": "nasa"},
+            [
+                {"term": {"source": "flickr"}},
+                {"term": {"creator": "nasa"}},
+            ],
+            id="filter_by_creator",
+        ),
+    ],
+)
+def test_build_collection_query(image_media_type_config, data, expected_query_filter):
+    serializer = image_media_type_config.search_request_serializer(data={})
+    serializer.is_valid(raise_exception=True)
+    actual_query = search_controller.build_collection_query(serializer, data)
+    expected_query = Q(
+        "bool",
+        filter=expected_query_filter,
+        must_not=[{"term": {"mature": True}}],
+    )
+
+    assert actual_query == expected_query

--- a/api/test/unit/models/test_media_report.py
+++ b/api/test/unit/models/test_media_report.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Literal, Union
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -21,8 +20,6 @@ from api.models.media import (
 
 
 pytestmark = pytest.mark.django_db
-
-MediaType = Union[Literal["audio"], Literal["image"]]
 
 reason_params = pytest.mark.parametrize("reason", [DMCA, MATURE, OTHER])
 

--- a/api/test/unit/serializers/test_media_serializers.py
+++ b/api/test/unit/serializers/test_media_serializers.py
@@ -195,17 +195,17 @@ def test_index_is_only_set_if_authenticated(
     mock_es.indices.exists.return_value = True
 
     request = authed_request if authenticated else anon_request
-    serializer = MediaSearchRequestSerializer(
-        data={"internal__index": "some-index"}, context={"request": request}
+    serializer = ImageSearchRequestSerializer(
+        data={"internal__index": "image-some-index"}, context={"request": request}
     )
     assert serializer.is_valid()
     assert serializer.validated_data.get("index") == (
-        "some-index" if authenticated else None
+        "image-some-index" if authenticated else None
     )
 
     if authenticated:
         # If authenticated, we should have checked that the index exists.
-        mock_es.indices.exists.assert_called_with("some-index")
+        mock_es.indices.exists.assert_called_with("image-some-index")
     else:
         # If not authenticated, the validator quickly returns ``None``.
         mock_es.indices.exists.assert_not_called()
@@ -215,12 +215,12 @@ def test_index_is_only_set_if_authenticated(
 @patch("django.conf.settings.ES")
 @pytest.mark.parametrize(
     "index, is_valid",
-    (("index-that-exists", True), ("index-that-does-not-exist", False)),
+    (("image-index-that-exists", True), ("image-index-that-does-not-exist", False)),
 )
 def test_index_is_only_set_if_valid(mock_es, index, is_valid, authed_request):
     mock_es.indices.exists = lambda index: "exists" in index
 
-    serializer = MediaSearchRequestSerializer(
+    serializer = ImageSearchRequestSerializer(
         data={"internal__index": index}, context={"request": authed_request}
     )
     assert serializer.is_valid() == is_valid

--- a/api/test/unit/views/test_media_views.py
+++ b/api/test/unit/views/test_media_views.py
@@ -2,6 +2,8 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from rest_framework.response import Response
+
 import pytest
 import pytest_django.asserts
 
@@ -26,7 +28,7 @@ def test_list_query_count(api_client, media_type_config):
     )
     with patch(
         "api.views.media_views.search_controller",
-        search=MagicMock(return_value=controller_ret),
+        query_media=MagicMock(return_value=controller_ret),
     ), patch(
         "api.serializers.media_serializers.search_controller",
         get_sources=MagicMock(return_value={}),
@@ -47,6 +49,36 @@ def test_retrieve_query_count(api_client, media_type_config):
         res = api_client.get(f"/v1/{media_type_config.url_prefix}/{media.identifier}/")
 
     assert res.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "path, expected_params",
+    [
+        pytest.param("tag/cat/", {"tag": "cat"}, id="tag"),
+        pytest.param("source/flickr/", {"source": "flickr"}, id="source"),
+        pytest.param(
+            "source/flickr/creator/cat/",
+            {"source": "flickr", "creator": "cat"},
+            id="source_creator",
+        ),
+    ],
+)
+def test_collection_parameters(path, expected_params, api_client):
+    mock_get_media_results = MagicMock(return_value=Response())
+
+    with patch(
+        "api.views.media_views.MediaViewSet.get_media_results",
+        new_callable=lambda: mock_get_media_results,
+    ) as mock_get_media_results:
+        api_client.get(f"/v1/images/{path}")
+
+    actual_params = mock_get_media_results.call_args[0][3]
+    request_kind = mock_get_media_results.call_args[0][1]
+
+    assert mock_get_media_results.called
+    assert actual_params == expected_params
+    assert request_kind == "collection"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2849 by @obulat
Fixes #2850 by @obulat

## Note
This PR was changed a lot after reviews, mainly removing the query parameters, so I wrote a new description in [this comment](https://github.com/WordPress/openverse/pull/2853#issuecomment-1747352637). The old description is left here for the record.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the endpoints for additional search views for both audio and image. The endpoints start with `/v1/images` or `/v1/audio`:
- **Tag** view: `/tag/tag_name`
- **Source** view: `/source/source_name`
- **Creator** view: `/source/source_name/creator/creator_name`.
These endpoints return paginated results because they accept `page` query parameter. They also support query parameters such as `license`, `license_type`, `category`,  [image-only] `aspect_ratio`, `size`, [audio-only] `length`, `peaks`. Currently, the frontend plans and designs do not allow for querying the collections using these filter parameters, but we can add this feature later.

To enable this feature, I had to refactor the media serializers and the search controller.

### Search controller
 I extracted functions that are common for both the collection and search requests.
Both the `collection`s and the `search` endpoints now call the `search_controller.query_media` function. `query_media` builds the relevant query (collection or search), sets up other search parameters, executes the search, tallies the results and builds the search context.
The new `build_collection_query` creates a query from a dictionary of the possible query predicates (`filter`, `must_not`, `should` and `must` dictionaries). All of these dictionaries are then combined with a `Bool` query. This makes the query much less nested than the query that we currently create in the `search` method in the `search_controller`.

### Serializers
This PR adds a `MediaCollectionRequestSerializer` to allow for filtering the collections using the filters such as `license` or `category`. This would allow us to make large collections easier to browse by various criteria such as the license or category.

This new serializer reuses some common functionality from the `MediaSearchRequestSerializer`. To make it possible, I had to extract the common functionality into `MediaListRequestSerializer`.

### Sorting of the results
The results are sorted by `created_on`. The tag results also add the boost for `unstable__authority` (for the authorized requests).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app using `just up`.
Try various collection routes:
1. http://localhost:50280/v1/images/source/stocksnap (source collection, only the sources that are present in the sample data can be used to test locally)
1. http://localhost:50280/v1/images/source/flickr/creator/Manzabar/ (creator collection)
1. http://localhost:50280/v1/images/tag/cat (tag collection, images)
1. http://localhost:50280/v1/audio/tag/birds (tag collection, audio)
1. http://localhost:50280/v1/audio/tag/birds/?extension=flac (additional query parameter)
1. http://localhost:50280/v1/images/source/flickr/?page=2 (second page of results)

Try the routes that should return errors:
1. http://localhost:50280/v1/images/source/met (We don't have anything from `met` in the sample data, so the source validator throws an error
1. http://localhost:50280/v1/images/source/flickr,stocksnap (The path parameters are not split by a comma, so only a single parameter is allowed)

If there are no items corresponding to the requested values, the empty collection can be returned:
http://localhost:50280/v1/images/source/flickr/creator/Manzaba/ (the creator name is missing the last `r` letter)

Since the image and audio search had to be modified, too, check that they work as expected (the CI should check that, too).



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
