### PR TITLE
Add blurring to the global audio player

### DIFF
--- a/frontend/src/components/VAudioTrack/layouts/VGlobalLayout.vue
+++ b/frontend/src/components/VAudioTrack/layouts/VGlobalLayout.vue
@@ -9,8 +9,9 @@
       <VLink
         :href="`/audio/${audio.id}`"
         class="hover-underline absolute inset-x-0 top-[10.5px] z-10 line-clamp-2 flex flex-row items-center justify-between px-4 pe-12 text-sr font-semibold text-dark-charcoal"
+        :class="{ 'blur-text': shouldBlur }"
       >
-        {{ audio.title }}
+        {{ shouldBlur ? $t("sensitiveContent.title.audio") : audio.title }}
       </VLink>
 
       <slot name="controller" :usable-frac="0.5" />
@@ -22,6 +23,8 @@
 import { defineComponent, PropType } from "vue"
 
 import type { AudioDetail } from "~/types/media"
+
+import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 
 import VAudioThumbnail from "~/components/VAudioThumbnail/VAudioThumbnail.vue"
 import VLink from "~/components/VLink.vue"
@@ -37,6 +40,13 @@ export default defineComponent({
       type: Object as PropType<AudioDetail>,
       required: true,
     },
+  },
+  setup(props) {
+    const { isHidden: shouldBlur } = useSensitiveMedia(props.audio)
+
+    return {
+      shouldBlur,
+    }
   },
 })
 </script>


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds blurring to the global audio player to cover the scenario described in https://github.com/WordPress/openverse/issues/377#issuecomment-1686558423.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR and run the dev server.
1. Enable the following flags from `/preferences`.
   - `fake_sensitive`
   - `sensitive_content`
   - `fetch_sensitive`
2. Search for something.
3. Switch to the audio media type so that the row layout of the audio track is shown.
4. Play a blurred track. See that the global audio player is also blurred.
5. Open the blurred track and opt to unblur it.
6. Go back to search results. The global audio player will now be unblurred.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
