### PR TITLE
Revert changes to drop and recreate popularity constants views

### DIFF
--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -83,21 +83,6 @@ def drop_media_matview(
     postgres.run(f"DROP MATERIALIZED VIEW IF EXISTS public.{db_view} CASCADE;")
 
 
-def drop_media_popularity_constants(
-    postgres_conn_id,
-    media_type=IMAGE,
-    constants=IMAGE_POPULARITY_CONSTANTS_VIEW,
-    pg_timeout: float = timedelta(minutes=10).total_seconds(),
-):
-    if media_type == AUDIO:
-        constants = AUDIO_POPULARITY_CONSTANTS_VIEW
-
-    postgres = PostgresHook(
-        postgres_conn_id=postgres_conn_id, default_statement_timeout=pg_timeout
-    )
-    postgres.run(f"DROP MATERIALIZED VIEW IF EXISTS public.{constants} CASCADE;")
-
-
 def drop_media_popularity_relations(
     postgres_conn_id,
     media_type=IMAGE,

--- a/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
+++ b/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
@@ -76,7 +76,7 @@ def create_refresh_popularity_metrics_task_group(
                 "media_type": media_type,
             },
             execution_timeout=execution_timeout,
-            doc="Drops the popularity constants view.",
+            doc=("Drops the popularity constants view."),
         )
 
         create_constants = PythonOperator(

--- a/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
+++ b/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
@@ -20,8 +20,7 @@ from data_refresh.data_refresh_types import DataRefresh
 
 GROUP_ID = "refresh_popularity_metrics_and_constants"
 UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID = "update_media_popularity_metrics_table"
-DROP_MEDIA_POPULARITY_CONSTANTS_TASK_ID = "drop_media_popularity_constants_view"
-CREATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID = "create_media_popularity_constants_view"
+UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID = "update_media_popularity_constants_view"
 
 
 def create_refresh_popularity_metrics_task_group(
@@ -68,33 +67,22 @@ def create_refresh_popularity_metrics_task_group(
             },
         )
 
-        drop_constants = PythonOperator(
-            task_id=DROP_MEDIA_POPULARITY_CONSTANTS_TASK_ID,
-            python_callable=sql.drop_media_popularity_constants,
-            op_kwargs={
-                "postgres_conn_id": POSTGRES_CONN_ID,
-                "media_type": media_type,
-            },
-            execution_timeout=execution_timeout,
-            doc=("Drops the popularity constants view."),
-        )
-
-        create_constants = PythonOperator(
-            task_id=CREATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID,
-            python_callable=sql.create_media_popularity_constants_view,
+        update_constants = PythonOperator(
+            task_id=UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID,
+            python_callable=sql.update_media_popularity_constants,
             op_kwargs={
                 "postgres_conn_id": POSTGRES_CONN_ID,
                 "media_type": media_type,
             },
             execution_timeout=execution_timeout,
             doc=(
-                "Recreates the popularity constants view. This completely "
+                "Updates the popularity constants view. This completely "
                 "recalculates the popularity constants for each provider."
             ),
         )
 
-        recreate_constants_status = PythonOperator(
-            task_id=f"report_{CREATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID}_status",
+        update_constants_status = PythonOperator(
+            task_id=f"report_{UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID}_status",
             python_callable=reporting.report_status,
             op_kwargs={
                 "media_type": media_type,
@@ -104,7 +92,7 @@ def create_refresh_popularity_metrics_task_group(
             },
         )
 
-        update_metrics >> [drop_constants, update_metrics_status]
-        drop_constants >> create_constants >> recreate_constants_status
+        update_metrics >> [update_constants, update_metrics_status]
+        update_constants >> update_constants_status
 
     return refresh_all_popularity_data


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

### Background

#2841 modified the popularity and data refreshes to drop and recreate the popularity constants matviews, rather than refreshing them. This was done to address the matview refresh timing out, since a similar strategy had previously worked for the media matviews.

### Problem

I neglected to realize that this is not possible for the _constants_ matviews, because regular provider DAGs now calculate popularity at ingestion and use this view to do so. Consequently, provider DAGs are failing while the view is being rebuilt.

### Fix

This PR reverts the changes to drop and recreate the popularity constants matview. Notably, this means we may start to see issues with the refresh taking a very long time again. **The popularity steps are about to be removed from the data refresh DAG, so data refreshes will not be affected. Only popularity refreshes, which are permitted to take much longer, will be affected. This will give us time to investigate other optimizations.**

Actions that must be taken:
* Wait until the current image popularity refresh DagRun passes the `create_media_popularity_constants_view` step, finishing creating the view that was dropped
* Merge this PR
* Retry all failed DAGs
* Merge changes to remove popularity steps from the data refreshes (drafted in #2818)
* Turn the image data refresh back on
* Observe the behavior of the view refresh in the popularity DAGs and investigate optimizations or extend timeouts.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the data refreshes and popularity refreshes and ensure they work. Observe the DAG graphs and see that the popularity constants views are NOT dropped and then recreated, but instead refreshed.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
