### PR TITLE
Remove popularity constants view

### DIFF
--- a/catalog/dags/common/popularity/constants.py
+++ b/catalog/dags/common/popularity/constants.py
@@ -1,8 +1,6 @@
 IMAGE_VIEW_NAME = "image_view"
 AUDIO_VIEW_NAME = "audio_view"
 AUDIOSET_VIEW_NAME = "audioset_view"
-IMAGE_POPULARITY_CONSTANTS_VIEW = "image_popularity_constants"
-AUDIO_POPULARITY_CONSTANTS_VIEW = "audio_popularity_constants"
 IMAGE_POPULARITY_PERCENTILE_FUNCTION = "image_popularity_percentile"
 AUDIO_POPULARITY_PERCENTILE_FUNCTION = "audio_popularity_percentile"
 STANDARDIZED_IMAGE_POPULARITY_FUNCTION = "standardized_image_popularity"

--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -230,11 +230,7 @@ def calculate_media_popularity_percentile_value(
         """
     )
 
-    raw_percentile_value = postgres.run(
-        calculate_new_percentile_value_query, handler=_single_value
-    )
-
-    return raw_percentile_value
+    return postgres.run(calculate_new_percentile_value_query, handler=_single_value)
 
 
 @task

--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -28,8 +28,7 @@ IMAGE_VIEW_PROVIDER_FID_IDX = "image_view_provider_fid_idx"
 AUDIO_VIEW_PROVIDER_FID_IDX = "audio_view_provider_fid_idx"
 
 # Column name constants
-RAW_VALUE = "raw_value"
-VALUE = "value"
+VALUE = "val"
 CONSTANT = "constant"
 FID = col.FOREIGN_ID.db_name
 IDENTIFIER = col.IDENTIFIER.db_name
@@ -62,7 +61,6 @@ POPULARITY_METRICS_TABLE_COLUMNS = [
     Column(name=PARTITION, definition="character varying(80) PRIMARY KEY"),
     Column(name=METRIC, definition="character varying(80)"),
     Column(name=PERCENTILE, definition="float"),
-    Column(name=RAW_VALUE, definition="float"),
     Column(name=VALUE, definition="float"),
     Column(name=CONSTANT, definition="float"),
 ]
@@ -182,7 +180,7 @@ def update_media_popularity_metrics(
     updates_string = ",\n          ".join(
         f"{c}=EXCLUDED.{c}"
         for c in column_names
-        if c not in [PARTITION, CONSTANT, "val"]
+        if c not in [PARTITION, CONSTANT, VALUE]
     )
     popularity_metric_inserts = _get_popularity_metric_insert_values_string(
         popularity_metrics
@@ -275,8 +273,7 @@ def update_percentile_and_constants_values_for_provider(
     update_constant_query = dedent(
         f"""
         UPDATE public.{popularity_metrics_table}
-        SET {RAW_VALUE}={raw_percentile_value}, {VALUE} = {percentile_value},
-          {CONSTANT} = {new_constant}
+        SET {VALUE} = {percentile_value}, {CONSTANT} = {new_constant}
         WHERE {col.PROVIDER.db_name} = '{provider}';
         """
     )
@@ -338,7 +335,7 @@ def _format_popularity_metric_insert_tuple_string(
     percentile,
 ):
     # Default null val and constant
-    return f"('{provider}', '{metric}', {percentile}, null, null, null)"
+    return f"('{provider}', '{metric}', {percentile}, null, null)"
 
 
 def create_media_popularity_percentile_function(

--- a/catalog/dags/common/popularity/sql.py
+++ b/catalog/dags/common/popularity/sql.py
@@ -15,7 +15,7 @@ from common.popularity.constants import (
     STANDARDIZED_AUDIO_POPULARITY_FUNCTION,
     STANDARDIZED_IMAGE_POPULARITY_FUNCTION,
 )
-from common.sql import PostgresHook
+from common.sql import PostgresHook, _single_value
 from common.storage import columns as col
 from common.storage.db_columns import AUDIO_TABLE_COLUMNS, IMAGE_TABLE_COLUMNS
 
@@ -28,8 +28,8 @@ IMAGE_VIEW_PROVIDER_FID_IDX = "image_view_provider_fid_idx"
 AUDIO_VIEW_PROVIDER_FID_IDX = "audio_view_provider_fid_idx"
 
 # Column name constants
-RAW_VALUE = "raw_val"
-VALUE = "val"
+RAW_VALUE = "raw_value"
+VALUE = "value"
 CONSTANT = "constant"
 FID = col.FOREIGN_ID.db_name
 IDENTIFIER = col.IDENTIFIER.db_name
@@ -67,8 +67,8 @@ POPULARITY_METRICS_TABLE_COLUMNS = [
     Column(name=CONSTANT, definition="float"),
 ]
 
-# Further refactoring of this type will be done in
-# https://github.com/WordPress/openverse/issues/2678
+# Further refactoring of this nature will be done in
+# https://github.com/WordPress/openverse/issues/2678.
 POPULARITY_METRICS_BY_MEDIA_TYPE = {
     AUDIO: AUDIO_POPULARITY_METRICS,
     IMAGE: IMAGE_POPULARITY_METRICS,
@@ -153,15 +153,6 @@ def create_media_popularity_metrics(
         """
     )
     postgres.run(query)
-
-
-# TODO move this somewhere where it can be reused
-def _single_value(cursor):
-    try:
-        row = cursor.fetchone()
-        return row[0]
-    except Exception as e:
-        raise ValueError("Unable to extract expected row data from cursor") from e
 
 
 @task

--- a/catalog/dags/common/sql.py
+++ b/catalog/dags/common/sql.py
@@ -27,6 +27,14 @@ logger = logging.getLogger(__name__)
 # https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/_api/airflow/providers/postgres/hooks/postgres/index.html#airflow.providers.postgres.hooks.postgres.PostgresHook.copy_expert # noqa
 
 
+def _single_value(cursor):
+    try:
+        row = cursor.fetchone()
+        return row[0]
+    except Exception as e:
+        raise ValueError("Unable to extract expected row data from cursor") from e
+
+
 class PostgresHook(UpstreamPostgresHook):
     """
     PostgresHook that sets the database timeout on any query to match the airflow task

--- a/catalog/dags/data_refresh/dag_factory.py
+++ b/catalog/dags/data_refresh/dag_factory.py
@@ -34,7 +34,7 @@ from common.constants import (
     OPENLEDGER_API_CONN_ID,
     XCOM_PULL_TEMPLATE,
 )
-from common.sql import PGExecuteQueryOperator
+from common.sql import PGExecuteQueryOperator, _single_value
 from data_refresh.data_refresh_task_factory import create_data_refresh_task_group
 from data_refresh.data_refresh_types import DATA_REFRESH_CONFIGS, DataRefresh
 from data_refresh.reporting import report_record_difference

--- a/catalog/dags/data_refresh/dag_factory.py
+++ b/catalog/dags/data_refresh/dag_factory.py
@@ -43,14 +43,6 @@ from data_refresh.reporting import report_record_difference
 logger = logging.getLogger(__name__)
 
 
-def _single_value(cursor):
-    try:
-        row = cursor.fetchone()
-        return row[0]
-    except Exception as e:
-        raise ValueError("Unable to extract expected row data from cursor") from e
-
-
 def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequence[str]):
     """
     Instantiate a DAG for a data refresh.

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -96,6 +96,9 @@ def update_batches(
     task: AbstractOperator = None,
     **kwargs,
 ):
+    if total_row_count == 0:
+        return 0
+
     # Progress is tracked in an Airflow variable. When the task run starts, we resume
     # from the start point set by this variable (defaulted to 0). This prevents the
     # task from starting over at the beginning on retries.

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -7,19 +7,11 @@ from airflow.models.abstractoperator import AbstractOperator
 
 from common import slack
 from common.constants import POSTGRES_CONN_ID
-from common.sql import PostgresHook
+from common.sql import PostgresHook, _single_value
 from database.batched_update import constants
 
 
 logger = logging.getLogger(__name__)
-
-
-def _single_value(cursor):
-    try:
-        row = cursor.fetchone()
-        return row[0]
-    except Exception as e:
-        raise ValueError("Unable to extract expected row data from cursor") from e
 
 
 @task.branch

--- a/catalog/dags/database/recreate_popularity_calculation_dag_factory.py
+++ b/catalog/dags/database/recreate_popularity_calculation_dag_factory.py
@@ -89,20 +89,6 @@ def create_recreate_popularity_calculation_dag(data_refresh: DataRefresh):
             ),
         )
 
-        create_constants_view = PythonOperator(
-            task_id="create_popularity_constants_view",
-            python_callable=sql.create_media_popularity_constants_view,
-            op_kwargs={
-                "postgres_conn_id": POSTGRES_CONN_ID,
-                "media_type": media_type,
-            },
-            execution_timeout=data_refresh.create_pop_constants_view_timeout,
-            doc=(
-                "Create the materialized view with popularity constants for each "
-                "provider, using the percentile function."
-            ),
-        )
-
         create_popularity_function = PythonOperator(
             task_id="create_standardized_popularity_function",
             python_callable=sql.create_standardized_media_popularity_function,
@@ -135,7 +121,6 @@ def create_recreate_popularity_calculation_dag(data_refresh: DataRefresh):
             [drop_relations, drop_functions]
             >> create_metrics_table
             >> [update_metrics_table, create_percentile_function]
-            >> create_constants_view
             >> create_popularity_function
             >> create_matview
         )

--- a/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
+++ b/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
@@ -19,8 +19,8 @@ from data_refresh.data_refresh_types import DataRefresh
 
 
 GROUP_ID = "refresh_popularity_metrics_and_constants"
-UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID = "update_media_popularity_metrics_table"
-UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID = "update_media_popularity_constants_view"
+UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID = "update_media_popularity_metrics"
+UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID = "update_media_popularity_constants"
 
 
 def create_refresh_popularity_metrics_task_group(
@@ -42,18 +42,17 @@ def create_refresh_popularity_metrics_task_group(
     execution_timeout = refresh_config.refresh_metrics_timeout
 
     with TaskGroup(group_id=GROUP_ID) as refresh_all_popularity_data:
-        # TODO explain exactly what this does since this is now too vague
         update_metrics = sql.update_media_popularity_metrics.override(
             task_id=UPDATE_MEDIA_POPULARITY_METRICS_TASK_ID,
             execution_timeout=execution_timeout,
-            doc=(
-                "Updates the metrics and target percentiles. If a popularity"
-                " metric is configured for a new provider, this step will add it"
-                " to the metrics table."
-            ),
         )(
             postgres_conn_id=POSTGRES_CONN_ID,
             media_type=media_type,
+        )
+        update_metrics.doc = (
+            "Updates the metrics and target percentiles. If a popularity"
+            " metric is configured for a new provider, this step will add it"
+            " to the metrics table."
         )
 
         update_metrics_status = PythonOperator(
@@ -63,22 +62,49 @@ def create_refresh_popularity_metrics_task_group(
                 "media_type": media_type,
                 "dag_id": refresh_config.dag_id,
                 "message": "Popularity metrics update complete | "
-                "_Next: popularity constants view update_",
+                "_Next: popularity constants update_",
             },
         )
 
         # For each provider that supports popularity data for this media type,
         # recalculate the percentile value used to generate the constant.
-        update_vals = sql.update_percentile_and_constants_for_provider.partial(
-            postgres_conn_id=POSTGRES_CONN_ID,
-            media_type=media_type,
-        ).expand(
-            provider=[
-                provider
-                for provider in sql.POPULARITY_METRICS_BY_MEDIA_TYPE[media_type].keys()
-            ]
+        update_constants = (
+            sql.update_percentile_and_constants_for_provider.override(
+                group_id=UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID,
+            )
+            .partial(
+                postgres_conn_id=POSTGRES_CONN_ID,
+                media_type=media_type,
+                execution_timeout=execution_timeout,
+            )
+            .expand(
+                provider=[
+                    provider
+                    for provider in sql.POPULARITY_METRICS_BY_MEDIA_TYPE[
+                        media_type
+                    ].keys()
+                ]
+            )
+        )
+        update_constants.doc = (
+            "Recalculate the percentile values and popularity constants"
+            " for each provider, and update them in the metrics table. The"
+            " popularity constants will be used to calculate standardized"
+            " popularity scores."
         )
 
-        update_metrics >> update_metrics_status >> update_vals
+        update_constants_status = PythonOperator(
+            task_id=f"report_{UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID}_status",
+            python_callable=reporting.report_status,
+            op_kwargs={
+                "media_type": media_type,
+                "dag_id": refresh_config.dag_id,
+                "message": "Popularity constants update complete | "
+                "_Next: refresh matview_",
+            },
+        )
+
+        update_metrics >> [update_metrics_status, update_constants]
+        update_constants >> update_constants_status
 
     return refresh_all_popularity_data

--- a/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
+++ b/catalog/dags/popularity/refresh_popularity_metrics_task_factory.py
@@ -66,8 +66,6 @@ def create_refresh_popularity_metrics_task_group(
             },
         )
 
-        # For each provider that supports popularity data for this media type,
-        # recalculate the percentile value used to generate the constant.
         update_constants = (
             sql.update_percentile_and_constants_for_provider.override(
                 group_id=UPDATE_MEDIA_POPULARITY_CONSTANTS_TASK_ID,

--- a/catalog/tests/dags/common/loader/test_sql.py
+++ b/catalog/tests/dags/common/loader/test_sql.py
@@ -37,11 +37,9 @@ def table_info(
     return TableInfo(
         image=image_table,
         image_view=f"image_view_{identifier}",
-        constants=f"image_popularity_constants_{identifier}",
         metrics=f"image_popularity_metrics_{identifier}",
         standardized_popularity=f"standardized_popularity_{identifier}",
         popularity_percentile=f"popularity_percentile_{identifier}",
-        pop_constants_idx=f"test_popularity_constants_{identifier}_idx",
         image_view_idx=f"test_view_id_{identifier}_idx",
         provider_fid_idx=f"test_view_provider_fid_{identifier}_idx",
     )
@@ -84,7 +82,6 @@ def postgres_with_load_and_image_table(
     DROP TABLE IF EXISTS {load_table} CASCADE;
     DROP TABLE IF EXISTS {image_table} CASCADE;
     DROP INDEX IF EXISTS {image_table}_provider_fid_idx;
-    DROP MATERIALIZED VIEW IF EXISTS {table_info.constants} CASCADE;
     DROP TABLE IF EXISTS {table_info.metrics} CASCADE;
     DROP FUNCTION IF EXISTS {table_info.standardized_popularity} CASCADE;
     DROP FUNCTION IF EXISTS {table_info.popularity_percentile} CASCADE;

--- a/catalog/tests/dags/common/popularity/test_sql.py
+++ b/catalog/tests/dags/common/popularity/test_sql.py
@@ -328,8 +328,8 @@ def test_metrics_table_adds_values_and_constants(
     check_query = f"SELECT * FROM {table_info.metrics};"
     postgres_with_image_table.cursor.execute(check_query)
     expect_rows = [
-        ("diff_provider", "comments", 0.8, 50.0, 50.0, 12.5),
-        ("my_provider", "views", 0.5, 50.0, 50.0, 50.0),
+        ("diff_provider", "comments", 0.8, 50.0, 12.5),
+        ("my_provider", "views", 0.5, 50.0, 50.0),
     ]
     sorted_rows = sorted(list(postgres_with_image_table.cursor), key=lambda x: x[0])
     for expect_row, sorted_row in zip(expect_rows, sorted_rows):
@@ -386,8 +386,8 @@ def test_metrics_table_handles_zeros_and_missing_in_constants(
     check_query = f"SELECT * FROM {table_info.metrics};"
     postgres_with_image_table.cursor.execute(check_query)
     expect_rows = [
-        ("diff_provider", "comments", 0.8, None, None, None),
-        ("my_provider", "views", 0.8, 0.0, 1.0, 0.25),
+        ("diff_provider", "comments", 0.8, None, None),
+        ("my_provider", "views", 0.8, 1.0, 0.25),
     ]
     sorted_rows = sorted(list(postgres_with_image_table.cursor), key=lambda x: x[0])
     for expect_row, sorted_row in zip(expect_rows, sorted_rows):

--- a/catalog/tests/dags/common/popularity/test_sql.py
+++ b/catalog/tests/dags/common/popularity/test_sql.py
@@ -21,11 +21,9 @@ POSTGRES_TEST_URI = os.getenv("AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING")
 class TableInfo(NamedTuple):
     image: str
     image_view: str
-    constants: str
     metrics: str
     standardized_popularity: str
     popularity_percentile: str
-    pop_constants_idx: str
     image_view_idx: str
     provider_fid_idx: str
 
@@ -38,11 +36,9 @@ def table_info(
     return TableInfo(
         image=image_table,
         image_view=f"image_view_{identifier}",
-        constants=f"image_popularity_constants_{identifier}",
         metrics=f"image_popularity_metrics_{identifier}",
         standardized_popularity=f"standardized_popularity_{identifier}",
         popularity_percentile=f"popularity_percentile_{identifier}",
-        pop_constants_idx=f"test_popularity_constants_{identifier}_idx",
         image_view_idx=f"test_view_id_{identifier}_idx",
         provider_fid_idx=f"test_view_provider_fid_{identifier}_idx",
     )
@@ -56,7 +52,6 @@ def postgres_with_image_table(table_info):
 
     drop_test_relations_query = f"""
     DROP MATERIALIZED VIEW IF EXISTS {table_info.image_view} CASCADE;
-    DROP MATERIALIZED VIEW IF EXISTS {table_info.constants} CASCADE;
     DROP TABLE IF EXISTS {table_info.metrics} CASCADE;
     DROP TABLE IF EXISTS {table_info.image} CASCADE;
     DROP FUNCTION IF EXISTS {table_info.standardized_popularity} CASCADE;
@@ -89,16 +84,36 @@ USING btree (provider, md5(foreign_identifier));
 
 def _set_up_popularity_metrics(metrics_dict, table_info, mock_pg_hook_task):
     conn_id = POSTGRES_CONN_ID
+    # Create metrics table
     sql.create_media_popularity_metrics(
         postgres_conn_id=conn_id,
         popularity_metrics_table=table_info.metrics,
     )
-    sql.update_media_popularity_metrics(
+    # Insert values from metrics_dict into metrics table
+    sql.update_media_popularity_metrics.function(
         postgres_conn_id=conn_id,
         popularity_metrics=metrics_dict,
         popularity_metrics_table=table_info.metrics,
         task=mock_pg_hook_task,
     )
+
+    # For each provider in metrics_dict, calculate the percentile and then
+    # update the percentile and popularity constant
+    for provider in metrics_dict.keys():
+        percentile_val = sql.calculate_media_popularity_percentile_value.function(
+            postgres_conn_id=conn_id,
+            provider=provider,
+            task=mock_pg_hook_task,
+            popularity_metrics_table=table_info.metrics,
+            popularity_percentile=table_info.popularity_percentile,
+        )
+        sql.update_percentile_and_constants_values_for_provider.function(
+            postgres_conn_id=conn_id,
+            provider=provider,
+            raw_percentile_value=percentile_val,
+            popularity_metrics_table=table_info.metrics,
+            popularity_metrics=metrics_dict,
+        )
 
 
 def _set_up_popularity_percentile_function(table_info):
@@ -117,18 +132,13 @@ def _set_up_popularity_constants(
     table_info,
     mock_pg_hook_task,
 ):
-    conn_id = POSTGRES_CONN_ID
-    _set_up_popularity_percentile_function(table_info)
-    _set_up_popularity_metrics(metrics_dict, table_info, mock_pg_hook_task)
+    # Execute the data query first (typically, loads sample data into the media table)
     pg.cursor.execute(data_query)
     pg.connection.commit()
-    sql.create_media_popularity_constants_view(
-        conn_id,
-        popularity_constants=table_info.constants,
-        popularity_constants_idx=table_info.pop_constants_idx,
-        popularity_metrics=table_info.metrics,
-        popularity_percentile=table_info.popularity_percentile,
-    )
+
+    # Then set up functions, metrics, and constants
+    _set_up_popularity_percentile_function(table_info)
+    _set_up_popularity_metrics(metrics_dict, table_info, mock_pg_hook_task)
 
 
 def _set_up_std_popularity_func(
@@ -150,7 +160,7 @@ def _set_up_std_popularity_func(
         conn_id,
         mock_pg_hook_task,
         function_name=table_info.standardized_popularity,
-        popularity_constants=table_info.constants,
+        popularity_metrics=table_info.metrics,
     )
 
 
@@ -270,7 +280,7 @@ def test_popularity_percentile_function_nones_when_missing_type(
     assert actual_percentile_val is None
 
 
-def test_constants_view_adds_values_and_constants(
+def test_metrics_table_adds_values_and_constants(
     postgres_with_image_table, table_info, mock_pg_hook_task
 ):
     data_query = dedent(
@@ -315,7 +325,7 @@ def test_constants_view_adds_values_and_constants(
         postgres_with_image_table, data_query, metrics, table_info, mock_pg_hook_task
     )
 
-    check_query = f"SELECT * FROM {table_info.constants};"
+    check_query = f"SELECT * FROM {table_info.metrics};"
     postgres_with_image_table.cursor.execute(check_query)
     expect_rows = [
         ("diff_provider", "comments", 0.8, 50.0, 50.0, 12.5),
@@ -326,7 +336,7 @@ def test_constants_view_adds_values_and_constants(
         assert expect_row == pytest.approx(sorted_row)
 
 
-def test_constants_view_handles_zeros_and_missing(
+def test_metrics_table_handles_zeros_and_missing_in_constants(
     postgres_with_image_table, table_info, mock_pg_hook_task
 ):
     data_query = dedent(
@@ -364,14 +374,16 @@ def test_constants_view_handles_zeros_and_missing(
         """
     )
     metrics = {
+        # Provider that has some records with popularity data
         "my_provider": {"metric": "views", "percentile": 0.8},
+        # Provider that has a metric configured, but no records with data for that metric
         "diff_provider": {"metric": "comments", "percentile": 0.8},
     }
     _set_up_popularity_constants(
         postgres_with_image_table, data_query, metrics, table_info, mock_pg_hook_task
     )
 
-    check_query = f"SELECT * FROM {table_info.constants};"
+    check_query = f"SELECT * FROM {table_info.metrics};"
     postgres_with_image_table.cursor.execute(check_query)
     expect_rows = [
         ("diff_provider", "comments", 0.8, None, None, None),
@@ -417,7 +429,7 @@ def test_get_providers_with_popularity_data_for_media_type(
 
     expected_providers = ["diff_provider", "my_provider"]
     actual_providers = sql.get_providers_with_popularity_data_for_media_type(
-        POSTGRES_CONN_ID, media_type="image", constants_view=table_info.constants
+        POSTGRES_CONN_ID, media_type="image", popularity_metrics=table_info.metrics
     )
 
     assert actual_providers == expected_providers
@@ -456,7 +468,7 @@ def test_standardized_popularity_function_calculates(
     _set_up_std_popularity_func(
         postgres_with_image_table, data_query, metrics, table_info, mock_pg_hook_task
     )
-    check_query = f"SELECT * FROM {table_info.constants};"
+    check_query = f"SELECT * FROM {table_info.metrics};"
     postgres_with_image_table.cursor.execute(check_query)
     print(list(postgres_with_image_table.cursor))
     arg_list = [

--- a/docker/upstream_db/0004_openledger_image_view.sql
+++ b/docker/upstream_db/0004_openledger_image_view.sql
@@ -1,7 +1,10 @@
 CREATE TABLE public.image_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
-  percentile float
+  percentile float,
+  raw_val float,
+  val float,
+  constant float
 );
 
 
@@ -30,19 +33,6 @@ $$
 LANGUAGE SQL
 STABLE
 RETURNS NULL ON NULL INPUT;
-
-
-CREATE MATERIALIZED VIEW public.image_popularity_constants AS
-  WITH popularity_metric_values AS (
-    SELECT
-    *,
-    image_popularity_percentile(provider, metric, percentile) AS val
-    FROM image_popularity_metrics
-  )
-  SELECT *, ((1 - percentile) / percentile) * val AS constant
-  FROM popularity_metric_values;
-
-CREATE UNIQUE INDEX ON image_popularity_constants (provider);
 
 
 CREATE FUNCTION standardized_image_popularity(provider text, meta_data jsonb)

--- a/docker/upstream_db/0004_openledger_image_view.sql
+++ b/docker/upstream_db/0004_openledger_image_view.sql
@@ -2,7 +2,6 @@ CREATE TABLE public.image_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  raw_value float,
   value float,
   constant float
 );

--- a/docker/upstream_db/0004_openledger_image_view.sql
+++ b/docker/upstream_db/0004_openledger_image_view.sql
@@ -2,8 +2,8 @@ CREATE TABLE public.image_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  raw_val float,
-  val float,
+  raw_value float,
+  value float,
   constant float
 );
 

--- a/docker/upstream_db/0004_openledger_image_view.sql
+++ b/docker/upstream_db/0004_openledger_image_view.sql
@@ -38,7 +38,7 @@ RETURNS NULL ON NULL INPUT;
 CREATE FUNCTION standardized_image_popularity(provider text, meta_data jsonb)
 RETURNS FLOAT AS $$
   SELECT ($2->>metric)::FLOAT / (($2->>metric)::FLOAT + constant)
-  FROM image_popularity_constants WHERE provider=$1;
+  FROM image_popularity_metrics WHERE provider=$1;
 $$
 LANGUAGE SQL
 STABLE

--- a/docker/upstream_db/0004_openledger_image_view.sql
+++ b/docker/upstream_db/0004_openledger_image_view.sql
@@ -2,7 +2,7 @@ CREATE TABLE public.image_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  value float,
+  val float,
   constant float
 );
 

--- a/docker/upstream_db/0007_openledger_audio_view.sql
+++ b/docker/upstream_db/0007_openledger_audio_view.sql
@@ -2,7 +2,7 @@ CREATE TABLE public.audio_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  value float,
+  val float,
   constant float
 );
 

--- a/docker/upstream_db/0007_openledger_audio_view.sql
+++ b/docker/upstream_db/0007_openledger_audio_view.sql
@@ -2,8 +2,8 @@ CREATE TABLE public.audio_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  raw_val float,
-  val float,
+  raw_value float,
+  value float,
   constant float
 );
 

--- a/docker/upstream_db/0007_openledger_audio_view.sql
+++ b/docker/upstream_db/0007_openledger_audio_view.sql
@@ -32,7 +32,7 @@ RETURNS NULL ON NULL INPUT;
 CREATE FUNCTION standardized_audio_popularity(provider text, meta_data jsonb)
 RETURNS FLOAT AS $$
   SELECT ($2->>metric)::FLOAT / (($2->>metric)::FLOAT + constant)
-  FROM audio_popularity_constants WHERE provider=$1;
+  FROM audio_popularity_metrics WHERE provider=$1;
 $$
 LANGUAGE SQL
 STABLE

--- a/docker/upstream_db/0007_openledger_audio_view.sql
+++ b/docker/upstream_db/0007_openledger_audio_view.sql
@@ -2,7 +2,6 @@ CREATE TABLE public.audio_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
   percentile float,
-  raw_value float,
   value float,
   constant float
 );

--- a/docker/upstream_db/0007_openledger_audio_view.sql
+++ b/docker/upstream_db/0007_openledger_audio_view.sql
@@ -1,7 +1,10 @@
 CREATE TABLE public.audio_popularity_metrics (
   provider character varying(80) PRIMARY KEY,
   metric character varying(80),
-  percentile float
+  percentile float,
+  raw_val float,
+  val float,
+  constant float
 );
 
 
@@ -24,19 +27,6 @@ $$
 LANGUAGE SQL
 STABLE
 RETURNS NULL ON NULL INPUT;
-
-
-CREATE MATERIALIZED VIEW public.audio_popularity_constants AS
-  WITH popularity_metric_values AS (
-    SELECT
-    *,
-    audio_popularity_percentile(provider, metric, percentile) AS val
-    FROM audio_popularity_metrics
-  )
-  SELECT *, ((1 - percentile) / percentile) * val AS constant
-  FROM popularity_metric_values;
-
-CREATE UNIQUE INDEX ON audio_popularity_constants (provider);
 
 
 CREATE FUNCTION standardized_audio_popularity(provider text, meta_data jsonb)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fast fix for urgent production issue.

⚠️ This is a very long PR description, but the goal was for the testing steps to be extremely thorough so it is easy for others to test. The changes are not particularly complicated, but we **do** want to be exhaustive in testing. Please ping me if you need any assistance at all. ⚠️ 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Note: throughout the PR description I sometimes refer only to the tables and views for image for simplicity, but the same is true for audio. This PR's code changes affect both media types, and both should be tested.

### Background and problem

Currently we have an `image_popularity_metrics` table (that contains information like the name of the `metric` field in the `meta_data` column to use for calculating pop scores), and an `image_popularity_constants` **view** which contains all the information from the metrics table, **plus** two calculated fields: a percentile value and popularity constant. The constant is based on the percentile value, and is what ultimately gets used during ingestion/popularity refreshes to calculate standardized popularity.

Currently, when we want to update our popularity constants we **refresh that view.** This process is taking an extremely long time. We cannot drop and recreate the view instead, because the constants need to be available at all times for ingestion (i.e. we can't drop the old constants until the new ones are done being calculated). At any rate, recreating the view is _also_ taking a long time.

## Approach in this PR

This PR addresses the issue by removing the `image_popularity_constants` view, and instead adding the calculated columns directly to the `image_popularity_metrics` table. In production, we will manually hardcode these columns to their last known good values (taken from a snapshot).

Then in the popularity refresh DAG, instead of refreshing the constants view I've added some new tasks that first calculate the percentile value, and then update the metrics table with the new percentile and constant once done. We use the exact same existing SQL functions to calculate the values, but SELECT them individually instead of refreshing the view.

<img width="1333" alt="Screenshot 2023-08-25 at 2 15 54 PM" src="https://github.com/WordPress/openverse/assets/63313398/6f2e605f-c87e-46c9-b094-d4c64c41fabf">

Some benefits of this approach:

* I'm hopeful that this will entirely circumvent whatever performance issues we're having with the materialized view
* If we _do_ continue to see performance issues, they will be much easier to debug because the scope of the investigation is reduced to just the sql functions.
* If we get the constants into a strange state again, we can resolve things **much** more quickly because we can always manually update the constants to their last known values (for example, right now if the view is dropped there is absolutely no way to run ingestion or refreshes until the entire view can be fully recreated. You cannot simply insert into a view.)
* Possibly even a performance improvement because the updates for each provider are done in parallel (although it's definitely possible that the optimizer was already parallelizing this in the matview refresh)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

A note for code review: the code changes are in an area that will be cleaned up in #2678. Some things follow the existing conventions for now, because I wanted to keep this change as small as possible.

We need to test local env and the process for updating on production.

### Local env

Run `just recreate` on this branch to make sure you have the schema changes and our sample data. In `just catalog/pgcli`:

```sql
-- Verify the constants view is gone (this should fail)
> describe image_popularity_constants;

-- Observe that by default you have no calculated constants (valuess for val/constant will all be null)
> select * from image_popularity_metrics;
```

Now run the image popularity refresh DAG and make sure it works.

```sql
-- See that you now have calculated popularity constants. The nulls are for providers we don't
-- have sample data for and are expected
> select * from image_popularity_metrics;
+-----------+--------------------+------------+-----------+--------+--------------------+
| provider  | metric             | percentile | val  | constant           |
|-----------+--------------------+------------+-----------+--------+--------------------|
| nappy     | downloads          | 0.85       | <null> | <null>             |
| rawpixel  | download_count     | 0.85       | <null> | <null>             |
| wikimedia | global_usage_count | 0.85       | <null> | <null>             |
| flickr    | views              | 0.85       | 35.0      | 6.176470588235295  |
| stocksnap | downloads_raw      | 0.85      | 120.0  | 21.176470588235297 |
+-----------+--------------------+------------+-----------+--------+--------------------+
```

Now run the Flickr DAG until it ingests a few 100 records and mark it as a success.

```sql
-- See that the newly ingested records have calculated standardized popularity. Note that a value of 0 is normal, but there
-- should be some records with non-0 scores
openledger> select foreign_identifier, standardized_popularity, updated_on from image where provider = 'flickr' order by updated_on desc limit 10;
+--------------------+-------------------------+-------------------------------+
| foreign_identifier | standardized_popularity | updated_on                    |
|--------------------+-------------------------+-------------------------------|
| 53136893332        | 0.0                     | 2023-08-25 00:26:10.817251+00 |
| 53136895092        | 0.0                     | 2023-08-25 00:26:10.817251+00 |
| 53136897297        | 0.39306358381502887     | 2023-08-25 00:26:10.817251+00 |
| 53136898092        | 0.32692307692307687     | 2023-08-25 00:26:10.817251+00 |
| 53136900057        | 0.0                     | 2023-08-25 00:26:10.817251+00 |
| 53136901057        | 0.0                     | 2023-08-25 00:26:10.817251+00 |
| 53136901902        | 0.0                     | 2023-08-25 00:26:10.817251+00 |
| 53136908212        | 0.8601864181091877      | 2023-08-25 00:26:10.817251+00 |
| 53136910592        | 0.7953216374269005      | 2023-08-25 00:26:10.817251+00 |
| 53136879167        | 0.32692307692307687     | 2023-08-25 00:26:10.817251+00 |
+--------------------+-------------------------+-------------------------------+
```

To be very thorough, you can also run the `image_popularity_refresh` a second time and then inspect the metrics table to see that the constant and val for flickr were updated (now that we have new records).

Repeat the process for `audio`. I recommend using Jamendo when you get to the step about running a provider DAG. These were the values I got after running a popularity refresh with audio on just the sample data:

```sql
+-----------------+--------------------+------------+-----------+-----------+---------------------+
| provider        | metric             | percentile | val     | constant            |
|-----------------+--------------------+------------+-----------+-----------+---------------------|
| wikimedia_audio | global_usage_count | 0.85       | 1.0       | 0.17647058823529416 |
| jamendo         | listens            | 0.85       | 2245028.0 | 396181.41176470596  |
| freesound       | num_downloads      | 0.85       | 34.0      | 6.000000000000002   |
+-----------------+--------------------+------------+-----------+-----------+---------------------+
```

This is **not** necessary for testing this PR, but to be completely safe I personally tested the data refreshes as well. This branch includes all the popularity refresh changes, including #4580 :) 

### Production approach

Merging this PR will not automatically update the tables/views/functions in production. We have to do that manually. To test the process, first checkout main and run `just recreate` to go back to plain sample data and the old schema.

Now run the image and audio popularity refreshes. (There is a bug on `main`, fixed in this PR, where the batched updates error when there are 0 rows to update -- as in nappy, rawpixel, and wikimedia in our sample data. You can ignore these or mark them as successful manually, it doesn't matter). Then in pgcli run `SELECT * FROM public.audio_popularity_constants` and `SELECT * FROM public.image_popularity_constants` and double check that the results look identical to the percentiles/constants calculated for the sample data on this test branch (this helps test that the constants are being calculated the exact same as before).

**We are going to simulate exactly what we will do on production, by first running these queries on our local copy of `main`. Then we'll check out this branch _without_ doing a `recreate`, simulating merging the PR. Bear with me!**

Let's start: while we're still on `main`, run the SQL queries that we'll run on production. I give the queries for both audio and image, with commentary:

```sql
-- Audio

-- Update the metrics table to have the new columns
ALTER TABLE public.audio_popularity_metrics
ADD COLUMN val float,
ADD COLUMN constant float;

-- Insert vals into the metrics table. Here I'm using the vals we got from our sample data, but
-- on production we'll grab the actual percentile vals and constants from a snapshot.
UPDATE public.audio_popularity_metrics AS audio_metrics
SET val = new_vals.val, constant = new_vals.constant
FROM (values
	('wikimedia_audio', 1.0, 0.17647058823529416),
	('jamendo', 2245028.0, 396181.41176470596),
	('freesound', 34.0, 6.000000000000002)
) AS new_vals(provider, val, constant)
WHERE new_vals.provider = audio_metrics.provider;

-- Drop the standardized popularity function so we can recreate it to not rely on the constants
-- view. Note that dropping this function necessarily drops the matview (e.g. audio_view).
-- That's okay because this view is already no longer being used anywhere, and will soon be
-- dropped in an upcoming PR. When applying in prod, though, we should make sure no provider
-- DAGs are currently running since provider DAGs use this function.
DROP FUNCTION IF EXISTS public.standardized_audio_popularity CASCADE;

-- Recreate the standardized popularity function. The only change is that it is grabbing the
-- constant from the metrics table instead of the constants view. 
CREATE OR REPLACE FUNCTION public.standardized_audio_popularity(
 	provider text, meta_data jsonb
) RETURNS FLOAT AS $$
	SELECT ($2->>metric)::float / (($2->>metric)::float + constant)
	FROM public.audio_popularity_metrics WHERE provider=$1;
$$
LANGUAGE SQL
STABLE
RETURNS NULL ON NULL INPUT;

-- Note: we have not dropped the constants view yet!


-- Image. All queries are the same, just with 'image' swapped for 'audio'

ALTER TABLE public.image_popularity_metrics
ADD COLUMN val float,
ADD COLUMN constant float;

UPDATE public.image_popularity_metrics AS image_metrics
 SET val = new_vals.val, constant = new_vals.constant
 FROM (values
     ('flickr', 35.0, 6.176470588235295),
     ('stocksnap', 120.0, 21.176470588235297)
 ) AS new_vals(provider, val, constant)
 WHERE new_vals.provider = image_metrics.provider;

DROP FUNCTION IF EXISTS public.standardized_image_popularity CASCADE;

CREATE OR REPLACE FUNCTION public.standardized_image_popularity(
 	provider text, meta_data jsonb
) RETURNS FLOAT AS $$
	SELECT ($2->>metric)::float / (($2->>metric)::float + constant)
	FROM public.image_popularity_metrics WHERE provider=$1;
$$
LANGUAGE SQL
STABLE
RETURNS NULL ON NULL INPUT;

```

At this point, we have not merged the PR but provider DAGs and data refreshes can already be turned back on in production. DAGs at ingestion are using the constants from the metrics table, and data refreshes have been updated (in another PR) to not do popularity steps, so they're good to go.

The final step is to update the popularity refresh DAGs to update constants in the metrics table, rather than refreshing the view. That change makes it to production by merging this PR. Simulate that by checking out this branch (but do NOT `just recreate`, so you still have the manually edited schema). Run `just up` to pick up changes.

Now in pgcli, we can finally drop the constants views:

```sql
DROP MATERIALIZED VIEW public.audio_popularity_constants;
DROP MATERIALIZED VIEW public.image_popularity_constants;
```

And now try running the image and audio popularity refreshes and ensure they work!




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
