### PR TITLE
Update `just` aliases

### DIFF
--- a/documentation/general/general_setup.md
+++ b/documentation/general/general_setup.md
@@ -97,6 +97,11 @@ If for some reason, you are unable to install `just`, you can refer to the
 commands individually in a terminal. It won't be the best user experience, but
 it will work just the same.
 
+We also recommend setting up
+[shell completions](https://github.com/casey/just#shell-completion-scripts) for
+`just` to make it faster to find and run recipes. On macOS with the default Z
+shell, Homebrew installs completions for `just` by default.
+
 ## Conditional setup
 
 A subset of the following requirements will be required depending on the extent

--- a/justfile
+++ b/justfile
@@ -234,7 +234,11 @@ deploy:
 
 alias b := build
 alias d := down
-alias l := logs
+alias l := lint
+
+alias L := logs
+alias P := precommit
+alias I := install
 
 # alias for `just api/up`
 a:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #771 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- changes the alias `l` to be `lint`, which is arguably more commonly used than `logs`
- adds uppercase aliases `P`, `L` and `I` for `precommit`, `logs` and `install` respectively
- documents installing shell completions for `just` which enables <kbd>Tab</kbd> completion for recipe names and `just` flags
  - to some extent (save for the additional <kbd>Tab</kbd>) this makes each unambiguous substring of the recipe name an alias for it

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Read the updated docs.
1. Install shell completion for `just`.
2. Test <kbd>Tab</kbd> completion for `just` recipes and CLI flags.
3. Check that the updated aliases work as expected.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
