### PR TITLE
Simplify, improve and document the i18n pipeline

### DIFF
--- a/documentation/frontend/guides/index.md
+++ b/documentation/frontend/guides/index.md
@@ -8,4 +8,5 @@ deploy
 test
 analytics
 icons
+translate
 ```

--- a/documentation/frontend/guides/translate.md
+++ b/documentation/frontend/guides/translate.md
@@ -2,7 +2,7 @@
 
 ## Fallbacks
 
-If the translation for a string is missing, the list of fallback language will
+If the translation for a string is missing, the list of fallback languages will
 be checked, in order, for a translation. If one is found, it will be used. If
 none is found, the final fallback, which is English will be used to render the
 text.

--- a/documentation/frontend/guides/translate.md
+++ b/documentation/frontend/guides/translate.md
@@ -1,0 +1,33 @@
+# Translate
+
+## Fallbacks
+
+If the translation for a string is missing, the list of fallback language will
+be checked, in order, for a translation. If one is found, it will be used. If
+none is found, the final fallback, which is English will be used to render the
+text.
+
+For example, _Español de México_ / Spanish (Mexico) falls back to _Español_ /
+Spanish (Spain) as the latter has a higher translation coverage.
+
+If you know that a particular language is compatible with another with higher
+translation coverage, you can modify the fallback chain defined in the
+`frontend/src/locales/scripts/locale-fallback.json` file, and submit a PR.
+
+Going back to the same example, it would be defined in the fallback file as
+follows.
+
+```json
+{
+  "es-mx": ["es"]
+}
+```
+
+English is the final fallback for all languages as it always has 100% coverage.
+You need not define it explicitly as it's specified as the default.
+
+```json
+{
+  "default": ["en"]
+}
+```

--- a/documentation/frontend/reference/i18n.md
+++ b/documentation/frontend/reference/i18n.md
@@ -1,8 +1,8 @@
-# Internationalisation
+# Internationalization
 
 The frontend uses Nuxt's [i18n module](https://i18n.nuxtjs.org/) to support
-[internationalisation](https://developer.mozilla.org/en-US/docs/Glossary/I18N),
-enabling localisation of the user interface.
+[internationaliation](https://developer.mozilla.org/en-US/docs/Glossary/I18N),
+enabling localization of the user interface.
 
 WordPress uses GlotPress for managing translations, which is built on top of the
 [`gettext` standard](https://www.gnu.org/software/gettext/). On the other hand,

--- a/documentation/frontend/reference/i18n.md
+++ b/documentation/frontend/reference/i18n.md
@@ -1,7 +1,7 @@
 # Internationalization
 
 The frontend uses Nuxt's [i18n module](https://i18n.nuxtjs.org/) to support
-[internationaliation](https://developer.mozilla.org/en-US/docs/Glossary/I18N),
+[internationalization](https://developer.mozilla.org/en-US/docs/Glossary/I18N),
 enabling localization of the user interface.
 
 WordPress uses GlotPress for managing translations, which is built on top of the

--- a/documentation/frontend/reference/i18n.md
+++ b/documentation/frontend/reference/i18n.md
@@ -1,0 +1,75 @@
+# Internationalisation
+
+The frontend uses Nuxt's [i18n module](https://i18n.nuxtjs.org/) to support
+[internationalisation](https://developer.mozilla.org/en-US/docs/Glossary/I18N),
+enabling localisation of the user interface.
+
+WordPress uses GlotPress for managing translations, which is built on top of the
+[`gettext` standard](https://www.gnu.org/software/gettext/). On the other hand,
+Nuxt (and most JS-based i18n libraries) use
+[JSON](https://kazupon.github.io/vue-i18n/guide/formatting.html) for managing
+translations. This disconnect means that Openverse translations must convert
+from JSON to POT and back again. Hence there is quite a bit of scaffolding
+involved.
+
+## Upload pipeline
+
+This pipeline deals with how translations strings are extracted from the
+frontend application and provided to GlotPress for translation.
+
+### Steps
+
+- Create a POT file from the `en.json5` file.
+
+  **Script:** `i18n:generate-pot`
+
+- Upload this
+  [POT file](https://github.com/WordPress/openverse/blob/translations/openverse.pot)
+  to a fixed URL. Currently the file is hosted in the `translations` branch of
+  the [WordPress/openverse](https://github.com/WordPress/openverse) repo.
+
+- GlotPress presents the strings, fuzzy translations and other helpful context
+  to translators in a web UI to help them provide a translation.
+
+## Download pipeline
+
+This pipeline deals with how translations are retrieved from GlotPress,
+processed and loaded into Nuxt via the Nuxt i18n module.
+
+### Steps
+
+- Parse and extract the list of all locales from GlotPress's PHP source code.
+  Then narrow down the list to locales available in the WP GlotPress instance
+  and populate their coverage percentage from the
+  [GlotPress stats](https://translate.wordpress.org/projects/meta/openverse/).
+
+  The output is written to `wp-locales.json`.
+
+  **Script:** `i18n:create-locales-list`
+
+- Download all translations from GlotPress as JED 1.x JSON files. The flattened
+  JED 1.x (derived from the flattened POT files) files are converted back into
+  the nested JSON as expected by Nuxt i18n.
+
+  This script uses the `wp-locales.json` file for the list of locales, if
+  downloading each locale separately and in parallel.
+
+  **Script:** `i18n:get-translations`
+
+- Separate the locales into three groups based on the JSON files emitted by
+  `i18n:get-translations`.
+
+  - **translated:** JSON file is present with mappings, written to
+    `valid-locales.json`.
+  - **untranslated:** JSON file is present but empty, written to both
+    `valid-locales.json` and `untranslated-locales.json`.
+  - **invalid:** JSON file is not present, written to `invalid-locales.json`.
+
+  **Script:** `i18n:update-locales`
+
+- Pass the list of valid locales (along with extra fields) into the Nuxt i18n
+  module. This is configured in the Nuxt configuration file, `nuxt.config.ts`.
+
+- Pass the fallback locale mappings to the underlying Vue i18n plugin. This is
+  configured in the plugin configuration file,
+  `frontend/src/plugins/vue-i18n.ts`.

--- a/documentation/frontend/reference/index.md
+++ b/documentation/frontend/reference/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :titlesonly:
 
+i18n
 feature_flags
 testing_guidelines
 playwright_tests

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -20,6 +20,7 @@ src/locales/openverse.zip
 src/locales/*.json
 src/locales/scripts/valid-locales.json
 src/locales/scripts/untranslated-locales.json
+src/locales/scripts/invalid-locales.json
 src/locales/scripts/wp-locales.json
 
 # Workspace mock-files

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -93,18 +93,20 @@ const filenames: NonNullable<NuxtConfig["build"]>["filenames"] = {
 
 const openverseLocales = [
   {
-    // unique identifier for the locale in Vue i18n
-    code: "en",
+    /* Nuxt i18n fields */
+
+    code: "en", // unique identifier for the locale in Vue i18n
+    dir: "ltr",
+    file: "en.json",
+    iso: "en", // used for SEO purposes (html lang attribute)
+
+    /* Custom fields */
+
     name: "English",
     nativeName: "English",
-    // ISO code used for SEO purposes (html lang attribute)
-    iso: "en",
-    // wp_locale as found in GlotPress
-    wpLocale: "en_US",
-    file: "en.json",
   },
   ...(locales ?? []),
-].filter((l) => Boolean(l.iso)) as LocaleObject[]
+].filter((l) => Boolean(l.code)) as LocaleObject[]
 
 const port = process.env.PORT || 8443
 const isProdNotPlaywright = isProd && !(process.env.PW === "true")

--- a/frontend/src/locales/scripts/create-wp-locale-list.js
+++ b/frontend/src/locales/scripts/create-wp-locale-list.js
@@ -35,8 +35,6 @@ const createPropertyRePatterns = ({
     "native_name",
     "lang_code_iso_639_1", // used for HTML lang attribute
     "slug", // unique identifier used by Nuxt i18n
-    "nplurals",
-    "plural_expression",
     "text_direction",
   ],
 } = {}) => {

--- a/frontend/src/locales/scripts/create-wp-locale-list.js
+++ b/frontend/src/locales/scripts/create-wp-locale-list.js
@@ -33,16 +33,11 @@ const createPropertyRePatterns = ({
   properties = [
     "english_name",
     "native_name",
-    "lang_code_iso_639_1",
-    "lang_code_iso_639_2",
-    "country_code",
-    "slug",
+    "lang_code_iso_639_1", // used for HTML lang attribute
+    "slug", // unique identifier used by Nuxt i18n
     "nplurals",
     "plural_expression",
-    "google_code",
-    "facebook_locale",
     "text_direction",
-    "wp_locale",
   ],
 } = {}) => {
   const propertyRePatterns = {}
@@ -73,10 +68,7 @@ function parseLocaleData(rawData) {
         data[camelCasedPropName] = value[1]
       }
     })
-    return {
-      wpLocale: wpLocale,
-      data,
-    }
+    return [wpLocale, data]
   }
 }
 
@@ -89,20 +81,15 @@ function parseLocaleData(rawData) {
  * @returns {Promise<{}>}
  */
 async function getWpLocaleData() {
-  const locales = {}
-
   const data = await getGpLocalesData()
   const rawLocalesData = data
     .split("new GP_Locale();")
     .splice(1)
     .map((item) => item.trim())
 
-  rawLocalesData.forEach((rawData) => {
-    const localeData = parseLocaleData(rawData)
-    if (localeData) {
-      locales[localeData.wpLocale] = localeData.data
-    }
-  })
+  const locales = Object.fromEntries(
+    rawLocalesData.map(parseLocaleData).filter(Boolean)
+  )
   const unsortedLocales = await addFetchedTranslationStatus(locales)
   return Object.keys(unsortedLocales)
     .sort()

--- a/frontend/src/locales/scripts/create-wp-locale-list.js
+++ b/frontend/src/locales/scripts/create-wp-locale-list.js
@@ -88,7 +88,13 @@ async function getWpLocaleData() {
   const locales = Object.fromEntries(
     rawLocalesData.map(parseLocaleData).filter(Boolean)
   )
+  console.log(`${rawLocalesData.length} locales found in GP source code.`)
+
   const unsortedLocales = await addFetchedTranslationStatus(locales)
+  console.log(
+    `${Object.keys(unsortedLocales).length} locales found in WP GP instance.`
+  )
+
   return Object.keys(unsortedLocales)
     .sort()
     .reduce((accumulator, currentValue) => {

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -37,7 +37,10 @@ const getValidatedLocales = async () => {
   }))
   for (const locale of allLocales) {
     const fileLocation = `${process.cwd()}/src/locales/${locale.file}`
-    if (fs.existsSync(fileLocation)) {
+    if (
+      fs.existsSync(fileLocation) &&
+      Object.keys(JSON.parse(fs.readFileSync(fileLocation))).length
+    ) {
       result.translated.push(locale)
     } else {
       result.untranslated.push(locale)

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -13,12 +13,14 @@ const { addFetchedTranslationStatus } = require("./get-translations-status")
  * @returns {{
  * translated: import('./types').I18nLocaleProps[],
  * untranslated: import('./types').I18nLocaleProps[]
+ * invalid: import('./types').I18nLocaleProps[],
  * }}
  */
 const getValidatedLocales = async () => {
   const result = {
     translated: [],
     untranslated: [],
+    invalid: [],
   }
   const updatedLocaleList = await addFetchedTranslationStatus(localesList)
   const allLocales = Object.values(updatedLocaleList).map((locale) => ({
@@ -37,13 +39,14 @@ const getValidatedLocales = async () => {
   }))
   for (const locale of allLocales) {
     const fileLocation = `${process.cwd()}/src/locales/${locale.file}`
-    if (
-      fs.existsSync(fileLocation) &&
-      Object.keys(JSON.parse(fs.readFileSync(fileLocation))).length
-    ) {
-      result.translated.push(locale)
+    if (fs.existsSync(fileLocation)) {
+      if (Object.keys(JSON.parse(fs.readFileSync(fileLocation))).length) {
+        result.translated.push(locale)
+      } else {
+        result.untranslated.push(locale)
+      }
     } else {
-      result.untranslated.push(locale)
+      result.invalid.push(locale)
     }
   }
   return result
@@ -51,16 +54,30 @@ const getValidatedLocales = async () => {
 
 try {
   getValidatedLocales().then((locales) => {
+    console.log(`Found ${locales.translated.length} locales with translations.`)
     const fileName = "valid-locales.json"
+    const valid = [...locales.translated, ...locales.untranslated]
     fs.writeFileSync(
       process.cwd() + `/src/locales/scripts/` + fileName,
-      JSON.stringify(locales.translated, null, 2) + "\n"
+      JSON.stringify(valid, null, 2) + "\n"
+    )
+
+    console.log(
+      `Found ${locales.untranslated.length} locales without translations.`
     )
     const untranslatedFileName = "untranslated-locales.json"
     fs.writeFileSync(
       process.cwd() + `/src/locales/scripts/` + untranslatedFileName,
       JSON.stringify(locales.untranslated, null, 2) + "\n"
     )
+
+    console.log(`Found ${locales.invalid.length} invalid locales.`)
+    const invalidFileName = "invalid-locales.json"
+    fs.writeFileSync(
+      process.cwd() + `/src/locales/scripts/` + invalidFileName,
+      JSON.stringify(locales.invalid, null, 2) + "\n"
+    )
+
     console.log(`> Wrote locale metadata for @nuxt/i18n.`)
   })
 } catch (err) {

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -22,14 +22,18 @@ const getValidatedLocales = async () => {
   }
   const updatedLocaleList = await addFetchedTranslationStatus(localesList)
   const allLocales = Object.values(updatedLocaleList).map((locale) => ({
+    /* Nuxt i18n fields */
+
     code: locale.slug,
-    name: locale.name,
-    nativeName: locale.nativeName ?? locale.name,
-    iso: locale.langCodeIso_639_1,
-    wpLocale: locale.wpLocale,
     dir: locale.textDirection || "ltr",
-    translated: locale.translated,
     file: `${locale.slug}.json`,
+    iso: locale.langCodeIso_639_1 ?? undefined,
+
+    /* Custom fields */
+
+    name: locale.name,
+    nativeName: locale.nativeName || locale.name,
+    translated: locale.translated,
   }))
   for (const locale of allLocales) {
     const fileLocation = `${process.cwd()}/src/locales/${locale.file}`

--- a/frontend/src/locales/scripts/locale-fallback.json
+++ b/frontend/src/locales/scripts/locale-fallback.json
@@ -1,0 +1,14 @@
+{
+  "en-au": ["en"],
+  "en-ca": ["en"],
+  "en-gb": ["en"],
+  "en-za": ["en"],
+  "es-ar": ["es"],
+  "es-cl": ["es"],
+  "es-co": ["es"],
+  "es-do": ["es"],
+  "es-ec": ["es"],
+  "es-mx": ["es"],
+  "es-ve": ["es"],
+  "default": ["en"]
+}

--- a/frontend/src/locales/scripts/locale-fallback.json
+++ b/frontend/src/locales/scripts/locale-fallback.json
@@ -1,8 +1,4 @@
 {
-  "en-au": ["en"],
-  "en-ca": ["en"],
-  "en-gb": ["en"],
-  "en-za": ["en"],
   "es-ar": ["es"],
   "es-cl": ["es"],
   "es-co": ["es"],

--- a/frontend/src/plugins/vue-i18n.ts
+++ b/frontend/src/plugins/vue-i18n.ts
@@ -1,6 +1,8 @@
+import fallbackLocale from "~/locales/scripts/locale-fallback.json"
+
 export default () => {
   return {
-    fallbackLocale: "en",
+    fallbackLocale,
     silentFallbackWarn: true,
     pluralizationRules: {
       /**

--- a/frontend/typings/nuxt__types/index.d.ts
+++ b/frontend/typings/nuxt__types/index.d.ts
@@ -52,5 +52,6 @@ declare module "@nuxtjs/i18n" {
   export interface LocaleObject {
     name: string
     nativeName: string
+    translated: number
   }
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2591 by @zackkrida 
Fixes #2885 by @dhruvkb 
Fixes #2886 by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- fixes a bug where untranslated locales would always be blank
- fixes a bug where locales without ISO would be dropped from the application
- fixes a bug where the `translated` field in the locale was missing in the TS type
- removes fields from `wp-locales.json` that were not used anywhere
- simplifies some code and adds logging in the locale management scripts
- implements fallback locales, with Español covered as an example
- adds documentation for the translation upload, download pipeline (to clarify the meaning of the Node scripts)
- adds documentation about how to use fallback locales

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Delete all i18n files.
   - `frontend/src/locales/*.json`
   - `frontend/src/locales/scripts/(wp|valid|untranslated)-locales.json`
1. Run `pnpm i18n`.
1. Check out the PR and run the dev server.
1. Switch to Spanish (Mexico) as the locale, it is incompletely translated.
1. Compare the page to the same page on staging and see that in the locally running app, English fallback is nowhere to be seen.
1. Compare some strings from the 'About' page to translations for Spanish (Spain) and see that fallback locales have been recognised.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
