### PR TITLE
Use a temp checkout path for automation when building docs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -830,7 +830,7 @@ jobs:
       - name: Replace preview of current PR
         if: github.event_name == 'pull_request'
         run: |
-          cp -r . /tmp/gh-pages
+          cp -r gh-pages /tmp/gh-pages
           sudo rm -rf /tmp/gh-pages/_preview/${{ github.event.pull_request.number }}
           mv /tmp/docs /tmp/gh-pages/_preview/${{ github.event.pull_request.number }}
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -814,17 +814,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: gh-pages
+          path: gh-pages
 
       - name: Checkout automations from repository
         uses: actions/checkout@v3
         with:
-          path: /tmp/automation-checkout
+          path: automation-checkout
 
       - name: Copy existing previews
         if: github.event_name == 'push'
         run: |
           mv /tmp/docs /tmp/gh-pages
-          mv _preview /tmp/gh-pages/_preview
+          mv gh-pages/_preview /tmp/gh-pages/_preview
 
       - name: Replace preview of current PR
         if: github.event_name == 'pull_request'
@@ -838,8 +839,8 @@ jobs:
         id: preview_diff
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PYTHONPATH: /tmp/automation-checkout/automations/python
-        working-directory: /tmp/automation-checkout/automations/python/workflows
+          PYTHONPATH: ${{ github.workspace }}/automation-checkout/automations/python
+        working-directory: ${{ github.workspace }}/automation-checkout/automations/python/workflows
         run: python get_folder_differences.py
 
       - name: Deploy

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -818,7 +818,7 @@ jobs:
       - name: Checkout automations from repository
         uses: actions/checkout@v3
         with:
-          path: automation-checkout
+          path: /tmp/automation-checkout
 
       - name: Copy existing previews
         if: github.event_name == 'push'
@@ -838,8 +838,8 @@ jobs:
         id: preview_diff
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PYTHONPATH: ${{ github.workspace }}/automation-checkout/automations/python
-        working-directory: ${{ github.workspace }}/automation-checkout/automations/python/workflows
+          PYTHONPATH: /tmp/automation-checkout/automations/python
+        working-directory: /tmp/automation-checkout/automations/python/workflows
         run: python get_folder_differences.py
 
       - name: Deploy

--- a/documentation/meta/ci_cd/jobs/documentation.md
+++ b/documentation/meta/ci_cd/jobs/documentation.md
@@ -54,6 +54,9 @@ Documentation is only emitted if all the following conditions are met.
   that their changes are valid, or were skipped, implying that they have no
   changes.
 
+A comment is also published linking to the generated preview, and any new or
+modified pages.
+
 ## `clean-gh-pages`
 
 This job is executed when a PR is closed


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2900 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Fixes an issue with #2647 which was causing the documentation publishing step to fail because a repo was being checked out inside of another repo (namely the automation used during the CI steps was being checked out to `<workspace>/automation-checkout` when the actual `gh-pages` branch was being checked out to `<workspace>` itself).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

~~I'm not sure the best way to test this, I'll follow up with a small doc change which should at least trigger the preview, but we may need to wait for a legitimate docs change in order to see if it is successful or not.~~

I've added a legitimate documentation change, so hopefully we'll be able to see the results once this is merged.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
