### PR TITLE
Fix Elasticsearch memory hogging the right way

### DIFF
--- a/docker-compose.overrides.yml
+++ b/docker-compose.overrides.yml
@@ -1,4 +1,0 @@
-services:
-  es:
-    # Memory limit for ES, as it tends to be a memory hoarder
-    mem_limit: 4294967296

--- a/docker/es/env.docker
+++ b/docker/es/env.docker
@@ -6,3 +6,9 @@ discovery.type="single-node"
 
 http.cors.enabled="true"
 http.cors.allow-origin="/.*/"
+
+# Elasticsearch will reserve 50-60% of available system memory
+# if left to its own devices. Setting this to half a GB is sufficient
+# for local testing and prevent ES from hogging such a significant
+# amount of system memory.
+ES_JAVA_OPTS="-Xms512m -Xmx512m"

--- a/justfile
+++ b/justfile
@@ -9,7 +9,6 @@ IS_PROD := env_var_or_default("PROD", env_var_or_default("IS_PROD", ""))
 PROD_ENV := env_var_or_default("PROD_ENV", "")
 IS_CI := env_var_or_default("CI", "")
 DC_USER := env_var_or_default("DC_USER", "opener")
-ENABLE_DC_OVERRIDES := env_var_or_default("OPENVERSE_ENABLE_DC_OVERRIDES", "true")
 
 # Show all available recipes, also recurses inside nested justfiles
 @_default:
@@ -117,9 +116,6 @@ DOCKER_FILE := "-f " + (
         else { "docker-compose.yml" }
     }
     else { "docker-compose.yml" }
-) + (
-    if ENABLE_DC_OVERRIDES == "true" { " -f docker-compose.overrides.yml" }
-    else { "" }
 )
 EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to https://github.com/WordPress/openverse/commit/6cdfb59acf8bfe3aa3dc5528e8846e6ae2d62a4f

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I noticed that Elasticsearch was happily using 60% of my system RAM. At one point today this actually caused an OOM issue in my kernel during a `just recreate` run, despite having 32 GB RAM! The overrides file does _not_ work for me (ES just crashes instead of staying within the limit). However, I remembered from the work I recently did to fix our production ES 8 cluster's heap configuration, that ES will respect heap limits passed as JVM args. Therefore, we can get rid of the overrides file (which we didn't really like any way) and use the heap limits. I've set them to half a gig, which should be _just fine_ for local testing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and run `just down && just up` and confirm that Elasticsearch does not use 60% of your system memory :grin: 

Run `just down -v && just up && just init` and confirm that ingestion still works locally.

Note: This might slow down ingestion locally by a _very small amount of time_. When I run it locally I don't see an issue but for other computer configurations it may behave differently. If that's the case, we can increase it to 1 GB or all the way to the 2 GB that the previous overrides would have forced ES to use (remember it doesn't use the full amount of system memory available to it by default!).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
