### PR TITLE
Replace deprecated function from Pillow

### DIFF
--- a/api/api/utils/watermark.py
+++ b/api/api/utils/watermark.py
@@ -150,6 +150,12 @@ def _get_attribution_text(image_info):
     return f'"{title}" by {creator} is licensed under {full_license}.'
 
 
+def _get_attribution_height(text, font):
+    draw = ImageDraw.Draw(Image.new("RGB", (0, 0)))
+    _, _, _, height = draw.multiline_textbbox((0, 0), text, font)
+    return height
+
+
 # Actions
 
 
@@ -200,7 +206,7 @@ def _print_attribution_on_image(img: Image.Image, image_info):
 
     text = _get_attribution_text(image_info)
     text = _fit_in_width(text, font, new_width)
-    _, attribution_height = font.getsize_multiline(text)
+    attribution_height = _get_attribution_height(text, font)
 
     frame_width = margin + new_width + margin
     frame_height = margin + height + margin + attribution_height + margin


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes tests of #2874.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes the `FreeTypeFont.getsize_multiline()` function from the watermark script in favor of [`ImageDraw.multiline_textbbox()`](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.multiline_textbbox). It was already deprecated and is now being removed in the last [Pillow version](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods). Thanks to examples in python-pillow/Pillow#6655 I learned how to do the replace.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
In `main`, run the tests for the watermark endpoint and observe the warning:

>  /api/api/utils/watermark.py:203: DeprecationWarning: getsize_multiline is deprecated and will be removed in Pillow 10 (2023-07-01). Use ImageDraw.multiline_textbbox instead.

```sh 
just api/test -k watermark
```

They should pass cleanly in this branch. Also, confirms manually checking the endpoint for any image, like e.g. http://localhost:50280/v1/images/02267cc0-7d60-432c-b151-f20ff314f225/watermark/ Make sure you have the env var `WATERMARK_ENABLED` set to True.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
