### PR TITLE
Skip flaky global audio visual regression test

### DIFF
--- a/frontend/test/playwright/visual-regression/components/global-audio-player.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/global-audio-player.spec.ts
@@ -12,7 +12,8 @@ import audio from "~~/test/playwright/utils/audio"
 
 for (const dir of languageDirections) {
   breakpoints.describeXs(async ({ expectSnapshot }) => {
-    test(`Global audio player on the search page - ${dir}`, async ({
+    // https://github.com/WordPress/openverse/issues/3009
+    test.skip(`Global audio player on the search page - ${dir}`, async ({
       page,
     }) => {
       await dismissTranslationBanner(page)

--- a/packages/eslint-plugin/src/rules/no-unexplained-disabled-test.ts
+++ b/packages/eslint-plugin/src/rules/no-unexplained-disabled-test.ts
@@ -25,9 +25,7 @@ export const noUnexplainedDisabledTest = OpenverseRule<[], MessageIds>({
   create(context) {
     const sourceCode = context.getSourceCode()
 
-    const hasIssueCommentWithLink = (
-      node: TSESTree.Node | TSESTree.Comment
-    ) => {
+    const hasIssueCommentWithLink = (node: TSESTree.Node) => {
       const commentsBeforeNode = sourceCode.getCommentsBefore(node)
       for (const comment of commentsBeforeNode) {
         if (/\bhttps:\/\/github\.com\/.*?\/issues\/\d+\b/.test(comment.value)) {
@@ -38,14 +36,14 @@ export const noUnexplainedDisabledTest = OpenverseRule<[], MessageIds>({
       return false
     }
 
-    const testSkipRegex = /test\.skip\s*\(/g
-    const testSkipEachRegex = /test\.skip\.each\s*\(/g
-    const testConcurrentSkipEachRegex = /test\.concurrent\.skip\.each\s*\(/g
-    const testTodoRegex = /test\.todo\s*\(/g
-    const itSkipRegex = /it\.skip\s*\(/g
-    const itEachSkipRegex = /it\.each\.skip\s*\(/g
-    const describeSkipRegex = /describe\.skip\s*\(/g
-    const describeEachSkipRegex = /describe\.each\.skip\s*\(/g
+    const testSkipRegex = /^test\.skip\s*\(/g
+    const testSkipEachRegex = /^test\.skip\.each\s*\(/g
+    const testConcurrentSkipEachRegex = /^test\.concurrent\.skip\.each\s*\(/g
+    const testTodoRegex = /^test\.todo\s*\(/g
+    const itSkipRegex = /^it\.skip\s*\(/g
+    const itEachSkipRegex = /^it\.each\.skip\s*\(/g
+    const describeSkipRegex = /^describe\.skip\s*\(/g
+    const describeEachSkipRegex = /^describe\.each\.skip\s*\(/g
 
     return {
       CallExpression(node) {

--- a/packages/eslint-plugin/test/rules/no-unexplained-disabled-test.spec.ts
+++ b/packages/eslint-plugin/test/rules/no-unexplained-disabled-test.spec.ts
@@ -50,6 +50,40 @@ const invalidTestCases = [
     `,
     errors: [{ messageId: "missingIssueComment" } as const],
   },
+  {
+    name: "Nested blocks with multiple skipped tests shows multiple errors",
+    code: `
+      describe("block", () => {
+        test("no skipped", () => {})
+
+        test.skip("first skipped", () => {})
+
+        test("also not skipped", () => {})
+
+        test.skip("second skipped", () => {})
+      })
+    `,
+    errors: [
+      { messageId: "missingIssueComment" },
+      { messageId: "missingIssueComment" },
+    ] as const,
+  },
+  {
+    name: "Skipped external block and skipped nested block have separate errors",
+    code: `
+      test.skip("external skip", () => {})
+
+      describe("block", () => {
+        test("not skipped", () => {})
+
+        test.skip("nested skip", () => {})
+      })
+    `,
+    errors: [
+      { messageId: "missingIssueComment" },
+      { messageId: "missingIssueComment" },
+    ] as const,
+  },
 ]
 
 const validTestCases = [
@@ -112,6 +146,29 @@ const validTestCases = [
         ])('.add(%i, %i)', async (a, b, expected) => {
         expect(a + b).toBe(expected) // will not be run
         })
+    `,
+  },
+  {
+    name: "Nested skip valid with comment on skipped test",
+    code: `
+      describe("group of tests", () => {
+        // https://github.com/WordPress/openverse/issues/2573
+        test.skip("skipped", () => {})
+      })
+    `,
+  },
+  {
+    name: "Nested and external blocks do not error",
+    code: `
+      // https://github.com/WordPress/openverse/issues/2573
+      test.skip("external skip", () => {})
+
+      describe("block", () => {
+        test("not skipped", () => {})
+
+        // https://github.com/WordPress/openverse/issues/2573
+        test.skip("nested skip", () => {})
+      })
     `,
   },
 ]


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse/issues/3009

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Skip the test mentioned in the issue.

To do so, however, I had to fix a bug in the ESLint rule. The regex was too imprecise and would match skipped test nested inside of blocks. This caused the error to occur on the top-most block that contained any skipped block, which is not the intended behaviour. The fix was relatively simple in the end, just to refine the regex to only match the start of the source code block.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass. Confirm the bug is fixed in the eslint plugin by making changes to the unit tests for the rule and trying to break it further.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
