### PR TITLE
Populate sensitivities for single result view

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -486,9 +486,13 @@ def search(
         # check things like provider density for a set of queries.
         tallies.count_provider_occurrences(results_to_tally, index)
 
-    search_context = SearchContext.build(results, origin_index)
+    if not results:
+        results = []
 
-    return results or [], page_count, result_count, search_context.asdict()
+    result_ids = [result.identifier for result in results]
+    search_context = SearchContext.build(result_ids, origin_index)
+
+    return results, page_count, result_count, search_context.asdict()
 
 
 def related_media(uuid, index, filter_dead):
@@ -522,8 +526,12 @@ def related_media(uuid, index, filter_dead):
 
     result_count, _ = _get_result_and_page_count(response, results, page_size, page)
 
-    search_context = SearchContext.build(results, index)
-    return results or [], result_count, search_context.asdict()
+    if not results:
+        results = []
+
+    result_ids = [result.identifier for result in results]
+    search_context = SearchContext.build(result_ids, index)
+    return results, result_count, search_context.asdict()
 
 
 def get_sources(index):

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -44,7 +44,12 @@ class SearchContext:
             # cf: https://github.com/WordPress/openverse/issues/2154
             Q(
                 "terms",
-                **{"identifier.keyword": [result.identifier for result in results]},
+                **{"identifier.keyword": all_result_identifiers},
+            )
+            if len(results) > 1
+            else Q(
+                "term",
+                **{"identifier.keyword": all_result_identifiers[0]},
             )
         )
 

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -1,12 +1,15 @@
 from dataclasses import asdict, dataclass
-from typing import Self
+from typing import Protocol, Self
 
 from django.conf import settings
 
 from elasticsearch_dsl import Q, Search
-from elasticsearch_dsl.response import Hit
 
 from api.constants.media_types import OriginIndex
+
+
+class Identifiable(Protocol):
+    identifier: str
 
 
 @dataclass
@@ -22,7 +25,7 @@ class SearchContext:
     """Subset of result identifiers for results with sensitive textual content."""
 
     @classmethod
-    def build(cls, results: list[Hit], origin_index: OriginIndex) -> Self:
+    def build(cls, results: list[Identifiable], origin_index: OriginIndex) -> Self:
         if not results:
             return cls(list(), set())
 

--- a/api/api/utils/search_context.py
+++ b/api/api/utils/search_context.py
@@ -15,7 +15,7 @@ class SearchContext:
     # to convey that it is the Openverse result identifier and
     # not the document _id
 
-    all_result_identifiers: set[str]
+    all_result_identifiers: list[str]
     """All the result identifiers gathered for the search."""
 
     sensitive_text_result_identifiers: set[str]
@@ -24,9 +24,9 @@ class SearchContext:
     @classmethod
     def build(cls, results: list[Hit], origin_index: OriginIndex) -> Self:
         if not results:
-            return cls(set(), set())
+            return cls(list(), set())
 
-        all_result_identifiers = {r.identifier for r in results}
+        all_result_identifiers = [result.identifier for result in results]
 
         if not settings.ENABLE_FILTERED_INDEX_QUERIES:
             return cls(all_result_identifiers, set())

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 
 from rest_framework import status
 from rest_framework.decorators import action
@@ -90,14 +89,10 @@ class MediaViewSet(ReadOnlyModelViewSet):
     # Standard actions
 
     def retrieve(self, request, *_, **__):
-        @dataclass
-        class PseudoHit:  # implements Identifiable protocol
-            identifier: str
-
         instance = self.get_object()
-        hit = PseudoHit(identifier=str(instance.identifier))
-
-        search_context = SearchContext.build([hit], self.default_index).asdict()
+        search_context = SearchContext.build(
+            [str(instance.identifier)], self.default_index
+        ).asdict()
         serializer_context = search_context | self.get_serializer_context()
         serializer = self.get_serializer(instance, context=serializer_context)
 

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -153,3 +153,28 @@ def related(fixture):
     related_url = fixture["results"][0]["related_url"]
     response = requests.get(related_url)
     assert response.status_code == 200
+
+
+def sensitive_search_and_detail(media_type):
+    search_res = requests.get(
+        f"{API_URL}/v1/{media_type}/",
+        params={"q": "bird", "unstable__include_sensitive_results": "true"},
+        verify=False,
+    )
+    results = search_res.json()["results"]
+
+    sensitive_result = None
+    sensitivities = []
+    for result in results:
+        if sensitivities := result["unstable__sensitivity"]:
+            sensitive_result = result
+            break
+    assert sensitive_result is not None
+    assert len(sensitivities) != 0
+
+    detail_res = requests.get(
+        f"{API_URL}/v1/{media_type}/{sensitive_result['id']}", verify=False
+    )
+    details = detail_res.json()
+
+    assert sensitivities == details["unstable__sensitivity"]

--- a/api/test/test_audio_integration.py
+++ b/api/test/test_audio_integration.py
@@ -20,6 +20,7 @@ from test.media_integration import (
     search_quotes_exact,
     search_source_and_excluded,
     search_special_chars,
+    sensitive_search_and_detail,
     stats,
     uuid_validation,
 )
@@ -157,3 +158,7 @@ def test_audio_uuid_validation():
 
 def test_audio_related(audio_fixture):
     related(audio_fixture)
+
+
+def test_audio_sensitive_search_and_detail():
+    sensitive_search_and_detail("audio")

--- a/api/test/test_image_integration.py
+++ b/api/test/test_image_integration.py
@@ -19,6 +19,7 @@ from test.media_integration import (
     search_quotes_exact,
     search_source_and_excluded,
     search_special_chars,
+    sensitive_search_and_detail,
     stats,
     uuid_validation,
 )
@@ -136,3 +137,7 @@ def test_image_uuid_validation():
 
 def test_image_related(image_fixture):
     related(image_fixture)
+
+
+def test_audio_sensitive_search_and_detail():
+    sensitive_search_and_detail("images")

--- a/api/test/unit/utils/test_search_context.py
+++ b/api/test/unit/utils/test_search_context.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 def test_no_results(media_type_config):
     search_context = SearchContext.build([], media_type_config.origin_index)
 
-    assert search_context == SearchContext(set(), set())
+    assert search_context == SearchContext(list(), set())
 
 
 @pytest.mark.parametrize(
@@ -68,7 +68,7 @@ def test_sensitive_text(
         search_context = SearchContext.build(results, media_type_config.origin_index)
 
     assert search_context == SearchContext(
-        {r.identifier for r in results},
+        [r.identifier for r in results],
         {maybe_sensitive_text_model.identifier}
         if has_sensitive_text and setting_enabled
         else set(),

--- a/api/test/unit/utils/test_search_context.py
+++ b/api/test/unit/utils/test_search_context.py
@@ -48,6 +48,7 @@ def test_sensitive_text(
     )
 
     results = [maybe_sensitive_text_hit] + [hit for _, hit in clear_results]
+    result_ids = [result.identifier for result in results]
 
     if not setting_enabled:
         es_host = settings.ES.transport.kwargs["host"]
@@ -58,14 +59,14 @@ def test_sensitive_text(
             reply=500,
         ) as mock:
             search_context = SearchContext.build(
-                results, media_type_config.origin_index
+                result_ids, media_type_config.origin_index
             )
             assert (
                 mock.total_matches == 0
             ), "There should be zero requests to ES if the setting is disabled"
         pook.off()
     else:
-        search_context = SearchContext.build(results, media_type_config.origin_index)
+        search_context = SearchContext.build(result_ids, media_type_config.origin_index)
 
     assert search_context == SearchContext(
         [r.identifier for r in results],


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2926 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR populates the sensitivies for single result view by manually defining the `retrieve` view in the `MediaViewSet` and extending the `SearchContext` to work for single results too.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out the branch and run the dev server `just api/up` (and `just api/init` if you haven't already)
0. Find a media item that has some sensitive content. To do so, add the the query param `unstable__include_sensitive_results=true` to the URL.
1. Open the same media's detail page, you should see the same sensitivities as the results page.
2. Report some media item as mature. Do the same for this media item. You should see identical sensitivity in the search resuls and single result pages.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
