### PR TITLE
Remove `requests-oauthlib` from api dependencies

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -40,7 +40,6 @@ Pillow = "~=10.0"
 psycopg2 = "~=2.9"
 python-decouple = "~=3.8"
 python-xmp-toolkit = "~=2.0"
-requests-oauthlib = "~=1.3"
 sentry-sdk = "~=1.30"
 django-split-settings = "*"
 

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "03846c61ea75a631e0d08ab662b5f10cdd50483efa5296cbc8451025985831ae"
+            "sha256": "9f5c3dec42b393b50067a42c3d98567c016123a79fd70c825079498925ff1c4f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -914,14 +914,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
-        },
-        "requests-oauthlib": {
-            "hashes": [
-                "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5",
-                "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"
-            ],
-            "index": "pypi",
-            "version": "==1.3.1"
         },
         "rpds-py": {
             "hashes": [


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes

Fixes #2895 by @sarayourfriend 

## Description

Removed `requests-oauthlib` from api dependencies.

## Testing Instructions

Check out the branch and run api tests:

```
$ just dc build web
$ just api/test
```

Try api calls locally to be sure, such as `curl "http://localhost:50280/v1/images/?q=test"`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
