### PR TITLE
Add ADRF and make the thumbnail view async

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -41,6 +41,7 @@ sentry-sdk = "~=1.30"
 django-split-settings = "*"
 psycopg = "~=3.1"
 uvicorn = {extras = ["standard"], version = "~=0.23"}
+adrf = "~=0.1.2"
 
 [requires]
 python_version = "3.11"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -18,6 +18,7 @@ pytest-sugar = "~=0.9"
 pook = {ref = "master", git = "git+https://github.com/h2non/pook.git"}
 
 [packages]
+adrf = "~=0.1.2"
 aiohttp = "~=3.8"
 aws-requests-auth = "~=0.4"
 deepdiff = "~=6.4"
@@ -26,6 +27,7 @@ django-cors-headers = "~=4.2"
 django-log-request-id = "~=2.0"
 django-oauth-toolkit = "~=2.3"
 django-redis = "~=5.4"
+django-split-settings = "*"
 django-tqdm = "~=1.3"
 django-uuslug = "~=2.0"
 djangorestframework = "~=3.14"
@@ -35,13 +37,11 @@ elasticsearch-dsl = "~=8.9"
 future = "~=0.18"
 limit = "~=0.2"
 Pillow = "~=10.1.0"
+psycopg = "~=3.1"
 python-decouple = "~=3.8"
 python-xmp-toolkit = "~=2.0"
 sentry-sdk = "~=1.30"
-django-split-settings = "*"
-psycopg = "~=3.1"
 uvicorn = {extras = ["standard"], version = "~=0.23"}
-adrf = "~=0.1.2"
 
 [requires]
 python_version = "3.11"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7e9adb0878e2d7523c7457b3712adde0aee93b6586d54eef2663d09e145a1b3e"
+            "sha256": "54293a6311c5ebb7d16bf6bb13d9a63f420b9275855cba28076d08f125ae95c2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "adrf": {
+            "hashes": [
+                "sha256:a33f8f51f0f80072ffb2af061df1fb119bc00adaa720a2972049d4aa33155337",
+                "sha256:ce7160878ba27999d333752941cde0687c1a205fc26fa0eda1bad3924958dc69"
+            ],
+            "index": "pypi",
+            "version": "==0.1.2"
+        },
         "aiohttp": {
             "hashes": [
                 "sha256:002f23e6ea8d3dd8d149e569fd580c999232b5fbc601c48d55398fbc2e582e8c",
@@ -132,6 +140,13 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.7.2"
+        },
+        "async-property": {
+            "hashes": [
+                "sha256:17d9bd6ca67e27915a75d92549df64b5c7174e9dc806b30a3934dc4ff0506380",
+                "sha256:8924d792b5843994537f8ed411165700b27b2bd966cefc4daeefc1253442a9d7"
+            ],
+            "version": "==0.2.2"
         },
         "async-timeout": {
             "hashes": [

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import urlparse
 

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import asdict, dataclass
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -33,13 +34,26 @@ ORIGINAL = "original"
 THUMBNAIL_STRATEGY = Literal["photon_proxy", "original"]
 
 
+@dataclass
+class ImageProxyMediaInfo:
+    media_provider: str
+    media_identifier: str
+    image_url: str
+
+
+@dataclass
+class ImageProxyConfig:
+    accept_header: str = "image/*"
+    is_full_size: bool = False
+    is_compressed: bool = True
+
+
 def get_request_params_for_extension(
     ext: str,
     headers: dict[str, str],
     image_url: str,
     parsed_image_url: urlparse,
-    is_full_size: bool,
-    is_compressed: bool,
+    proxy_config: ImageProxyConfig,
 ) -> tuple[str, dict[str, str], dict[str, str]]:
     """
     Get the request params (url, params, headers) for the thumbnail proxy.
@@ -49,7 +63,10 @@ def get_request_params_for_extension(
     """
     if ext in PHOTON_TYPES:
         return get_photon_request_params(
-            parsed_image_url, is_full_size, is_compressed, headers
+            parsed_image_url,
+            proxy_config.is_full_size,
+            proxy_config.is_compressed,
+            headers,
         )
     elif ext in ORIGINAL_TYPES:
         return image_url, {}, headers
@@ -59,24 +76,23 @@ def get_request_params_for_extension(
 
 
 def get(
-    image_url: str,
-    media_identifier: str,
-    media_provider: str,
-    accept_header: str = "image/*",
-    is_full_size: bool = False,
-    is_compressed: bool = True,
+    media_info: ImageProxyMediaInfo,
+    proxy_config: ImageProxyConfig = ImageProxyConfig(),
 ) -> HttpResponse:
     """
     Proxy an image through Photon if its file type is supported, else return the
     original image if the file type is SVG. Otherwise, raise an exception.
     """
+    image_url = media_info.image_url
+    media_identifier = media_info.media_identifier
+
     logger = parent_logger.getChild("get")
     tallies = django_redis.get_redis_connection("tallies")
     month = get_monthly_timestamp()
 
     image_extension = get_image_extension(image_url, media_identifier)
 
-    headers = {"Accept": accept_header} | HEADERS
+    headers = {"Accept": proxy_config.accept_header} | HEADERS
 
     parsed_image_url = urlparse(image_url)
     domain = parsed_image_url.netloc
@@ -86,8 +102,7 @@ def get(
         headers,
         image_url,
         parsed_image_url,
-        is_full_size,
-        is_compressed,
+        proxy_config,
     )
 
     try:
@@ -103,7 +118,7 @@ def get(
             f"{month}:{upstream_response.status_code}"
         )
         tallies.incr(
-            f"thumbnail_response_code_by_provider:{media_provider}:"
+            f"thumbnail_response_code_by_provider:{media_info.media_provider}:"
             f"{month}:{upstream_response.status_code}"
         )
         upstream_response.raise_for_status()

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -35,14 +35,14 @@ THUMBNAIL_STRATEGY = Literal["photon_proxy", "original"]
 
 
 @dataclass
-class ImageProxyMediaInfo:
+class MediaInfo:
     media_provider: str
     media_identifier: str
     image_url: str
 
 
 @dataclass
-class ImageProxyConfig:
+class RequestConfig:
     accept_header: str = "image/*"
     is_full_size: bool = False
     is_compressed: bool = True
@@ -53,7 +53,7 @@ def get_request_params_for_extension(
     headers: dict[str, str],
     image_url: str,
     parsed_image_url: urlparse,
-    proxy_config: ImageProxyConfig,
+    request_config: RequestConfig,
 ) -> tuple[str, dict[str, str], dict[str, str]]:
     """
     Get the request params (url, params, headers) for the thumbnail proxy.
@@ -64,8 +64,8 @@ def get_request_params_for_extension(
     if ext in PHOTON_TYPES:
         return get_photon_request_params(
             parsed_image_url,
-            proxy_config.is_full_size,
-            proxy_config.is_compressed,
+            request_config.is_full_size,
+            request_config.is_compressed,
             headers,
         )
     elif ext in ORIGINAL_TYPES:
@@ -76,8 +76,8 @@ def get_request_params_for_extension(
 
 
 def get(
-    media_info: ImageProxyMediaInfo,
-    proxy_config: ImageProxyConfig = ImageProxyConfig(),
+    media_info: MediaInfo,
+    request_config: RequestConfig = RequestConfig(),
 ) -> HttpResponse:
     """
     Proxy an image through Photon if its file type is supported, else return the
@@ -92,7 +92,7 @@ def get(
 
     image_extension = get_image_extension(image_url, media_identifier)
 
-    headers = {"Accept": proxy_config.accept_header} | HEADERS
+    headers = {"Accept": request_config.accept_header} | HEADERS
 
     parsed_image_url = urlparse(image_url)
     domain = parsed_image_url.netloc
@@ -102,7 +102,7 @@ def get(
         headers,
         image_url,
         parsed_image_url,
-        proxy_config,
+        request_config,
     )
 
     try:

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -148,7 +148,9 @@ def get(
                 f"thumbnail_http_error:{domain}:{month}:{code}:{exc.response.text}"
             )
             logger.warning(
-                f"Failed to render thumbnail {upstream_url=} {code=} {media_provider=}"
+                f"Failed to render thumbnail "
+                f"{upstream_url=} {code=} "
+                f"{media_info.media_provider=}"
             )
         raise UpstreamThumbnailException(f"Failed to render thumbnail. {exc}")
 

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -26,7 +26,7 @@ from api.serializers.audio_serializers import (
     AudioSerializer,
     AudioWaveformSerializer,
 )
-from api.utils.image_proxy import ImageProxyMediaInfo
+from api.utils import image_proxy
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 from api.views.media_views import MediaViewSet
 
@@ -80,7 +80,7 @@ class AudioViewSet(MediaViewSet):
     def tag_collection(self, request, tag, *_, **__):
         return super().tag_collection(request, tag, *_, **__)
 
-    async def get_image_proxy_media_info(self) -> ImageProxyMediaInfo:
+    async def get_image_proxy_media_info(self) -> image_proxy.MediaInfo:
         audio = await self.aget_object()
 
         image_url = None
@@ -91,7 +91,7 @@ class AudioViewSet(MediaViewSet):
         if not image_url:
             raise NotFound("Could not find artwork.")
 
-        return ImageProxyMediaInfo(
+        return image_proxy.MediaInfo(
             media_identifier=audio.identifier,
             media_provider=audio.provider,
             image_url=image_url,

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -97,7 +97,14 @@ class AudioViewSet(MediaViewSet):
             image_url=image_url,
         )
 
-    thumbnail = thumbnail_docs(MediaViewSet.thumbnail)
+    @thumbnail_docs
+    @action(detail=True, url_path="thumb", url_name="thumb")
+    def thumbnail(self, *args, **kwargs):
+        """
+        Retrieve the scaled down and compressed thumbnail of the artwork of an
+        audio track or its audio set.
+        """
+        super().thumbnail(*args, **kwargs)
 
     @waveform
     @action(

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -15,7 +15,7 @@ from api.docs.audio_docs import (
     source_collection,
     stats,
     tag_collection,
-    thumbnail,
+    thumbnail as thumbnail_docs,
     waveform,
 )
 from api.models import Audio
@@ -26,7 +26,7 @@ from api.serializers.audio_serializers import (
     AudioSerializer,
     AudioWaveformSerializer,
 )
-from api.serializers.media_serializers import MediaThumbnailRequestSerializer
+from api.utils.image_proxy import ImageProxyMediaInfo
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 from api.views.media_views import MediaViewSet
 
@@ -80,21 +80,8 @@ class AudioViewSet(MediaViewSet):
     def tag_collection(self, request, tag, *_, **__):
         return super().tag_collection(request, tag, *_, **__)
 
-    @thumbnail
-    @action(
-        detail=True,
-        url_path="thumb",
-        url_name="thumb",
-        serializer_class=MediaThumbnailRequestSerializer,
-        throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
-    )
-    def thumbnail(self, request, *_, **__):
-        """
-        Retrieve the scaled down and compressed thumbnail of the artwork of an
-        audio track or its audio set.
-        """
-
-        audio = self.get_object()
+    async def get_image_proxy_media_info(self) -> ImageProxyMediaInfo:
+        audio = await self.aget_object()
 
         image_url = None
         if audio_thumbnail := audio.thumbnail:
@@ -104,7 +91,13 @@ class AudioViewSet(MediaViewSet):
         if not image_url:
             raise NotFound("Could not find artwork.")
 
-        return super().thumbnail(request, audio, image_url)
+        return ImageProxyMediaInfo(
+            media_identifier=audio.identifier,
+            media_provider=audio.provider,
+            image_url=image_url,
+        )
+
+    thumbnail = thumbnail_docs(MediaViewSet.thumbnail)
 
     @waveform
     @action(

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -98,13 +98,13 @@ class AudioViewSet(MediaViewSet):
         )
 
     @thumbnail_docs
-    @action(detail=True, url_path="thumb", url_name="thumb")
-    def thumbnail(self, *args, **kwargs):
+    @MediaViewSet.thumbnail_action
+    async def thumbnail(self, *args, **kwargs):
         """
         Retrieve the scaled down and compressed thumbnail of the artwork of an
         audio track or its audio set.
         """
-        super().thumbnail(*args, **kwargs)
+        return await super().thumbnail(*args, **kwargs)
 
     @waveform
     @action(

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -15,9 +15,9 @@ from api.docs.audio_docs import (
     source_collection,
     stats,
     tag_collection,
-    thumbnail as thumbnail_docs,
-    waveform,
 )
+from api.docs.audio_docs import thumbnail as thumbnail_docs
+from api.docs.audio_docs import waveform
 from api.models import Audio
 from api.serializers.audio_serializers import (
     AudioCollectionRequestSerializer,

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -142,10 +142,10 @@ class ImageViewSet(MediaViewSet):
         )
 
     @thumbnail_docs
-    @action(detail=True, url_path="thumb", url_name="thumb")
-    def thumbnail(self, *args, **kwargs):
+    @MediaViewSet.thumbnail_action
+    async def thumbnail(self, *args, **kwargs):
         """Retrieve the scaled down and compressed thumbnail of the image."""
-        super().thumbnail(*args, **kwargs)
+        return await super().thumbnail(*args, **kwargs)
 
     @watermark_doc
     @action(detail=True, url_path="watermark", url_name="watermark")

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -141,7 +141,11 @@ class ImageViewSet(MediaViewSet):
             image_url=image_url,
         )
 
-    thumbnail = thumbnail_docs(MediaViewSet.thumbnail)
+    @thumbnail_docs
+    @action(detail=True, url_path="thumb", url_name="thumb")
+    def thumbnail(self, *args, **kwargs):
+        """Retrieve the scaled down and compressed thumbnail of the image."""
+        super().thumbnail(*args, **kwargs)
 
     @watermark_doc
     @action(detail=True, url_path="watermark", url_name="watermark")

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -35,7 +35,7 @@ from api.serializers.image_serializers import (
     WatermarkRequestSerializer,
 )
 from api.serializers.media_serializers import PaginatedRequestSerializer
-from api.utils.image_proxy import ImageProxyMediaInfo
+from api.utils import image_proxy
 from api.utils.watermark import watermark
 from api.views.media_views import MediaViewSet
 
@@ -127,7 +127,7 @@ class ImageViewSet(MediaViewSet):
         serializer = self.get_serializer(image, context=context)
         return Response(data=serializer.data)
 
-    async def get_image_proxy_media_info(self) -> ImageProxyMediaInfo:
+    async def get_image_proxy_media_info(self) -> image_proxy.MediaInfo:
         image = await self.aget_object()
         image_url = image.url
         # Hotfix to use thumbnails for SMK images
@@ -135,7 +135,7 @@ class ImageViewSet(MediaViewSet):
         if "iip.smk.dk" in image_url and image.thumbnail:
             image_url = image.thumbnail
 
-        return ImageProxyMediaInfo(
+        return image_proxy.MediaInfo(
             media_identifier=image.identifier,
             media_provider=image.provider,
             image_url=image_url,

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -22,8 +22,8 @@ from api.docs.image_docs import (
     source_collection,
     stats,
     tag_collection,
-    thumbnail as thumbnail_docs,
 )
+from api.docs.image_docs import thumbnail as thumbnail_docs
 from api.docs.image_docs import watermark as watermark_doc
 from api.models import Image
 from api.serializers.image_serializers import (
@@ -34,11 +34,7 @@ from api.serializers.image_serializers import (
     OembedSerializer,
     WatermarkRequestSerializer,
 )
-from api.serializers.media_serializers import (
-    MediaThumbnailRequestSerializer,
-    PaginatedRequestSerializer,
-)
-from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
+from api.serializers.media_serializers import PaginatedRequestSerializer
 from api.utils.image_proxy import ImageProxyMediaInfo
 from api.utils.watermark import watermark
 from api.views.media_views import MediaViewSet

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -22,7 +22,7 @@ from api.docs.image_docs import (
     source_collection,
     stats,
     tag_collection,
-    thumbnail,
+    thumbnail as thumbnail_docs,
 )
 from api.docs.image_docs import watermark as watermark_doc
 from api.models import Image
@@ -39,6 +39,7 @@ from api.serializers.media_serializers import (
     PaginatedRequestSerializer,
 )
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
+from api.utils.image_proxy import ImageProxyMediaInfo
 from api.utils.watermark import watermark
 from api.views.media_views import MediaViewSet
 
@@ -130,25 +131,21 @@ class ImageViewSet(MediaViewSet):
         serializer = self.get_serializer(image, context=context)
         return Response(data=serializer.data)
 
-    @thumbnail
-    @action(
-        detail=True,
-        url_path="thumb",
-        url_name="thumb",
-        serializer_class=MediaThumbnailRequestSerializer,
-        throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
-    )
-    def thumbnail(self, request, *_, **__):
-        """Retrieve the scaled down and compressed thumbnail of the image."""
-
-        image = self.get_object()
+    async def get_image_proxy_media_info(self) -> ImageProxyMediaInfo:
+        image = await self.aget_object()
         image_url = image.url
         # Hotfix to use thumbnails for SMK images
         # TODO: Remove when small thumbnail issues are resolved
         if "iip.smk.dk" in image_url and image.thumbnail:
             image_url = image.thumbnail
 
-        return super().thumbnail(request, image, image_url)
+        return ImageProxyMediaInfo(
+            media_identifier=image.identifier,
+            media_provider=image.provider,
+            image_url=image_url,
+        )
+
+    thumbnail = thumbnail_docs(MediaViewSet.thumbnail)
 
     @watermark_doc
     @action(detail=True, url_path="watermark", url_name="watermark")

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -282,13 +282,14 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
             "Subclasses must implement `get_image_proxy_media_info`"
         )
 
-    @action(
+    thumbnail_action = action(
         detail=True,
         url_path="thumb",
         url_name="thumb",
         serializer_class=media_serializers.MediaThumbnailRequestSerializer,
         throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
     )
+
     async def thumbnail(self, request, *_, **__):
         serializer = self.get_serializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -9,6 +9,10 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from api.constants.media_types import MediaType
 from api.constants.search import SearchStrategy
+from adrf.views import APIView as AsyncAPIView
+from adrf.viewsets import ViewSetMixin as AsyncViewSetMixin
+from asgiref.sync import sync_to_async
+
 from api.controllers import search_controller
 from api.controllers.elasticsearch.related import related_media
 from api.models import ContentProvider
@@ -18,6 +22,7 @@ from api.serializers.provider_serializers import ProviderSerializer
 from api.utils import image_proxy
 from api.utils.pagination import StandardPagination
 from api.utils.search_context import SearchContext
+from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +40,12 @@ class InvalidSource(APIException):
     default_code = "invalid_source"
 
 
-class MediaViewSet(ReadOnlyModelViewSet):
+image_proxy_aget = sync_to_async(image_proxy.get, thread_sensitive=True)
+
+
+class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
+    view_is_async = True
+
     lookup_field = "identifier"
     # TODO: https://github.com/encode/django-rest-framework/pull/6789
     lookup_value_regex = (
@@ -78,6 +88,8 @@ class MediaViewSet(ReadOnlyModelViewSet):
                 filter_content=True
             ).values_list("provider_identifier")
         )
+
+    aget_object = sync_to_async(ReadOnlyModelViewSet.get_object)
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -265,16 +277,30 @@ class MediaViewSet(ReadOnlyModelViewSet):
 
         return Response(data=serializer.data, status=status.HTTP_201_CREATED)
 
-    def thumbnail(self, request, media_obj, image_url):
+    async def get_image_proxy_media_info(self) -> image_proxy.ImageProxyMediaInfo:
+        raise NotImplementedError(
+            "Subclasses must implement `get_image_proxy_media_info`"
+        )
+
+    @action(
+        detail=True,
+        url_path="thumb",
+        url_name="thumb",
+        serializer_class=media_serializers.MediaThumbnailRequestSerializer,
+        throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
+    )
+    async def thumbnail(self, request, *_, **__):
         serializer = self.get_serializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
-        return image_proxy.get(
-            image_url,
-            media_obj.identifier,
-            media_obj.provider,
-            accept_header=request.headers.get("Accept", "image/*"),
-            **serializer.validated_data,
+        media_info = await self.get_image_proxy_media_info()
+
+        return await image_proxy_aget(
+            media_info,
+            proxy_config=image_proxy.ImageProxyConfig(
+                accept_header=request.headers.get("Accept", "image/*"),
+                **serializer.validated_data,
+            ),
         )
 
     # Helper functions

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -7,12 +7,12 @@ from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from api.constants.media_types import MediaType
-from api.constants.search import SearchStrategy
 from adrf.views import APIView as AsyncAPIView
 from adrf.viewsets import ViewSetMixin as AsyncViewSetMixin
 from asgiref.sync import sync_to_async
 
+from api.constants.media_types import MediaType
+from api.constants.search import SearchStrategy
 from api.controllers import search_controller
 from api.controllers.elasticsearch.related import related_media
 from api.models import ContentProvider

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -40,7 +40,7 @@ class InvalidSource(APIException):
     default_code = "invalid_source"
 
 
-image_proxy_aget = sync_to_async(image_proxy.get, thread_sensitive=True)
+image_proxy_aget = sync_to_async(image_proxy.get)
 
 
 class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -277,7 +277,7 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
 
         return Response(data=serializer.data, status=status.HTTP_201_CREATED)
 
-    async def get_image_proxy_media_info(self) -> image_proxy.ImageProxyMediaInfo:
+    async def get_image_proxy_media_info(self) -> image_proxy.MediaInfo:
         raise NotImplementedError(
             "Subclasses must implement `get_image_proxy_media_info`"
         )
@@ -298,7 +298,7 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
 
         return await image_proxy_aget(
             media_info,
-            proxy_config=image_proxy.ImageProxyConfig(
+            request_config=image_proxy.RequestConfig(
                 accept_header=request.headers.get("Accept", "image/*"),
                 **serializer.validated_data,
             ),

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -12,8 +12,8 @@ import requests
 
 from api.utils.image_proxy import (
     HEADERS,
-    ImageProxyConfig,
-    ImageProxyMediaInfo,
+    MediaInfo,
+    RequestConfig,
     UpstreamThumbnailException,
     extension,
 )
@@ -26,7 +26,7 @@ TEST_IMAGE_URL = PHOTON_URL_FOR_TEST_IMAGE.replace(settings.PHOTON_ENDPOINT, "ht
 TEST_MEDIA_IDENTIFIER = "123"
 TEST_MEDIA_PROVIDER = "foo"
 
-TEST_MEDIA_INFO = ImageProxyMediaInfo(
+TEST_MEDIA_INFO = MediaInfo(
     media_identifier=TEST_MEDIA_IDENTIFIER,
     media_provider=TEST_MEDIA_PROVIDER,
     image_url=TEST_IMAGE_URL,
@@ -143,7 +143,7 @@ def test_get_successful_no_auth_key_not_compressed(mock_image_data):
         .mock
     )
 
-    res = photon_get(TEST_MEDIA_INFO, ImageProxyConfig(is_compressed=False))
+    res = photon_get(TEST_MEDIA_INFO, RequestConfig(is_compressed=False))
 
     assert res.content == MOCK_BODY.encode()
     assert res.status_code == 200
@@ -166,7 +166,7 @@ def test_get_successful_no_auth_key_full_size(mock_image_data):
         .mock
     )
 
-    res = photon_get(TEST_MEDIA_INFO, ImageProxyConfig(is_full_size=True))
+    res = photon_get(TEST_MEDIA_INFO, RequestConfig(is_full_size=True))
 
     assert res.content == MOCK_BODY.encode()
     assert res.status_code == 200
@@ -186,7 +186,7 @@ def test_get_successful_no_auth_key_full_size_not_compressed(mock_image_data):
 
     res = photon_get(
         TEST_MEDIA_INFO,
-        ImageProxyConfig(is_full_size=True, is_compressed=False),
+        RequestConfig(is_full_size=True, is_compressed=False),
     )
 
     assert res.content == MOCK_BODY.encode()
@@ -211,7 +211,7 @@ def test_get_successful_no_auth_key_png_only(mock_image_data):
         .mock
     )
 
-    res = photon_get(TEST_MEDIA_INFO, ImageProxyConfig(accept_header="image/png"))
+    res = photon_get(TEST_MEDIA_INFO, RequestConfig(accept_header="image/png"))
 
     assert res.content == MOCK_BODY.encode()
     assert res.status_code == 200
@@ -455,7 +455,7 @@ def test__get_extension_from_url(image_url, expected_ext):
 def test_photon_get_raises_by_not_allowed_types(image_type):
     image_url = TEST_IMAGE_URL.replace(".jpg", f".{image_type}")
     image = ImageFactory.create(url=image_url)
-    media_info = ImageProxyMediaInfo(
+    media_info = MediaInfo(
         media_identifier=image.identifier,
         media_provider=image.provider,
         image_url=image_url,
@@ -476,7 +476,7 @@ def test_photon_get_raises_by_not_allowed_types(image_type):
 def test_photon_get_saves_image_type_to_cache(redis, headers, expected_cache_val):
     image_url = TEST_IMAGE_URL.replace(".jpg", "")
     image = ImageFactory.create(url=image_url)
-    media_info = ImageProxyMediaInfo(
+    media_info = MediaInfo(
         media_identifier=image.identifier,
         media_provider=image.provider,
         image_url=image_url,

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -29,7 +29,7 @@ TEST_MEDIA_PROVIDER = "foo"
 TEST_MEDIA_INFO = ImageProxyMediaInfo(
     media_identifier=TEST_MEDIA_IDENTIFIER,
     media_provider=TEST_MEDIA_PROVIDER,
-    image_url=TEST_IMAGE_URL
+    image_url=TEST_IMAGE_URL,
 )
 
 UA_HEADER = HEADERS["User-Agent"]
@@ -455,7 +455,11 @@ def test__get_extension_from_url(image_url, expected_ext):
 def test_photon_get_raises_by_not_allowed_types(image_type):
     image_url = TEST_IMAGE_URL.replace(".jpg", f".{image_type}")
     image = ImageFactory.create(url=image_url)
-    media_info = ImageProxyMediaInfo(image.identifier, image_url)
+    media_info = ImageProxyMediaInfo(
+        media_identifier=image.identifier,
+        media_provider=image.provider,
+        image_url=image_url,
+    )
 
     with pytest.raises(UnsupportedMediaType):
         photon_get(media_info)
@@ -472,8 +476,11 @@ def test_photon_get_raises_by_not_allowed_types(image_type):
 def test_photon_get_saves_image_type_to_cache(redis, headers, expected_cache_val):
     image_url = TEST_IMAGE_URL.replace(".jpg", "")
     image = ImageFactory.create(url=image_url)
-    media_info = ImageProxyMediaInfo(image.identifier, image_url)
-
+    media_info = ImageProxyMediaInfo(
+        media_identifier=image.identifier,
+        media_provider=image.provider,
+        image_url=image_url,
+    )
     with pook.use():
         pook.head(image_url, reply=200, response_headers=headers)
         with pytest.raises(UnsupportedMediaType):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

First step of #2789 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is the first step to convert the image proxy route to async. It converts the overall view to async. I've split this into a separate PR because (a) it is complex enough on its own and (b) converting the actual `image_proxy.get` function is blocked on sharing the aiohttp client session (for which I'll have another PR up later today, it's already finished I just forgot to push it last night :facepalm:).

So this PR only converts the _view_ side of things to async. It does this by abstracting the thumbnails route in a slightly different way than it was before, which allows the audio and image views to ignore most of the safe-sync-in-async compatibility issues. To make that interplay a little easier, I decided to refactor `image_proxy.get` to use two MRO objects for the input, rather than the one-by-one parameter definitions. Now that I'm writing this, I'm realising that I could have avoided the changes to `image_proxy.get` itself by creating a new response definition for `get_image_proxy_media_info` and then using `asdict` to spread that into `image_proxy.get`. If y'all want me to make that change, I think it's a fine one to simplify the overall PR. On the other hand, I think the new API is also a bit cleaner, if potentially too abstract. Let me know what y'all think because I'm two minds about it.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the PR and run `just build web` to get the new dependencies. Also keep in mind that this PR depends on #3011.

Run `just api/up` and make various search requests, thumbnail, and related requests. Generally: exercise the image and audio media views and their various routes. Everything should essentially work as it did before. The existing API integration tests should also continue to work, along will all unit tests. This change should be generally totally transparent and not result in any observable differences on the consumer side, which is why I didn't add any new tests for this: the existing tests already cover the media view and should continue to work without changes. The only tests I changed were to use pook a little more fluidly and to accommodate the changes to the `image_proxy.get` function's interface.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
