### PR TITLE
Replace "mature" with "sensitive" in api help strings

### DIFF
--- a/api/api/migrations/0052_relational_fields.py
+++ b/api/api/migrations/0052_relational_fields.py
@@ -39,12 +39,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='matureaudio',
             name='identifier',
-            field=models.OneToOneField(db_column="identifier", db_constraint=False, help_text='The reference to the mature audio.', on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, related_name='mature_audio', serialize=False, to='api.audio', to_field='identifier'),
+            field=models.OneToOneField(db_column="identifier", db_constraint=False, help_text='The reference to the sensitive audio.', on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, related_name='mature_audio', serialize=False, to='api.audio', to_field='identifier'),
         ),
         migrations.AlterField(
             model_name='matureimage',
             name='identifier',
-            field=models.OneToOneField(db_column="identifier", db_constraint=False, help_text='The reference to the mature image.', on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, related_name='mature_image', serialize=False, to='api.image', to_field='identifier'),
+            field=models.OneToOneField(db_column="identifier", db_constraint=False, help_text='The reference to the sensitive image.', on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, related_name='mature_image', serialize=False, to='api.image', to_field='identifier'),
         ),
         migrations.RenameField(
             model_name="audioreport",

--- a/api/api/models/audio.py
+++ b/api/api/models/audio.py
@@ -279,7 +279,7 @@ class MatureAudio(AbstractMatureMedia):
         db_constraint=False,
         db_column="identifier",
         related_name="mature_audio",
-        help_text="The reference to the mature audio.",
+        help_text="The reference to the sensitive audio.",
     )
 
     class Meta:

--- a/api/api/models/media.py
+++ b/api/api/models/media.py
@@ -353,7 +353,7 @@ class AbstractMatureMedia(PerformIndexUpdateMixin, models.Model):
         db_constraint=False,
         db_column="identifier",
         related_name="mature_abstract_media",
-        help_text="The reference to the mature media.",
+        help_text="The reference to the sensitive media.",
     )
     """
     Sub-classes must override this field to point to a concrete sub-class of

--- a/api/api/serializers/media_serializers.py
+++ b/api/api/serializers/media_serializers.py
@@ -122,7 +122,7 @@ class MediaSearchRequestSerializer(serializers.Serializer):
         label="mature",
         default=False,
         required=False,
-        help_text="Whether to include content for mature audiences.",
+        help_text="Whether to include sensitive content.",
     )
 
     # The ``unstable__`` prefix is used in the query params.


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes

Fixes #2625 by @AetherUnbound 

## Description

Updates API help strings to reflect "sensitive" terminology, rather than "mature" legacy terms.

## Testing Instructions

Get the local environment up and running on this branch, then run `just api/test`, and do smoke testing to ensure the API is still running ok (e.g. `curl "http://localhost:50280/v1/images/?q=test"`). 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
