### PR TITLE
Correctly set up constant fields in API responses

### DIFF
--- a/api/api/serializers/image_serializers.py
+++ b/api/api/serializers/image_serializers.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from rest_framework import serializers
 
 from api.constants.field_order import field_position_map
@@ -133,14 +135,13 @@ class OembedSerializer(BaseModelSerializer):
     spec: https://oembed.com.
     """
 
-    version = serializers.ReadOnlyField(
+    version = serializers.SerializerMethodField(
         help_text="The oEmbed version number, always set to 1.0.",
-        default="1.0",
     )
-    type = serializers.ReadOnlyField(
+    type = serializers.SerializerMethodField(
         help_text="The resource type, always set to 'photo' for images.",
-        default="photo",
     )
+
     width = serializers.SerializerMethodField(
         help_text="The width of the image in pixels."
     )
@@ -155,6 +156,14 @@ class OembedSerializer(BaseModelSerializer):
         help_text="A direct link to the media creator.",  # copied from ``Image``
         source="creator_url",
     )
+
+    @staticmethod
+    def get_type() -> Literal["photo"]:
+        return "photo"
+
+    @staticmethod
+    def get_version() -> Literal["1.0"]:
+        return "1.0"
 
     class Meta:
         model = Image

--- a/api/api/serializers/image_serializers.py
+++ b/api/api/serializers/image_serializers.py
@@ -158,11 +158,11 @@ class OembedSerializer(BaseModelSerializer):
     )
 
     @staticmethod
-    def get_type() -> Literal["photo"]:
+    def get_type(*_) -> Literal["photo"]:
         return "photo"
 
     @staticmethod
-    def get_version() -> Literal["1.0"]:
+    def get_version(*_) -> Literal["1.0"]:
         return "1.0"
 
     class Meta:

--- a/api/api/serializers/provider_serializers.py
+++ b/api/api/serializers/provider_serializers.py
@@ -29,7 +29,7 @@ class ProviderSerializer(serializers.ModelSerializer):
     )
 
     @staticmethod
-    def get_logo_url() -> str | None:
+    def get_logo_url(*_) -> str | None:
         return None
 
     class Meta:

--- a/api/api/serializers/provider_serializers.py
+++ b/api/api/serializers/provider_serializers.py
@@ -21,13 +21,16 @@ class ProviderSerializer(serializers.ModelSerializer):
         source="domain_name",
         help_text="The URL of the source, e.g. https://www.flickr.com",
     )
-    logo_url = serializers.ReadOnlyField(
-        default=None,
+    logo_url = serializers.SerializerMethodField(
         help_text="The URL to a logo for the source.",
     )
     media_count = serializers.SerializerMethodField(
         help_text="The number of media items indexed from the source.",
     )
+
+    @staticmethod
+    def get_logo_url() -> str | None:
+        return None
 
     class Meta:
         model = ContentProvider


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3034 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR replaces `ReadOnlyField`s with `SerializerMethodField`s that return constant values for values that never change and are not derived from models:
`OEmbedSerializer`: `version`, `type`
`ProviderSerializer`: `logo_url`


This makes the documentation a little bit clearer and fixes the warnings in logs.

Currently, `logo_url` type is given as `string`, but it always returns `null`. The updated version shows `string or null`. I tried setting it to "only null", but spectacular still throws a warning that it couldn't get the type of the value. `string or null` is more accurate than `string`.
<img width="412" alt="Provider serializer logo url type" src="https://github.com/WordPress/openverse/assets/15233243/d90742df-5d43-4f43-ae7a-af50d57b6e4a">


### OEmbed serializer
Currently, the documentation says that these values are "default", making it seem like a different value is also possible.
<img width="552" alt="OEmbed Serializer current" src="https://github.com/WordPress/openverse/assets/15233243/aff6e2a0-2be6-4e2a-9edc-6f5061ede537">

In this PR, the documentation says "Value: 1.0", making it clear that it's only a single value.
<img width="545" alt="OEmbed Serializer updated" src="https://github.com/WordPress/openverse/assets/15233243/e01c2cde-7c2b-465f-bc93-e08c063b3407">

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
If you run the app on `main` (`just up`), and open the documentation (e.g. http://0.0.0.0:50280/v1/#tag/audio/operation/audio_stats), you should see the warnings mentioned in the related issue in the Docker logs.
These warnings should not be visible in this PR. The documentation for these fields should be updated to match snapshots in the PR description.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
