### PR TITLE
Remove mentions of tailwind-config-viewer from docs

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -20,7 +20,6 @@ use the Openverse API, you should instead refer to the
 <!-- These use HTML anchors because Sphinx treats them as internal references without scheme. -->
 
 - <a href="./storybook">Storybook</a> (UI components)
-- <a href="./tailwind">Tailwind Config Viewer</a> (design tokens)
 
 # Table of contents
 

--- a/documentation/meta/ci_cd/actions.md
+++ b/documentation/meta/ci_cd/actions.md
@@ -72,7 +72,7 @@ input, passing a space-separated list of image names.
 
 ## `build-docs`
 
-Builds the documentation, including this Sphinx site, the frontend Storybook and
-the Tailwind config viewer and stores it at `/tmp/docs`. This compiled
-documentation is deployed to an appropriate location by the
+Builds the documentation, including this Sphinx site and the frontend Storybook
+and stores it at `/tmp/docs`. This compiled documentation is deployed to an
+appropriate location by the
 [`emit-docs`](/meta/ci_cd/jobs/documentation.md#emit-docs) job.

--- a/documentation/meta/ci_cd/artifacts.md
+++ b/documentation/meta/ci_cd/artifacts.md
@@ -60,10 +60,9 @@ The following artifacts are related to documentation.
 
 - `documentation`
 
-  This is the main documentation comprising of the Sphinx site, the Storybook
-  and the Tailwind Config Viewer. It's built by the
-  [`build-docs`](/meta/ci_cd/jobs/documentation.md#build-docs) job and used by
-  the [`emit-docs`](/meta/ci_cd/jobs/documentation.md#emit-docs) to deploy
-  either as the main documentation site (if the workflow is running for a new
-  commit pushed to `main`) or as a preview (if the workflow is running for a
-  PR).
+  This is the main documentation comprising the Sphinx site and the Storybook.
+  It's built by the [`build-docs`](/meta/ci_cd/jobs/documentation.md#build-docs)
+  job and used by the [`emit-docs`](/meta/ci_cd/jobs/documentation.md#emit-docs)
+  to deploy either as the main documentation site (if the workflow is running
+  for a new commit pushed to `main`) or as a preview (if the workflow is running
+  for a PR).

--- a/documentation/meta/ci_cd/jobs/documentation.md
+++ b/documentation/meta/ci_cd/jobs/documentation.md
@@ -45,8 +45,7 @@ Documentation is only emitted if all the following conditions are met.
   - a PR and
     - the source is a branch of `WordPress/openverse` and not a fork
     - the author of the PR is not Dependabot
-- either the documentation or the frontend has changed (for the Storybook and
-  Tailwind Config Viewer)
+- either the documentation or the frontend has changed (for Storybook)
 - all the primary tests ([`test-cat`](/meta/ci_cd/jobs/catalog.md#test-cat),
   [`test-ing`](/meta/ci_cd/jobs/ingestion_server.md#test-ing),
   [`test-api`](/meta/ci_cd/jobs/api.md#test-api),


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

I didn't open an issue for such a small fix

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes mentions of Tailwind config viewer, which was removed in #2827, from the docs.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
When the docs are rendered and the comment is published in this PR, check the rendered documentation and see that the front page does not have a link to Tailwind config viewer. The mentions should also be gone in the other pages.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
