### PR TITLE
Configure conf options as parameters

### DIFF
--- a/catalog/dags/providers/provider_dag_factory.py
+++ b/catalog/dags/providers/provider_dag_factory.py
@@ -371,9 +371,53 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
         ],
         render_template_as_native_obj=True,
         user_defined_macros={"date_partition_for_prefix": date_partition_for_prefix},
-        # Delete source data from airflow and db once ingestion is complete. Here as a
-        # parameter to support data quality testing in sql-only dags like iNaturalist.
-        params={"sql_rm_source_data_after_ingesting": Param(True, type="boolean")},
+        params={
+            "date": Param(
+                default=None,
+                type=["string", "null"],
+                format="date",
+                description="Override the ingestion date for a dated DAG.",
+            ),
+            "initial_query_params": Param(
+                default={},
+                type="object",
+                description=(
+                    "Override the set of `query_params` that will be used to fetch the"
+                    " first batch of records. This option is used to trigger a DagRun"
+                    " that resumes ingestion from a desired starting point, rather"
+                    " than starting over from the beginning."
+                ),
+            ),
+            "query_params_list": Param(
+                default=[],
+                type="array",
+                items={
+                    "type": "object",
+                },
+                description=(
+                    "A list of `query_params` dicts. When supplied, the ingester will"
+                    " be run for just these sets of params."
+                ),
+            ),
+            "skip_ingestion_errors": Param(
+                default=False,
+                type="boolean",
+                description=(
+                    "Whether to skip over all errors encountered during ingestion,"
+                    " continuing to the next batch and reporting errors in aggregate"
+                    " when ingestion is complete. This option should be used sparingly."
+                ),
+            ),
+            "sql_rm_source_data_after_ingesting": Param(
+                default=True,
+                type="boolean",
+                description=(
+                    "Whether to delete source data from airflow and DB once ingestion"
+                    " is complete. This is used to support data quality testing in"
+                    " SQL-only DAGs like iNaturalist."
+                ),
+            ),
+        },
     )
 
     with dag:

--- a/catalog/dags/providers/provider_dag_factory.py
+++ b/catalog/dags/providers/provider_dag_factory.py
@@ -380,7 +380,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
             ),
             "initial_query_params": Param(
                 default={},
-                type="object",
+                type=["object", "null"],
                 description=(
                     "Override the set of `query_params` that will be used to fetch the"
                     " first batch of records. This option is used to trigger a DagRun"
@@ -390,7 +390,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
             ),
             "query_params_list": Param(
                 default=[],
-                type="array",
+                type=["array", "null"],
                 items={
                     "type": "object",
                 },


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2917 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Configures DAG conf options as `params` on the DAG. This gives us the nice form in the UI when triggering a DAG, and adds documentation for the available options. It's also necessary, as the Airflow UI no longer has a `trigger DAG with conf...` option allowing triggering the DAG with an arbitrary conf dict, so we need this in order to be able to use the options.

<img width="841" alt="Screenshot 2023-09-19 at 12 35 23 PM" src="https://github.com/WordPress/openverse/assets/63313398/659e89b1-f01b-44f8-949a-3d9d1f0bfe4d">


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

We need to test that the conf options all still work. I used Wikimedia to test. I'm providing the exact conf options I used for convenient testing, but you could also simulate a more 'realistic' workflow by failing a task and getting the next `query_params` to use from the logs (this is how I got the test data below).

`date`:
* Click the `Trigger DAG` button in the UI and it will automatically open the options form. Select `2023-09-13` from the date picker.
* Hit the 'Trigger' button to run the DAG and verify in the logs that it is being run for the desired date. You'll see a log like `INFO - Using date 2023-09-13.`
* Manually pass or fail the task.
_____________________
`initial_query_params`:
* `Trigger DAG` and select 2023-09-13 as the `date` again. In `initial_query_params`, pass:
```
{"action": "query", "generator": "allimages", "gaisort": "timestamp", "gaidir": "newer", "gailimit": 250, "gulimit": 250, "gunamespace": 0, "format": "json", "gaistart": "1694563200", "gaiend": "1694649600", "prop": "imageinfo|globalusage", "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata", "gaicontinue": "20230913005115|Xmas-new_year_2008_(3173006850).jpg", "continue": "gaicontinue||"}
```
* Hit the 'Trigger' button to run the DAG and verify in the logs that it is starting from the supplied query params. You'll see a log like `INFO - Using initial_query_params from dag_run conf: {"action": "query", ....`
* Manually pass or fail the task
_____________________

`query_params_list`:
* `Trigger DAG` and select 2023-09-13 as the `date` again. In `query_params_list`, pass:
```
[
    {"action": "query", "generator": "allimages", "gaisort": "timestamp", "gaidir": "newer", "gailimit": 250, "gulimit": 250, "gunamespace": 0, "format": "json", "gaistart": "1694563200", "gaiend": "1694649600", "prop": "imageinfo|globalusage", "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata", "gaicontinue": "20230913005115|Xmas-new_year_2008_(3173006850).jpg", "continue": "gaicontinue||"},
    {"action": "query", "generator": "allimages", "gaisort": "timestamp", "gaidir": "newer", "gailimit": 250, "gulimit": 250, "gunamespace": 0, "format": "json", "gaistart": "1694563200", "gaiend": "1694649600", "prop": "imageinfo|globalusage", "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata", "gaicontinue": "20230913020645|Monnaie_-_Bronze,_\u00c9lyma\u00efde,_Incertain_-_btv1b103147537_(1_of_2).jpg", "continue": "gaicontinue||"}
]
```
* Hit the 'Trigger' button to run the DAG and verify in the logs that it only grabs batches for the params you supplied. You'll see two log like: `INFO - Using query params from `query_params_list` set in dag_run conf: {'action':  ....` which match the two sets of params you passed, in order.
* Don't manually pass/fail the task -- you can wait for it to finish, since it should only get two batches.
_____________________

`skip_ingestion_errors`:
* First, we need to make the DAG raise some errors. I added `raise Exception("Oh no!")` to the Wikimedia ingester just before [this line](https://github.com/WordPress/openverse/blob/517a16e407abad1801702b1dceabf1b0598f853b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py#L268) to make it error on every batch.
* Then I hit `Trigger DAG` to open the form. I set `date` to 2023-09-13 again, and passed the same `query_params_list` as in the previous step so that it'll only try to ingest two batches. Enable the `skip_ingestion_errors` option.
* Hit the 'Trigger' button to run the DAG and verify that the errors were skipped and reported in aggregate at the end. In the logs, you should be able to see that both batches were processed (you see the same `INFO - Using query params....` logs as before), and then at the end you should see something like:
```
[2023-09-19, 19:23:46 UTC] {provider_data_ingester.py:346} INFO - Using query params from `query_params_list` set in dag_run conf: None
[2023-09-19, 19:23:46 UTC] {provider_data_ingester.py:505} INFO - Committed 0 records
[2023-09-19, 19:23:46 UTC] {provider_data_ingester.py:308} INFO - The following query_params resulted in errors: 
{"action": "query", "generator": "allimages", "gaisort": "timestamp", "gaidir": "newer", "gailimit": 250, "gulimit": 250, "gunamespace": 0, "format": "json", "gaistart": "1694563200", "gaiend": "1694649600", "prop": "imageinfo|globalusage", "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata", "gaicontinue": "20230913010222|Monnaie._As,_Auguste,_Lyon_-_btv1b10444138k_(1_of_2).jpg", "continue": "gaicontinue||"}, 
{"action": "query", "generator": "allimages", "gaisort": "timestamp", "gaidir": "newer", "gailimit": 250, "gulimit": 250, "gunamespace": 0, "format": "json", "gaistart": "1694563200", "gaiend": "1694649600", "prop": "imageinfo|globalusage", "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata", "gaicontinue": "20230913021317|Monnaie._Denarius_serratus_-_btv1b104385707_(2_of_2).jpg", "continue": "gaicontinue||"}
[2023-09-19, 19:23:46 UTC] {provider_data_ingester.py:315} ERROR - The following errors were encountered during ingestion:
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
