### PR TITLE
Replace deprecated body in the ES requests with individual parameters

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -556,7 +556,6 @@ def get_sources(index):
         # Don't increase `size` without reading this issue first:
         # https://github.com/elastic/elasticsearch/issues/18838
         size = 100
-        
         aggs = {
             "unique_sources": {
                 "terms": {
@@ -566,7 +565,6 @@ def get_sources(index):
                 }
             }
         }
-    
         try:
             results = settings.ES.search(index=index, aggs=aggs, request_cache=True)
             buckets = results["aggregations"]["unique_sources"]["buckets"]

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -556,19 +556,19 @@ def get_sources(index):
         # Don't increase `size` without reading this issue first:
         # https://github.com/elastic/elasticsearch/issues/18838
         size = 100
-        agg_body = {
-            "aggs": {
-                "unique_sources": {
-                    "terms": {
-                        "field": "source.keyword",
-                        "size": size,
-                        "order": {"_key": "desc"},
-                    }
+        
+        aggs = {
+            "unique_sources": {
+                "terms": {
+                    "field": "source.keyword",
+                    "size": size,
+                    "order": {"_key": "desc"},
                 }
             }
         }
+    
         try:
-            results = settings.ES.search(index=index, body=agg_body, request_cache=True)
+            results = settings.ES.search(index=index, aggs=aggs, request_cache=True)
             buckets = results["aggregations"]["unique_sources"]["buckets"]
         except NotFoundError:
             buckets = [{"key": "none_found", "doc_count": 0}]


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3043  by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Replace the deprecated body parameter and using individual parameters.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

run `just api/test test/unit/controllers/test_search_controller.py` on terminal. Results are below and passed all the test. 

`test/unit/controllers/test_search_controller.py: 125 warnings
/venv/lib/python3.11/site-packages/elasticsearch_dsl/search.py:712: DeprecationWarning: Passing transport options in the API method is deprecated. Use 'Elasticsearch.options()' instead.
es.search(index=self._index, body=self.to_dict(), **self._params).body,

test/unit/controllers/test_search_controller.py: 237 warnings
/venv/lib/python3.11/site-packages/elasticsearch_dsl/search.py:712: DeprecationWarning: The 'body' parameter is deprecated and will be removed in a future version. Instead use individual parameters.
es.search(index=self._index, body=self.to_dict(), **self._params).body,

../venv/lib/python3.11/site-packages/_pytest/cacheprovider.py:451
/venv/lib/python3.11/site-packages/_pytest/cacheprovider.py:451: PytestCacheWarning: could not create cache path /api/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/api/.pytest_cache'
config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../venv/lib/python3.11/site-packages/_pytest/stepwise.py:56
/venv/lib/python3.11/site-packages/_pytest/stepwise.py:56: PytestCacheWarning: could not create cache path /api/.pytest_cache/v/cache/stepwise: [Errno 13] Permission denied: '/api/.pytest_cache'
session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

Results (86.18s (0:01:26)):
162 passed`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
