### PR TITLE
Transfer UUID validation inside serializer

### DIFF
--- a/api/api/serializers/image_serializers.py
+++ b/api/api/serializers/image_serializers.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from uuid import UUID
 
 from rest_framework import serializers
 
@@ -124,7 +125,15 @@ class OembedRequestSerializer(serializers.Serializer):
 
     @staticmethod
     def validate_url(value):
-        return add_protocol(value)
+        url = add_protocol(value)
+        if url.endswith("/"):
+            url = url[:-1]
+        identifier = url.rsplit("/", 1)[1]
+        try:
+            uuid = UUID(identifier)
+        except ValueError:
+            raise serializers.ValidationError("Could not parse identifier from URL.")
+        return uuid
 
 
 class OembedSerializer(BaseModelSerializer):

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -83,10 +83,7 @@ class ImageViewSet(MediaViewSet):
 
         context = self.get_serializer_context()
 
-        url = params.validated_data["url"]
-        if url.endswith("/"):
-            url = url[:-1]
-        identifier = url.rsplit("/", 1)[1]
+        identifier = params.validated_data["url"]
         image = get_object_or_404(Image, identifier=identifier)
         if not (image.height and image.width):
             image_file = requests.get(image.url, headers=self.OEMBED_HEADERS)

--- a/api/test/test_image_integration.py
+++ b/api/test/test_image_integration.py
@@ -92,6 +92,16 @@ def test_oembed_endpoint_with_non_existent_image():
     assert response.status_code == 404
 
 
+def test_oembed_endpoint_with_bad_identifier():
+    params = {
+        "url": "https://any.domain/any/path/not-a-valid-uuid",
+    }
+    response = requests.get(
+        f"{API_URL}/v1/images/oembed?{urlencode(params)}", verify=False
+    )
+    assert response.status_code == 400
+
+
 @pytest.mark.parametrize(
     "url",
     [


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR prevents the oEmbed endpoint from crashing when an invalid UUID is encountered. The UUID is now validated in the serializer, leading to DRF's `ValidationError` being raised if invalid. This is handled by DRF and converted to a 400 Bad Request reponse.

Earlier, Django would validate the UUID and raise a Django core `ValidationError` which does not map to a 400 response, and bubbles uncaught till it exits the worker.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR and run the dev server.
1. Visit the oEmbed endpoint `http://localhost:50280/v1/images/oembed/?url=` with the following `url` values:
   - valid and existing UUID like `2982c0bf-9c26-4543-a712-4d50a117ded8`
   - URL containing valid and existing UUID like `https://abc.xyz/def/2982c0bf-9c26-4543-a712-4d50a117ded8`
   - valid but non-existent UUID like `f6e28bad-860d-4cab-980f-de5aa79892d2`
   - invalid UUID like `f6e28bad-860d-4cab-980f-de5aa79`
2. In all cases you should see a DRF page with a proper error message and not the Django error page.

The PR also adds a test case checking for 400 response (before the PR the test would fail because the code would be 500).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
