### PR TITLE
[Proof of concept]: Alternative (simpler) frontend docker build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -182,14 +182,25 @@ jobs:
           just versions
           just versions >> "$GITHUB_OUTPUT"
 
-      # ℹ️Step only applies for frontend image.
+      # Step only applies for frontend image.
       # This step
       # - downloads translation strings from GlotPress so that they can be
       #   bundled inside the Docker image
-      - name: Prepare frontend for building
+      # - Removes all `node_modules` directory to clear the way for only
+      #   installing runtime dependencies of the frontend
+      # - Installs frontend runtime dependencies
+      # - Runs `nuxt build` with the correct environment variables in scope
+      - name: Prepare frontend
         if: matrix.image == 'frontend'
+        env:
+          SENTRY_DSN: https://b6466b74788a4a2f8a7912eea912beb7@o787041.ingest.sentry.io/5799642
+          NODE_ENV: production
+          NUXT_TELEMETRY_DISABLED: 1
         run: |
-          just frontend/run i18n
+          just p frontend i18n
+          pnpm m -w exec rm -rf node_modules
+          pnpm install --filter frontend --prod
+          just p frontend build:only
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -207,7 +218,6 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }}
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
-          build-contexts: ${{ matrix.build-contexts || '' }}
           build-args: |
             SEMANTIC_VERSION=${{ needs.get-image-tag.outputs.image_tag }}
             CATALOG_PY_VERSION=${{ steps.prepare-build-args.outputs.catalog_py_version }}
@@ -215,7 +225,6 @@ jobs:
             API_PY_VERSION=${{ steps.prepare-build-args.outputs.api_py_version }}
             INGESTION_PY_VERSION=${{ steps.prepare-build-args.outputs.ingestion_py_version }}
             FRONTEND_NODE_VERSION=${{ steps.prepare-build-args.outputs.frontend_node_version }}
-            FRONTEND_PNPM_VERSION=${{ steps.prepare-build-args.outputs.frontend_pnpm_version }}
 
       - name: Upload image `${{ matrix.image }}`
         uses: actions/upload-artifact@v3

--- a/automations/python/workflows/set_matrix_images.py
+++ b/automations/python/workflows/set_matrix_images.py
@@ -31,7 +31,11 @@ includes = {
     "ingestion_server": {"image": "ingestion_server", "target": "ing"},
     "api": {"image": "api", "target": "api"},
     "api_nginx": {"image": "api_nginx", "context": "api", "target": "nginx"},
-    "frontend": {"image": "frontend", "target": "app", "build-contexts": "repo_root=."},
+    "frontend": {
+        "image": "frontend",
+        "context": ".",
+        "file": "frontend/Dockerfile.prod",
+    },
     "frontend_nginx": {
         "image": "frontend_nginx",
         "context": "frontend",

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,21 @@
+ARG FRONTEND_NODE_VERSION
+
+FROM docker.io/node:${FRONTEND_NODE_VERSION}-alpine as app
+
+LABEL org.opencontainers.image.source="https://github.com/WordPress/openverse"
+
+# Install CURL for the production healthcheck
+RUN apk --no-cache add curl
+
+WORKDIR /home/node/
+
+USER node
+
+COPY --chown=node:node node_modules ./node_modules/
+COPY --chown=node:node frontend ./frontend/
+
+WORKDIR frontend
+
+EXPOSE 8443
+
+CMD ["npm", "run", "start", "--", "-H", "0.0.0.0"]

--- a/frontend/Dockerfile.prod.dockerignore
+++ b/frontend/Dockerfile.prod.dockerignore
@@ -1,0 +1,9 @@
+*
+
+!frontend/src
+!frontend/nuxt.config.ts
+!frontend/feat
+!frontend/.nuxt
+!frontend/package.json
+!frontend/node_modules
+!node_modules


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3118 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In the course of exploring options for the issue I ended up actually implementing the solution anyway. I only needed to make small changes to the CI scripts to enable it, some of which were similar to the request logs PR I have open. This PR is therefore based on that one, for the CI changes alone.

This is just a proof of concept. I want to wait for us to have time to consider the pros/cons of this and discuss other alternatives. But, because I already had this working, I wanted to get it up so that the work wasn't lost and others could reference it.

This PR should probably also go ahead and remove the `frontend/Dockerfile` and rename the new `frontend/Dockerfile.prod` to something more sensible, if there is a better name.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Reproduce the CI build then run the image locally and confirm it works:

First, prepare the environment by running `pnpm m -w exec rm -rf node_modules` to clean up your local. Alternatively, use a fresh clone of the repository if you have the time and bandwidth to spare. Then follow the CI's steps:

1. `pnpm install`
2. `just p frontend i18n`
3. `pnpm m -w exec rm -rf node_modules`
4. `pnpm install --filter frontend --prod`
5. 
    ```sh
    export SENTRY_DSN=https://b6466b74788a4a2f8a7912eea912beb7@o787041.ingest.sentry.io/5799642
    export NODE_ENV=production
    export NUXT_TELEMETRY_DISABLED=1
    just p frontend build:only
    ```
6. `docker build -t openverse-frontend-local:latest --build-arg FRONTEND_NODE_VERSION=$(just frontend/node-version) -f frontend/Dockerfile.prod .`
7. `docker run -it --rm -p 8443 openverse-frontend-local`

Now confirm you can reach the application at `localhost:8443` and that it works as expected.
 
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
