### PR TITLE
Use simple query for related

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -11,7 +11,7 @@ from django.core.cache import cache
 
 from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch_dsl import Q, Search
-from elasticsearch_dsl.query import EMPTY_QUERY, MoreLikeThis, Query
+from elasticsearch_dsl.query import EMPTY_QUERY, Match, Query, SimpleQueryString, Term
 from elasticsearch_dsl.response import Hit, Response
 
 import api.models as models
@@ -496,39 +496,37 @@ def search(
     return results, page_count, result_count, search_context.asdict()
 
 
-def related_media(uuid: str, index: str, filter_dead: bool) -> tuple[list[Hit], int]:
-    """Given a UUID, find related search results."""
+def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
+    """Given a UUID, find related search results based on title and tags."""
 
     search_client = Search(index=index)
 
     # Convert UUID to sequential ID.
     item = search_client
-    item = item.query("match", identifier=uuid)
-    _id = item.execute().hits[0].id
+    item_query = item.query("match", identifier=uuid)
+    item_hit = item_query.execute().hits[0]
+    title = item_hit.title
+    tags = ",".join([tag.name for tag in item_hit.tags])
 
     s = search_client
-    s = s.query(
-        MoreLikeThis(
-            fields=["tags.name", "title"],
-            like={"_index": index, "_id": _id},
-            min_term_freq=1,
-            max_query_terms=50,
-        )
-    )
-    # Prevent the items that users set as `mature` from showing up in
-    # recommendations.
-    s = s.exclude("term", mature=True)
+
+    # Match the title or tags
+    title_query = SimpleQueryString(query=title, fields=["title"])
+    tags_query = SimpleQueryString(fields=["tags.name"], query=tags)
+    related_query = title_query | tags_query
+
+    # Exclude the current item and mature content.
+    s = s.query(related_query & ~Match(identifier__keyword=uuid) & ~Term(mature=True))
+    # Exclude the dynamically disabled sources.
     s = _exclude_filtered(s)
-    page_size = 10
-    page = 1
+
+    page, page_size = 1, 10
     start, end = _get_query_slice(s, page_size, page, filter_dead)
     s = s[start:end]
+
     response = s.execute()
     results = _post_process_results(s, start, end, page_size, response, filter_dead)
-
-    result_count, _ = _get_result_and_page_count(response, results, page_size, page)
-
-    return results or [], result_count
+    return results or []
 
 
 def get_sources(index):

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -510,7 +510,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
 
     # Match related using tags, if the item has any.
     if tags := getattr(item_hit, "tags", None):
-        tags = ",".join([tag.name for tag in tags])
+        # Only use the first 10 tags
+        tags = ",".join([tag.name for tag in tags[:10]])
         tags_query = SimpleQueryString(fields=["tags.name"], query=tags)
         related_query |= tags_query
 

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -158,10 +158,9 @@ class MediaViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def related(self, request, identifier=None, *_, **__):
         try:
-            index = f"{self.default_index}-filtered"
             results = search_controller.related_media(
                 uuid=identifier,
-                index=index,
+                index=self.default_index,
                 filter_dead=True,
             )
             self.paginator.page_count = 1

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -159,15 +159,16 @@ class MediaViewSet(ReadOnlyModelViewSet):
     def related(self, request, identifier=None, *_, **__):
         try:
             index = f"{self.default_index}-filtered"
-            results, num_results = search_controller.related_media(
+            results = search_controller.related_media(
                 uuid=identifier,
                 index=index,
                 filter_dead=True,
             )
-            self.paginator.result_count = num_results
             self.paginator.page_count = 1
             # `page_size` refers to the maximum number of related images to return.
             self.paginator.page_size = 10
+            # `result_count` is hard-coded and is equal to the page size.
+            self.paginator.result_count = 10
         except ValueError as e:
             raise APIException(getattr(e, "message", str(e)))
         # If there are no hits in the search controller


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3149 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the related endpoint: now, instead of using `MoreLikeThis` query, it gets the title and the tags of the media, and searches for title/tag matches.
We use `or` between the title and tag queries (ES's should, not must) to make sure that there's a match (even if there's no match by title or no match by tags alone). I'm not sure what will happen if both are blank. What happens now?

The related no longer checks for `sensitivities` because it filters out the sensitive and mature results.
It also now returns 10 as the result_count because it does not make sense to return the full result count: there's no way to get other pages of the results, and this piece of information is not meaningful.

On main, the `/related` endpoint makes 3 ES requests. One to get the item itself and its `id`, one to get the MoreLikeThis query, and one to get all the sensitivities.
```
[f26e9f8778024f46b6652f5e48865267] POST http://es:9200/image/_search [status:200 duration:0.198s]
[2023-10-06 05:47:55,926 - elastic_transport.transport - 335][INFO] [f26e9f8778024f46b6652f5e48865267] POST http://es:9200/image/_search [status:200 duration:0.250s]
[2023-10-06 05:47:57,051 - elastic_transport.transport - 335][INFO] [f26e9f8778024f46b6652f5e48865267] POST http://es:9200/image-filtered/_search [status:200 duration:0.015s]
```

With this change, we get 2 ES requests. One gets the item itself to extract its title and tags. The other gets the title/tag matches.

```
[2023-10-06 05:45:37,855 - elastic_transport.transport - 335][INFO] [62341dcfaff941e197f6a083250b559c] POST http://es:9200/image-filtered/_search [status:200 duration:0.040s]
[2023-10-06 05:45:38,043 - elastic_transport.transport - 335][INFO] [62341dcfaff941e197f6a083250b559c] POST http://es:9200/image-filtered/_search [status:200 duration:0.074s]
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and check the `related` results. 
To see this work visually, you can run the frontend Nuxt app using the local API:
1. Set the API_URL variable in the `frontend/.env`: `API_URL=http://0.0.0.0:50280/`
2. Run the API using `just up`.
3. Run Nuxt using `just frontend/run dev`.

Compare the related items for the same image locally and in prod:
http://localhost:8443/image/c8e21cd7-ef1a-4a18-a2aa-5ec6730a33b4?q=japan
https://openverse.org/image/9cebb303-3787-4ac0-a9bc-47c182bbe237?q=%E9%81%A0%E3%81%8F%E8%BF%91%E3%81%8F%E3%81%AB%E3%81%BE%E3%81%9A%E3%81%B2%E3%81%A8%E3%81%A4
I think that since we removed the `creator` from the `related` query, the items are much closely "related" now. 
_I don't know why the uuids for the same image are different in the sample data and the prod data._

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
