### PR TITLE
fix: Replace RequestError with BadRequestError

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -9,7 +9,7 @@ from typing import Literal
 from django.conf import settings
 from django.core.cache import cache
 
-from elasticsearch.exceptions import NotFoundError, BadRequestError
+from elasticsearch.exceptions import BadRequestError, NotFoundError
 from elasticsearch_dsl import Q, Search
 from elasticsearch_dsl.query import EMPTY_QUERY, MoreLikeThis, Query
 from elasticsearch_dsl.response import Hit, Response

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -9,7 +9,7 @@ from typing import Literal
 from django.conf import settings
 from django.core.cache import cache
 
-from elasticsearch.exceptions import NotFoundError, RequestError
+from elasticsearch.exceptions import NotFoundError, BadRequestError
 from elasticsearch_dsl import Q, Search
 from elasticsearch_dsl.query import EMPTY_QUERY, MoreLikeThis, Query
 from elasticsearch_dsl.response import Hit, Response
@@ -447,7 +447,7 @@ def search(
 
         if settings.VERBOSE_ES_RESPONSE:
             log.info(pprint.pprint(search_response.to_dict()))
-    except (RequestError, NotFoundError) as e:
+    except (BadRequestError, NotFoundError) as e:
         raise ValueError(e)
 
     results = _post_process_results(

--- a/documentation/meta/monitoring/cloudwatch_logs/index.md
+++ b/documentation/meta/monitoring/cloudwatch_logs/index.md
@@ -184,7 +184,7 @@ outputs stack traces, for example, this means that stack traces will be split
 across multiple lines. Take the following, real stack trace:
 
 ```
-2023-06-04T00:32:12.485Z	2023-06-04 00:32:12,485 ERROR tasks.py:220 - Error processing task `CREATE_AND_POPULATE_FILTERED_INDEX` for `audio`: RequestError(400, 'search_phase_execution_exception', 'too_many_clauses: maxClauseCount is set to 1024')
+2023-06-04T00:32:12.485Z	2023-06-04 00:32:12,485 ERROR tasks.py:220 - Error processing task `CREATE_AND_POPULATE_FILTERED_INDEX` for `audio`: BadRequestError(400, 'search_phase_execution_exception', 'too_many_clauses: maxClauseCount is set to 1024')
 2023-06-04T00:32:12.539Z	Process Process-5:
 2023-06-04T00:32:12.541Z	Traceback (most recent call last):
 2023-06-04T00:32:12.541Z	File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
@@ -211,7 +211,7 @@ across multiple lines. Take the following, real stack trace:
 2023-06-04T00:32:12.541Z	self._raise_error(response.status_code, raw_data)
 2023-06-04T00:32:12.541Z	File "/venv/lib/python3.11/site-packages/elasticsearch/connection/base.py", line 328, in _raise_error
 2023-06-04T00:32:12.541Z	raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
-2023-06-04T00:32:12.541Z	elasticsearch.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception', 'too_many_clauses: maxClauseCount is set to 1024')
+2023-06-04T00:32:12.541Z	elasticsearch.exceptions.BadRequestError: BadRequestError(400, 'search_phase_execution_exception', 'too_many_clauses: maxClauseCount is set to 1024')
 ```
 
 Each line (prepended with a timestamp), is a separate log event. The implication


### PR DESCRIPTION
Fixes #3169 by @CodeAnk2829

## Description
`api/controllers/search_controller` imports an exception (`RequestError`) that does not exist causes an unexpected error. This PR fixes the issue by replacing `RequestError` with `BadRequestError`.



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
