### PR TITLE
Fix PR review reminder DAG for case where base branch is 2+ levels deep

### DIFF
--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
@@ -181,6 +181,12 @@ def get_min_required_approvals(gh: GitHubAPI, pr: dict) -> int:
         else:
             raise e
 
+    if "required_pull_request_reviews" not in branch_protection_rules:
+        # This can happen in the rare case where a PR is multiple branches deep,
+        # e.g. it depends on a branch which depends on a branch which depends on main.
+        # In that case, default to the rules for `main` as a safe default.
+        branch_protection_rules = get_branch_protection(gh, repo, "main")
+
     return branch_protection_rules["required_pull_request_reviews"][
         "required_approving_review_count"
     ]


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the PR review reminder DAG for the case where a PR depends on a PR 3 levels from main (creating a chain of `branch_beyond -> branch_tertiary -> branch_secondary -> main`). This case can be seen (at the current time) in #3162 which depends on #3161 which depends on #3143 which is pointed at main. For some reason, that many levels out from `main`, there's still some branch protection information but nothing which has the required pull request reviews.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the PR review request reminder DAG locally and see that it succeeds (whereas current runs on `main` are failing).

Tests should also pass!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
