### PR TITLE
Add DAG for filtering archived providers in catalog

### DIFF
--- a/catalog/dags/common/loader/sql.py
+++ b/catalog/dags/common/loader/sql.py
@@ -7,7 +7,7 @@ from psycopg2.errors import InvalidTextRepresentation
 from common.constants import IMAGE, MediaType, SQLInfo
 from common.loader import provider_details as prov
 from common.loader.paths import _extract_media_type
-from common.sql import PostgresHook
+from common.sql import RETURN_ROW_COUNT, PostgresHook
 from common.storage import columns as col
 from common.storage.columns import NULL, Column, UpsertStrategy
 from common.storage.db_columns import setup_db_columns_for_media_type
@@ -40,7 +40,6 @@ OLDEST_PER_PROVIDER = {
 }
 
 CURRENT_TSV_VERSION = "001"
-RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731
 
 
 def create_column_definitions(table_columns: list[Column], is_loading=True):

--- a/catalog/dags/common/sql.py
+++ b/catalog/dags/common/sql.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 # https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/_api/airflow/providers/postgres/hooks/postgres/index.html#airflow.providers.postgres.hooks.postgres.PostgresHook.copy_expert # noqa
 
 
+RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731
+
+
 def single_value(cursor):
     try:
         row = cursor.fetchone()

--- a/catalog/dags/common/storage/columns.py
+++ b/catalog/dags/common/storage/columns.py
@@ -767,3 +767,13 @@ AUDIO_SET_FOREIGN_IDENTIFIER = StringColumn(
     size=1000,
     truncate=False,
 )
+
+# Columns used by the Deleted Media tables
+
+DELETED_ON = TimestampColumn(
+    name="deleted_on", required=True, upsert_strategy=UpsertStrategy.no_change
+)
+
+DELETED_REASON = StringColumn(
+    name="deleted_reason", required=True, size=80, truncate=True
+)

--- a/catalog/dags/common/storage/db_columns.py
+++ b/catalog/dags/common/storage/db_columns.py
@@ -82,9 +82,29 @@ AUDIO_TABLE_COLUMNS = [
     col.AUDIO_SET_FOREIGN_IDENTIFIER,
 ]
 
+
 DB_COLUMNS_BY_MEDIA_TYPE = {AUDIO: AUDIO_TABLE_COLUMNS, IMAGE: IMAGE_TABLE_COLUMNS}
 
 
 def setup_db_columns_for_media_type(func: callable) -> callable:
     """Provide media-type-specific DB columns as a kwarg to the decorated function."""
     return setup_kwargs_for_media_type(DB_COLUMNS_BY_MEDIA_TYPE, "db_columns")(func)
+
+
+DELETED_IMAGE_TABLE_COLUMNS = IMAGE_TABLE_COLUMNS + [col.DELETED_ON, col.DELETED_REASON]
+DELETED_AUDIO_TABLE_COLUMNS = AUDIO_TABLE_COLUMNS + [col.DELETED_ON, col.DELETED_REASON]
+
+DELETED_MEDIA_DB_COLUMNS_BY_MEDIA_TYPE = {
+    AUDIO: DELETED_AUDIO_TABLE_COLUMNS,
+    IMAGE: DELETED_IMAGE_TABLE_COLUMNS,
+}
+
+
+def setup_deleted_db_columns_for_media_type(func: callable) -> callable:
+    """
+    Provide media-type-specific deleted media DB columns as a kwarg to the decorated
+    function.
+    """
+    return setup_kwargs_for_media_type(
+        DELETED_MEDIA_DB_COLUMNS_BY_MEDIA_TYPE, "deleted_db_columns"
+    )(func)

--- a/catalog/dags/database/batched_update/batched_update.py
+++ b/catalog/dags/database/batched_update/batched_update.py
@@ -7,7 +7,7 @@ from airflow.models.abstractoperator import AbstractOperator
 
 from common import slack
 from common.constants import POSTGRES_CONN_ID
-from common.sql import PostgresHook, single_value
+from common.sql import RETURN_ROW_COUNT, PostgresHook, single_value
 from database.batched_update import constants
 
 
@@ -57,7 +57,7 @@ def run_sql(
     postgres_conn_id: str = POSTGRES_CONN_ID,
     task: AbstractOperator = None,
     timeout: timedelta = None,
-    handler: callable = constants.RETURN_ROW_COUNT,
+    handler: callable = RETURN_ROW_COUNT,
     **kwargs,
 ):
     query = sql_template.format(

--- a/catalog/dags/database/batched_update/constants.py
+++ b/catalog/dags/database/batched_update/constants.py
@@ -40,4 +40,3 @@ UPDATE_BATCH_QUERY = """
     );
     """
 DROP_TABLE_QUERY = "DROP TABLE IF EXISTS {temp_table_name} CASCADE;"
-RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731

--- a/catalog/dags/database/delete_records/constants.py
+++ b/catalog/dags/database/delete_records/constants.py
@@ -19,4 +19,3 @@ DELETE_RECORDS_QUERY = """
     DELETE FROM {table}
     {select_query}
     """
-RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731

--- a/catalog/dags/database/delete_records/constants.py
+++ b/catalog/dags/database/delete_records/constants.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta
+
+
+DAG_ID = "delete_records"
+SLACK_USERNAME = "Upstream Delete Records"
+SLACK_ICON = ":database:"
+START_DATE = datetime(2023, 10, 25)
+DAGRUN_TIMEOUT = timedelta(days=31 * 3)
+CREATE_TIMEOUT = timedelta(hours=6)
+DELETE_TIMEOUT = timedelta(hours=1)
+
+CREATE_RECORDS_QUERY = """
+    INSERT INTO {destination_table} ({destination_cols})
+    SELECT {source_cols}
+    FROM {source_table}
+    {select_query}
+    """
+DELETE_RECORDS_QUERY = """
+    DELETE FROM {table}
+    {select_query}
+    """
+RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731

--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -1,0 +1,104 @@
+import logging
+from datetime import timedelta
+
+from airflow.decorators import task
+from airflow.models.abstractoperator import AbstractOperator
+
+from common import slack
+from common.constants import POSTGRES_CONN_ID
+from common.sql import PostgresHook
+from common.storage.columns import DELETED_ON, Column
+from common.storage.db_columns import (
+    setup_db_columns_for_media_type,
+    setup_deleted_db_columns_for_media_type,
+)
+from database.delete_records import constants
+
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def run_sql(
+    sql_template: str,
+    postgres_conn_id: str = POSTGRES_CONN_ID,
+    task: AbstractOperator = None,
+    timeout: timedelta = None,
+    handler: callable = constants.RETURN_ROW_COUNT,
+    **kwargs,
+):
+    query = sql_template.format(**kwargs)
+
+    postgres = PostgresHook(
+        postgres_conn_id=postgres_conn_id,
+        default_statement_timeout=(
+            timeout if timeout else PostgresHook.get_execution_timeout(task)
+        ),
+    )
+
+    return postgres.run(query, handler=handler)
+
+
+@task
+@setup_deleted_db_columns_for_media_type
+@setup_db_columns_for_media_type
+def create_deleted_records(
+    *,
+    select_query: str,
+    deleted_reason: str,
+    media_type: str,
+    db_columns: list[Column],
+    deleted_db_columns: list[Column],
+    task: AbstractOperator = None,
+    postgres_conn_id: str = POSTGRES_CONN_ID,
+):
+    """
+    Select records from the given media table using the select query, and then for each
+    record create a corresponding record in the Deleted Media table.
+    """
+
+    destination_cols = ", ".join([col.db_name for col in deleted_db_columns])
+
+    # To build the source columns, we first list all columns in the main media table
+    source_cols = ", ".join([col.db_name for col in db_columns])
+    # Then add the deleted-media specific columns.
+    # `deleted_on` is set to its insert value to get the current timestamp:
+    source_cols += f", {DELETED_ON.get_insert_value()}"
+    # `deleted_reason` is set to the given string
+    source_cols += f", '{deleted_reason}'"
+
+    return run_sql.function(
+        sql_template=constants.CREATE_RECORDS_QUERY,
+        postgres_conn_id=postgres_conn_id,
+        task=task,
+        destination_table=f"deleted_{media_type}",
+        destination_cols=destination_cols,
+        source_table=media_type,
+        source_cols=source_cols,
+        select_query=select_query,
+    )
+
+
+@task
+def delete_records_from_media_table(
+    table: str, select_query: str, postgres_conn_id: str = POSTGRES_CONN_ID
+):
+    """Delete records matching the select_query from the given media table."""
+    return run_sql.function(
+        sql_template=constants.DELETE_RECORDS_QUERY,
+        table=table,
+        select_query=select_query,
+    )
+
+
+@task
+def notify_slack(text: str) -> str:
+    """Send a message to Slack."""
+    slack.send_message(
+        text,
+        username=constants.SLACK_USERNAME,
+        icon_emoji=constants.SLACK_ICON,
+        dag_id=constants.DAG_ID,
+    )
+
+    return text

--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -6,7 +6,7 @@ from airflow.models.abstractoperator import AbstractOperator
 
 from common import slack
 from common.constants import POSTGRES_CONN_ID
-from common.sql import PostgresHook
+from common.sql import RETURN_ROW_COUNT, PostgresHook
 from common.storage.columns import DELETED_ON, Column
 from common.storage.db_columns import (
     setup_db_columns_for_media_type,
@@ -24,7 +24,7 @@ def run_sql(
     postgres_conn_id: str = POSTGRES_CONN_ID,
     task: AbstractOperator = None,
     timeout: timedelta = None,
-    handler: callable = constants.RETURN_ROW_COUNT,
+    handler: callable = RETURN_ROW_COUNT,
     **kwargs,
 ):
     query = sql_template.format(**kwargs)

--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -18,7 +18,6 @@ from database.delete_records import constants
 logger = logging.getLogger(__name__)
 
 
-@task
 def run_sql(
     sql_template: str,
     postgres_conn_id: str = POSTGRES_CONN_ID,
@@ -47,8 +46,8 @@ def create_deleted_records(
     select_query: str,
     deleted_reason: str,
     media_type: str,
-    db_columns: list[Column],
-    deleted_db_columns: list[Column],
+    db_columns: list[Column] = None,
+    deleted_db_columns: list[Column] = None,
     task: AbstractOperator = None,
     postgres_conn_id: str = POSTGRES_CONN_ID,
 ):
@@ -67,7 +66,7 @@ def create_deleted_records(
     # `deleted_reason` is set to the given string
     source_cols += f", '{deleted_reason}'"
 
-    return run_sql.function(
+    return run_sql(
         sql_template=constants.CREATE_RECORDS_QUERY,
         postgres_conn_id=postgres_conn_id,
         task=task,
@@ -84,7 +83,7 @@ def delete_records_from_media_table(
     table: str, select_query: str, postgres_conn_id: str = POSTGRES_CONN_ID
 ):
     """Delete records matching the select_query from the given media table."""
-    return run_sql.function(
+    return run_sql(
         sql_template=constants.DELETE_RECORDS_QUERY,
         table=table,
         select_query=select_query,

--- a/catalog/dags/database/delete_records/delete_records_dag.py
+++ b/catalog/dags/database/delete_records/delete_records_dag.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
     tags=["database"],
     dagrun_timeout=constants.DAGRUN_TIMEOUT,
     doc_md=__doc__,
-    default_args=DAG_DEFAULT_ARGS,
+    default_args={**DAG_DEFAULT_ARGS, "retries": 0},
     render_template_as_native_obj=True,
     params={
         "table_name": Param(

--- a/catalog/dags/database/delete_records/delete_records_dag.py
+++ b/catalog/dags/database/delete_records/delete_records_dag.py
@@ -1,0 +1,115 @@
+"""
+Delete Records DAG
+
+This DAG is used to delete records from the Catalog media tables, after creating a
+corresponding record in the associated `deleted_<media_type>` table for each record
+to be deleted. It is important to note that records deleted by this DAG will still be
+available in the API until the next data refresh runs.
+
+Presently, there is no logic to prevent records that have an entry in a Deleted Media
+table from simply being reingested during provider ingestion. Therefore in its current
+state, the DAG should _only_ be used to delete records that we can guarantee will not
+be reingested (for example, because the provider is archived).
+
+This DAG does not have automated handling for deadlocks, so you must be certain that
+records selected for deletion in this DAG are not also being written to by a provider
+DAG, for instance. The simplest way to do this is to ensure that any affected provider
+DAGs are not currently running.
+
+
+Required Dagrun Configuration parameters:
+
+* table_name:   the name of the table to delete from. Must be a valid media table
+* select_query: a SQL `WHERE` clause used to select the rows that will be deleted
+* reason:       a string explaining the reason for deleting the records. Ex ('deadlink')
+
+
+An example dag_run configuration used to delete all records for the "foo" image provider
+due to deadlinks would look like this:
+
+```
+{
+    "table_name": "image",
+    "select_query": "WHERE provider='foo'",
+    "reason": "deadlink"
+}
+```
+"""
+
+
+import logging
+
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from common.constants import AUDIO, DAG_DEFAULT_ARGS, MEDIA_TYPES
+from database.delete_records import constants
+from database.delete_records.delete_records import (
+    create_deleted_records,
+    delete_records_from_media_table,
+    notify_slack,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dag(
+    dag_id=constants.DAG_ID,
+    schedule=None,
+    start_date=constants.START_DATE,
+    tags=["database"],
+    dagrun_timeout=constants.DAGRUN_TIMEOUT,
+    doc_md=__doc__,
+    default_args=DAG_DEFAULT_ARGS,
+    render_template_as_native_obj=True,
+    params={
+        "table_name": Param(
+            default=AUDIO,
+            enum=MEDIA_TYPES,
+            description=("The name of the media table from which to select records."),
+        ),
+        "select_query": Param(
+            default="WHERE...",
+            type="string",
+            description=(
+                "The `WHERE` clause of a query that selects all the rows to"
+                " be deleted."
+            ),
+            pattern="^WHERE",
+        ),
+        "reason": Param(
+            default="",
+            type="string",
+            description=("Short descriptor of the reason for deleting the records."),
+        ),
+    },
+)
+def delete_records():
+    # Create the records in the Deleted Media table
+    update_deleted_media_table = create_deleted_records.override(
+        task_id="update_deleted_media_table", execution_timeout=constants.CREATE_TIMEOUT
+    )(
+        select_query="{{params.select_query}}",
+        deleted_reason="{{params.reason}}",
+        media_type="{{params.table_name}}",
+        db_columns=None,
+        deleted_db_columns=None,
+    )
+
+    # If successful, delete the records from the media table
+    delete_records = delete_records_from_media_table.override(
+        execution_timeout=constants.DELETE_TIMEOUT
+    )(table="{{params.table_name}}", select_query="{{params.select_query}}")
+
+    notify_complete = notify_slack(
+        text=(
+            f"Deleted {delete_records} records from the"
+            " {{params.table_name}} table matching query: `{{params.select_query}}`."
+        ),
+    )
+
+    update_deleted_media_table >> delete_records >> notify_complete
+
+
+delete_records()

--- a/catalog/dags/database/delete_records/delete_records_dag.py
+++ b/catalog/dags/database/delete_records/delete_records_dag.py
@@ -1,21 +1,10 @@
 """
-Delete Records DAG
+# Delete Records DAG
 
 This DAG is used to delete records from the Catalog media tables, after creating a
 corresponding record in the associated `deleted_<media_type>` table for each record
 to be deleted. It is important to note that records deleted by this DAG will still be
 available in the API until the next data refresh runs.
-
-Presently, there is no logic to prevent records that have an entry in a Deleted Media
-table from simply being reingested during provider ingestion. Therefore in its current
-state, the DAG should _only_ be used to delete records that we can guarantee will not
-be reingested (for example, because the provider is archived).
-
-This DAG does not have automated handling for deadlocks, so you must be certain that
-records selected for deletion in this DAG are not also being written to by a provider
-DAG, for instance. The simplest way to do this is to ensure that any affected provider
-DAGs are not currently running.
-
 
 Required Dagrun Configuration parameters:
 
@@ -34,6 +23,18 @@ due to deadlinks would look like this:
     "reason": "deadlink"
 }
 ```
+
+## Warnings
+
+Presently, there is no logic to prevent records that have an entry in a Deleted Media
+table from simply being reingested during provider ingestion. Therefore in its current
+state, the DAG should _only_ be used to delete records that we can guarantee will not
+be reingested (for example, because the provider is archived).
+
+This DAG does not have automated handling for deadlocks, so you must be certain that
+records selected for deletion in this DAG are not also being written to by a provider
+DAG, for instance. The simplest way to do this is to ensure that any affected provider
+DAGs are not currently running.
 """
 
 
@@ -67,7 +68,7 @@ logger = logging.getLogger(__name__)
         "table_name": Param(
             default=AUDIO,
             enum=MEDIA_TYPES,
-            description=("The name of the media table from which to select records."),
+            description="The name of the media table from which to select records.",
         ),
         "select_query": Param(
             default="WHERE...",
@@ -81,35 +82,33 @@ logger = logging.getLogger(__name__)
         "reason": Param(
             default="",
             type="string",
-            description=("Short descriptor of the reason for deleting the records."),
+            description="Short descriptor of the reason for deleting the records.",
         ),
     },
 )
 def delete_records():
     # Create the records in the Deleted Media table
-    update_deleted_media_table = create_deleted_records.override(
+    insert_into_deleted_media_table = create_deleted_records.override(
         task_id="update_deleted_media_table", execution_timeout=constants.CREATE_TIMEOUT
     )(
-        select_query="{{params.select_query}}",
-        deleted_reason="{{params.reason}}",
-        media_type="{{params.table_name}}",
-        db_columns=None,
-        deleted_db_columns=None,
+        select_query="{{ params.select_query }}",
+        deleted_reason="{{ params.reason }}",
+        media_type="{{ params.table_name }}",
     )
 
     # If successful, delete the records from the media table
     delete_records = delete_records_from_media_table.override(
         execution_timeout=constants.DELETE_TIMEOUT
-    )(table="{{params.table_name}}", select_query="{{params.select_query}}")
+    )(table="{{ params.table_name }}", select_query="{{ params.select_query }}")
 
     notify_complete = notify_slack(
         text=(
             f"Deleted {delete_records} records from the"
-            " {{params.table_name}} table matching query: `{{params.select_query}}`."
+            " {{ params.table_name }} table matching query: `{{ params.select_query }}`"
         ),
     )
 
-    update_deleted_media_table >> delete_records >> notify_complete
+    insert_into_deleted_media_table >> delete_records >> notify_complete
 
 
 delete_records()

--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -25,9 +25,8 @@ from psycopg2._json import Json
 
 from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID, XCOM_PULL_TEMPLATE
 from common.licenses import get_license_info_from_license_pair
-from common.loader.sql import RETURN_ROW_COUNT
 from common.slack import send_message
-from common.sql import PostgresHook
+from common.sql import RETURN_ROW_COUNT, PostgresHook
 from providers.provider_dag_factory import AWS_CONN_ID, OPENVERSE_BUCKET
 
 

--- a/catalog/dags/retired/database/terminate_long_queries_workflow.py
+++ b/catalog/dags/retired/database/terminate_long_queries_workflow.py
@@ -17,9 +17,8 @@ from common.constants import (
     OPENLEDGER_API_CONN_ID,
     XCOM_PULL_TEMPLATE,
 )
-from common.loader.sql import RETURN_ROW_COUNT
 from common.slack import send_message
-from common.sql import PostgresHook
+from common.sql import PostgresHook, RETURN_ROW_COUNT
 
 
 logger = logging.getLogger(__name__)

--- a/catalog/tests/dags/database/test_delete_records.py
+++ b/catalog/tests/dags/database/test_delete_records.py
@@ -1,0 +1,248 @@
+import logging
+
+import psycopg2
+import pytest
+
+from catalog.tests.test_utils import sql
+from common.storage import columns as col
+from common.storage.db_columns import DELETED_IMAGE_TABLE_COLUMNS, IMAGE_TABLE_COLUMNS
+from database.delete_records.delete_records import (
+    create_deleted_records,
+    delete_records_from_media_table,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+FID_A = "a"
+FID_B = "b"
+FID_C = "c"
+MATCHING_PROVIDER = "foo"
+NOT_MATCHING_PROVIDER = "bar"
+TITLE = "test title"
+LICENSE = "by"
+
+
+@pytest.fixture
+def identifier(request):
+    return f"{hash(request.node.name)}".replace("-", "_")
+
+
+@pytest.fixture
+def image_table(identifier):
+    # Parallelized tests need to use distinct database tables
+    return f"image_{identifier}"
+
+
+@pytest.fixture
+def deleted_image_table(identifier):
+    return f"deleted_image_{identifier}"
+
+
+@pytest.fixture
+def postgres_with_image_and_deleted_image_table(image_table, deleted_image_table):
+    conn = psycopg2.connect(sql.POSTGRES_TEST_URI)
+    cur = conn.cursor()
+    drop_table_query = f"""
+    DROP TABLE IF EXISTS {image_table} CASCADE;
+    DROP TABLE IF EXISTS {deleted_image_table} CASCADE;
+    """
+    cur.execute(drop_table_query)
+    cur.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;')
+    cur.execute(sql.CREATE_IMAGE_TABLE_QUERY.format(image_table))
+    cur.execute(sql.CREATE_DELETED_IMAGE_TABLE_QUERY.format(deleted_image_table))
+
+    conn.commit()
+
+    yield sql.PostgresRef(cursor=cur, connection=conn)
+
+    cur.execute(drop_table_query)
+
+    cur.close()
+    conn.commit()
+    conn.close()
+
+
+def _load_sample_data_into_image_table(image_table, postgres):
+    DEFAULT_COLS = {
+        col.LICENSE.db_name: LICENSE,
+        col.UPDATED_ON.db_name: "NOW()",
+        col.CREATED_ON.db_name: "NOW()",
+        col.TITLE.db_name: TITLE,
+    }
+
+    # Load sample data into the image table
+    sample_records = [
+        {
+            col.FOREIGN_ID.db_name: FID_A,
+            col.DIRECT_URL.db_name: f"https://images.com/{FID_A}/img.jpg",
+            col.PROVIDER.db_name: MATCHING_PROVIDER,
+        },
+        {
+            col.FOREIGN_ID.db_name: FID_B,
+            col.DIRECT_URL.db_name: f"https://images.com/{FID_B}/img.jpg",
+            col.PROVIDER.db_name: MATCHING_PROVIDER,
+        },
+        {
+            col.FOREIGN_ID.db_name: FID_C,
+            col.DIRECT_URL.db_name: f"https://images.com/{FID_C}/img.jpg",
+            col.PROVIDER.db_name: NOT_MATCHING_PROVIDER,
+        },
+    ]
+
+    sql.load_sample_data_into_image_table(
+        image_table, postgres, [{**record, **DEFAULT_COLS} for record in sample_records]
+    )
+
+
+def test_create_deleted_records(
+    postgres_with_image_and_deleted_image_table,
+    image_table,
+    deleted_image_table,
+    identifier,
+):
+    # Load sample data into the image table
+    _load_sample_data_into_image_table(
+        image_table,
+        postgres_with_image_and_deleted_image_table,
+    )
+
+    # Delete records matching the MATCHING_PROVIDER
+    select_query = f"WHERE provider='{MATCHING_PROVIDER}'"
+    deleted_reason = "FOO"
+    deleted_count = create_deleted_records.function(
+        media_type=image_table,
+        select_query=select_query,
+        deleted_reason=deleted_reason,
+        db_columns=IMAGE_TABLE_COLUMNS,
+        deleted_db_columns=DELETED_IMAGE_TABLE_COLUMNS,
+        postgres_conn_id=sql.POSTGRES_CONN_ID,
+    )
+
+    # Both records A and B should have been added to the deleted image table
+    assert deleted_count == 2
+
+    postgres_with_image_and_deleted_image_table.cursor.execute(
+        f"SELECT * FROM {deleted_image_table};"
+    )
+    actual_rows = postgres_with_image_and_deleted_image_table.cursor.fetchall()
+
+    assert len(actual_rows) == 2
+
+    # They should both retain the fields of the original record, and have
+    # the deleted_reason set appropriately.
+    assert actual_rows[0][sql.fid_idx] == FID_A
+    assert actual_rows[0][sql.title_idx] == TITLE
+    assert actual_rows[0][sql.license_idx] == LICENSE
+    assert actual_rows[0][sql.deleted_reason_idx] == deleted_reason
+
+    assert actual_rows[1][sql.fid_idx] == FID_B
+    assert actual_rows[1][sql.title_idx] == TITLE
+    assert actual_rows[1][sql.license_idx] == LICENSE
+    assert actual_rows[1][sql.deleted_reason_idx] == deleted_reason
+
+
+def test_create_deleted_records_with_query_matching_no_rows(
+    postgres_with_image_and_deleted_image_table,
+    image_table,
+    deleted_image_table,
+    identifier,
+):
+    # Load sample data into the image table
+    _load_sample_data_into_image_table(
+        image_table,
+        postgres_with_image_and_deleted_image_table,
+    )
+
+    # Try to delete records matching a condition that does not exist
+    select_query = "WHERE provider='NONEXISTENT_PROVIDER'"
+    deleted_reason = "FOO"
+    deleted_count = create_deleted_records.function(
+        media_type=image_table,
+        select_query=select_query,
+        deleted_reason=deleted_reason,
+        db_columns=IMAGE_TABLE_COLUMNS,
+        deleted_db_columns=DELETED_IMAGE_TABLE_COLUMNS,
+        postgres_conn_id=sql.POSTGRES_CONN_ID,
+    )
+
+    # No records should have been added to the deleted image table
+    assert deleted_count == 0
+
+    postgres_with_image_and_deleted_image_table.cursor.execute(
+        f"SELECT * FROM {deleted_image_table};"
+    )
+    actual_rows = postgres_with_image_and_deleted_image_table.cursor.fetchall()
+
+    assert len(actual_rows) == 0
+
+
+def test_delete_records_from_media_table(
+    postgres_with_image_and_deleted_image_table,
+    image_table,
+    deleted_image_table,
+    identifier,
+):
+    # Load sample data into the image table
+    _load_sample_data_into_image_table(
+        image_table,
+        postgres_with_image_and_deleted_image_table,
+    )
+
+    # Delete records matching the MATCHING_PROVIDER
+    select_query = f"WHERE provider='{MATCHING_PROVIDER}'"
+    deleted_count = delete_records_from_media_table.function(
+        table=image_table,
+        select_query=select_query,
+        postgres_conn_id=sql.POSTGRES_CONN_ID,
+    )
+
+    # Both records A and B should have been deleted
+    assert deleted_count == 2
+
+    postgres_with_image_and_deleted_image_table.cursor.execute(
+        f"SELECT * FROM {image_table};"
+    )
+    actual_rows = postgres_with_image_and_deleted_image_table.cursor.fetchall()
+
+    # There is only one record left in the image table
+    assert len(actual_rows) == 1
+
+    # They should both retain the fields of the original record, and have
+    # the deleted_reason set appropriately.
+    assert actual_rows[0][sql.fid_idx] == FID_C
+    assert actual_rows[0][sql.title_idx] == TITLE
+    assert actual_rows[0][sql.license_idx] == LICENSE
+
+
+def test_delete_no_records_from_media_table(
+    postgres_with_image_and_deleted_image_table,
+    image_table,
+    deleted_image_table,
+    identifier,
+):
+    # Load sample data into the image table
+    _load_sample_data_into_image_table(
+        image_table,
+        postgres_with_image_and_deleted_image_table,
+    )
+
+    # Try to delete records using a query that matches nothing
+    select_query = "WHERE provider='NONEXISTENT_PROVIDER'"
+    deleted_count = delete_records_from_media_table.function(
+        table=image_table,
+        select_query=select_query,
+        postgres_conn_id=sql.POSTGRES_CONN_ID,
+    )
+
+    # No records should have been deleted
+    assert deleted_count == 0
+
+    postgres_with_image_and_deleted_image_table.cursor.execute(
+        f"SELECT * FROM {image_table};"
+    )
+    actual_rows = postgres_with_image_and_deleted_image_table.cursor.fetchall()
+
+    # All three records are left in the image table
+    assert len(actual_rows) == 3

--- a/catalog/tests/dags/test_dag_parsing.py
+++ b/catalog/tests/dags/test_dag_parsing.py
@@ -26,6 +26,7 @@ DAG_PATHS = [
     "data_refresh/create_filtered_index_dag.py",
     "oauth2/authorize_dag.py",
     "oauth2/token_refresh_dag.py",
+    "database/delete_records/delete_records_dag.py",
 ]
 
 # Expected count from the DagBag once a file has been parsed

--- a/catalog/tests/test_utils/sql.py
+++ b/catalog/tests/test_utils/sql.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from collections import namedtuple
 from unittest import mock
 
@@ -6,7 +7,7 @@ from airflow.models import TaskInstance
 
 from common.loader.sql import create_column_definitions
 from common.storage import columns as col
-from common.storage.db_columns import IMAGE_TABLE_COLUMNS
+from common.storage.db_columns import DELETED_IMAGE_TABLE_COLUMNS, IMAGE_TABLE_COLUMNS
 from common.storage.tsv_columns import CURRENT_IMAGE_TSV_COLUMNS
 
 
@@ -43,6 +44,14 @@ UNIQUE_CONDITION_QUERY = (
     " USING btree (url);"
 )
 
+DELETED_IMAGE_TABLE_COLUMN_DEFINITIONS = create_column_definitions(
+    DELETED_IMAGE_TABLE_COLUMNS
+)
+
+CREATE_DELETED_IMAGE_TABLE_QUERY = f"""CREATE TABLE public.{{}} (
+    {DELETED_IMAGE_TABLE_COLUMN_DEFINITIONS}
+);"""
+
 
 PostgresRef = namedtuple("PostgresRef", ["cursor", "connection"])
 ti = mock.Mock(spec=TaskInstance)
@@ -74,6 +83,9 @@ width_idx = COLUMN_NAMES.index(col.WIDTH.db_name)
 height_idx = COLUMN_NAMES.index(col.HEIGHT.db_name)
 standardized_popularity_idx = COLUMN_NAMES.index(col.STANDARDIZED_POPULARITY.db_name)
 
+DELETED_MEDIA_COLUMN_NAMES = [column.db_name for column in DELETED_IMAGE_TABLE_COLUMNS]
+deleted_reason_idx = DELETED_MEDIA_COLUMN_NAMES.index(col.DELETED_REASON.db_name)
+
 
 def create_query_values(
     column_values: dict,
@@ -90,3 +102,20 @@ def create_query_values(
             val = f"'{str(val)}'"
         result.append(val)
     return ",".join(result)
+
+
+def _get_insert_query(image_table, values: dict):
+    # Append the required identifier
+    values[col.IDENTIFIER.db_name] = uuid.uuid4()
+
+    query_values = create_query_values(values, columns=IMAGE_TABLE_COLUMNS)
+
+    return f"INSERT INTO {image_table} VALUES({query_values});"
+
+
+def load_sample_data_into_image_table(image_table, postgres, records):
+    for record in records:
+        load_data_query = _get_insert_query(image_table, record)
+        postgres.cursor.execute(load_data_query)
+
+    postgres.connection.commit()

--- a/docker/upstream_db/0003_openledger_image_schema.sql
+++ b/docker/upstream_db/0003_openledger_image_schema.sql
@@ -56,35 +56,8 @@ CREATE UNIQUE INDEX image_url_key
 
 
 CREATE TABLE public.deleted_image (
-    identifier uuid PRIMARY KEY DEFAULT public.uuid_generate_v4(),
-    created_on timestamp with time zone NOT NULL,
-    updated_on timestamp with time zone NOT NULL,
+    LIKE public.image,
     deleted_on timestamp with time zone NOT NULL,
-    ingestion_type character varying(80),
-    provider character varying(80),
-    source character varying(80),
-    foreign_identifier character varying(3000),
-    foreign_landing_url character varying(1000),
-    url character varying(3000) NOT NULL,
-    thumbnail character varying(3000),
-    width integer,
-    height integer,
-    filesize integer,
-    license character varying(50) NOT NULL,
-    license_version character varying(25),
-    creator character varying(2000),
-    creator_url character varying(2000),
-    title character varying(5000),
-    meta_data jsonb,
-    tags jsonb,
-    watermarked boolean,
-    last_synced_with_source timestamp with time zone,
-    removed_from_source boolean NOT NULL,
-    filetype character varying(5),
-    category character varying(80),
-    standardized_popularity double precision,
     deleted_reason character varying(80)
 );
-
-
 ALTER TABLE public.deleted_image OWNER TO deploy;

--- a/docker/upstream_db/0003_openledger_image_schema.sql
+++ b/docker/upstream_db/0003_openledger_image_schema.sql
@@ -53,3 +53,38 @@ CREATE UNIQUE INDEX image_identifier_key
 CREATE UNIQUE INDEX image_url_key
     ON public.image
     USING btree (url);
+
+
+CREATE TABLE public.deleted_image (
+    identifier uuid PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+    created_on timestamp with time zone NOT NULL,
+    updated_on timestamp with time zone NOT NULL,
+    deleted_on timestamp with time zone NOT NULL,
+    ingestion_type character varying(80),
+    provider character varying(80),
+    source character varying(80),
+    foreign_identifier character varying(3000),
+    foreign_landing_url character varying(1000),
+    url character varying(3000) NOT NULL,
+    thumbnail character varying(3000),
+    width integer,
+    height integer,
+    filesize integer,
+    license character varying(50) NOT NULL,
+    license_version character varying(25),
+    creator character varying(2000),
+    creator_url character varying(2000),
+    title character varying(5000),
+    meta_data jsonb,
+    tags jsonb,
+    watermarked boolean,
+    last_synced_with_source timestamp with time zone,
+    removed_from_source boolean NOT NULL,
+    filetype character varying(5),
+    category character varying(80),
+    standardized_popularity double precision,
+    deleted_reason character varying(80)
+);
+
+
+ALTER TABLE public.deleted_image OWNER TO deploy;

--- a/docker/upstream_db/0006_openledger_audio_schema.sql
+++ b/docker/upstream_db/0006_openledger_audio_schema.sql
@@ -60,3 +60,44 @@ CREATE UNIQUE INDEX audio_identifier_key
 CREATE UNIQUE INDEX audio_url_key
     ON public.audio
     USING btree (url);
+
+
+CREATE TABLE public.deleted_audio (
+    identifier uuid PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+    created_on timestamp with time zone NOT NULL,
+    updated_on timestamp with time zone NOT NULL,
+    deleted_on timestamp with time zone NOT NULL,
+    ingestion_type character varying(80),
+    provider character varying(80),
+    source character varying(80),
+    foreign_identifier character varying(3000),
+    foreign_landing_url character varying(1000),
+    url character varying(3000) NOT NULL,
+    thumbnail character varying(3000),
+    filetype character varying(5),
+    duration integer,
+    bit_rate integer,
+    sample_rate integer,
+    category character varying(80),
+    genres character varying(80)[],
+    audio_set jsonb,
+    set_position integer,
+    alt_files jsonb,
+    filesize integer,
+    license character varying(50) NOT NULL,
+    license_version character varying(25),
+    creator character varying(2000),
+    creator_url character varying(2000),
+    title character varying(5000),
+    meta_data jsonb,
+    tags jsonb,
+    watermarked boolean,
+    last_synced_with_source timestamp with time zone,
+    removed_from_source boolean NOT NULL,
+    standardized_popularity double precision,
+    audio_set_foreign_identifier character varying(1000),
+    deleted_reason character varying(80)
+);
+
+
+ALTER TABLE public.audio OWNER TO deploy;

--- a/docker/upstream_db/0006_openledger_audio_schema.sql
+++ b/docker/upstream_db/0006_openledger_audio_schema.sql
@@ -63,41 +63,8 @@ CREATE UNIQUE INDEX audio_url_key
 
 
 CREATE TABLE public.deleted_audio (
-    identifier uuid PRIMARY KEY DEFAULT public.uuid_generate_v4(),
-    created_on timestamp with time zone NOT NULL,
-    updated_on timestamp with time zone NOT NULL,
+    LIKE public.audio,
     deleted_on timestamp with time zone NOT NULL,
-    ingestion_type character varying(80),
-    provider character varying(80),
-    source character varying(80),
-    foreign_identifier character varying(3000),
-    foreign_landing_url character varying(1000),
-    url character varying(3000) NOT NULL,
-    thumbnail character varying(3000),
-    filetype character varying(5),
-    duration integer,
-    bit_rate integer,
-    sample_rate integer,
-    category character varying(80),
-    genres character varying(80)[],
-    audio_set jsonb,
-    set_position integer,
-    alt_files jsonb,
-    filesize integer,
-    license character varying(50) NOT NULL,
-    license_version character varying(25),
-    creator character varying(2000),
-    creator_url character varying(2000),
-    title character varying(5000),
-    meta_data jsonb,
-    tags jsonb,
-    watermarked boolean,
-    last_synced_with_source timestamp with time zone,
-    removed_from_source boolean NOT NULL,
-    standardized_popularity double precision,
-    audio_set_foreign_identifier character varying(1000),
     deleted_reason character varying(80)
 );
-
-
-ALTER TABLE public.audio OWNER TO deploy;
+ALTER TABLE public.deleted_audio OWNER TO deploy;

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -44,6 +44,7 @@ The following are DAGs grouped by their primary tag:
 | DAG ID                                                                            | Schedule Interval |
 | --------------------------------------------------------------------------------- | ----------------- |
 | [`batched_update`](#batched_update)                                               | `None`            |
+| [`delete_records`](#delete_records)                                               | `None`            |
 | [`recreate_audio_popularity_calculation`](#recreate_audio_popularity_calculation) | `None`            |
 | [`recreate_image_popularity_calculation`](#recreate_image_popularity_calculation) | `None`            |
 | [`report_pending_reported_media`](#report_pending_reported_media)                 | `@weekly`         |
@@ -126,6 +127,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`check_silenced_dags`](#check_silenced_dags)
 1.  [`create_filtered_audio_index`](#create_filtered_audio_index)
 1.  [`create_filtered_image_index`](#create_filtered_image_index)
+1.  [`delete_records`](#delete_records)
 1.  [`europeana_workflow`](#europeana_workflow)
 1.  [`finnish_museums_workflow`](#finnish_museums_workflow)
 1.  [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3257 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR does a couple of things:

* Adds `deleted_audio` and `deleted_image` DB tables to the Catalog. These tables contain all the same columns as their respective media table, plus two new columns:
  * `deleted_on`: timestamp for when the record was "deleted" (ie added to the table)
  * `deleted_reason`: small string description for why the record was deleted (eg "deadlink")
* Adds a very simple DAG called `delete_records` that takes as params a `media_type`, `select_query`, and `reason`. Then it:
  * Selects all records from the given media table matching the `select_query`, and creates a new row in the corresponding `deleted_media` table that copies all fields over exactly, and adds the `deleted_on` timestamp and sets the `reason` for `deleted_reason`
  * If successful, it then deletes those same rows from the main media table and reports to Slack

The purpose of the table and DAG will be to delete archived provider records in the Catalog (so that they do not need to be filtered in ES on the API side for every query), while preserving the data so that it could be restored.

<img width="624" alt="Screenshot 2023-10-26 at 10 10 29 AM" src="https://github.com/WordPress/openverse/assets/63313398/4ca0b6cc-c4be-48ee-aab0-1ff1d345a4e2">

Some notes on what this DAG and tables do **not** do:

* It does not handle deadlocking or perform the create/deletes in a batched way. That's because our current use case operates on smaller, archived providers that are not undergoing ingestion, so we do not need this functionality. If added in the future, we should reuse code from the `batched_update` DAG.
* It does not add any logic at ingestion to ensure that records present in the deleted media tables are not reingested. Again, this is because our current use case is archived providers that are not undergoing ingestion, so there is no risk. If this DAG/table is used for other use cases in the future, that must be considered.
* It does not provide an automated way of restoring deleted records. In the future, it would be very simple to add a `restore_records` DAG that does the opposite flow (selects records from a deleted media table and copies them into the media table, then deletes the deleted_media record). However we shouldn't need it for this use case, and there are a lot of questions to answer about exactly how that should work/how history should be preserved. _(Note: if something goes wrong in prod and we do want to restore these records, that can be done manually very easily since we're preserving all the data in the deleted media table.)_

All of those things should be considered as part of a future project with a full proposal and implementation plan. The goal of the DAG and tables as they are implemented here is to suit this simple use case, and be easy to extend or change in the future.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You will need to first run `just recreate` to get the new tables in your local env, and restore sample data.

### Test an update with 0 records

Run the `delete_records` DAG with the following configuration:
```
{
"reason":"deadlink"
"select_query":"WHERE provider='foo'"
"table_name":"audio"
}
```
It should run successfully but update 0 records.

### Test with bad SQL

Run the DAG with the following configuration:
```
{
"reason":"deadlink"
"select_query":"WHERE foo=bar"
"table_name":"audio"
}
```
The first task should fail due to the invalid sql. The other tasks should be skipped.

### Test happy path
Run the DAG with the following configuration, simulating what will be done in production:
```
{
"reason":"deadlink"
"select_query":"WHERE provider='freesound'"
"table_name":"audio"
}
```
It should run and report that 828 records were deleted (assuming you started with clean sample data). Now run `just catalog/pgcli` to verify this in the Catalog DB:

```sql
openledger> select count(*) from audio;
+-------+
| count |
|-------|
| 4172  |
+-------+
SELECT 1
Time: 0.012s
openledger> select count(*) from deleted_audio;
+-------+
| count |
|-------|
| 828   |
+-------+
SELECT 1
Time: 0.005s
```
And run `just api/pgcli` to verify that this, of course, has not had an effect on the API yet:
```
openledger> select count(*) from audio;
+-------+
| count |
|-------|
| 5000  |
+-------+
SELECT 1
Time: 0.013s
```

Now, run an audio data refresh locally. When it completes, verify that the API now is missing the deleted records:
```
openledger> select count(*) from audio;
+-------+
| count |
|-------|
| 4172  |
+-------+
SELECT 1
Time: 0.009s
```

## Deployment/ next steps

In production, we'll have to:
* Merge this PR
* Manually run the queries to create the tables in prod
* Run the DAG with the configuration:
```
{
"reason":"deadlink"
"select_query":"WHERE (provider='thorvaldsensmuseum' or provider='eol' or provider='500px' or provider='behance' or provider='iha' or provider='deviantart' or provider='mccordmuseum')"
"table_name":"image"
}
```
(Providers were obtained by running `select distinct provider_identifier from content_provider where filter_content=True` in the API. We could also run the DAG separately for each provider if wanted.)
* Run a full image data refresh. **The records will still be available in the API until the next data refresh is run.**
* Only then can we merge code to remove the filtering for deadlink-only providers from the search controller (which will be in a separate PR).




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
