### PR TITLE
Simplify search query

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -11,7 +11,7 @@ from django.core.cache import cache
 
 from elasticsearch.exceptions import BadRequestError, NotFoundError
 from elasticsearch_dsl import Q, Search
-from elasticsearch_dsl.query import EMPTY_QUERY, Match, Query, SimpleQueryString, Term
+from elasticsearch_dsl.query import EMPTY_QUERY, Match, SimpleQueryString, Term, Terms
 from elasticsearch_dsl.response import Hit, Response
 
 import api.models as models
@@ -34,10 +34,7 @@ PROVIDER = "provider"
 DEEP_PAGINATION_ERROR = "Deep pagination is not allowed."
 QUERY_SPECIAL_CHARACTER_ERROR = "Unescaped special characters are not allowed."
 DEFAULT_BOOST = 10000
-
-
-class RankFeature(Query):
-    name = "rank_feature"
+DEFAULT_SEARCH_FIELDS = ["title", "description", "tags.name"]
 
 
 def _unmasked_query_end(page_size, page):
@@ -235,43 +232,12 @@ def _post_process_results(
     return results[:page_size]
 
 
-def _apply_filter(
-    s: Search,
-    search_params: media_serializers.MediaSearchRequestSerializer,
-    serializer_field: str,
-    es_field: str | None = None,
-    behaviour: Literal["filter", "exclude"] = "filter",
-):
+def get_dynamically_excluded_providers():
     """
-    Parse and apply a filter from the search parameters serializer.
-
-    The parameter key is assumed to have the same name as the corresponding
-    Elasticsearch property. Each parameter value is assumed to be a comma
-    separated list encoded as a string.
-
-    :param s: The ``Search`` instance to apply the filter to
-    :param search_params: the serializer instance containing user input
-    :param serializer_field: the name of the parameter field in ``search_params``
-    :param es_field: the corresponding parameter name in Elasticsearch
-    :param behaviour: whether to accept (``filter``) or reject (``exclude``) the hit
-    :return: the input ``Search`` object with the filters applied
+    Hide data sources from the catalog dynamically.
+    To exclude a provider, set ``filter_content`` to ``True`` in the
+    ``ContentProvider`` model in Django admin.
     """
-
-    if serializer_field in search_params.data:
-        arguments = search_params.data.get(serializer_field)
-        if arguments is None:
-            return s
-        arguments = arguments.split(",")
-        parameter = es_field or serializer_field
-        query = Q("terms", **{parameter: arguments})
-        method = getattr(s, behaviour)
-        return method("bool", should=query)
-
-    return s
-
-
-def _exclude_filtered(s: Search):
-    """Hide data sources from the catalog dynamically."""
 
     filter_cache_key = "filtered_providers"
     filtered_providers = cache.get(key=filter_cache_key)
@@ -282,16 +248,7 @@ def _exclude_filtered(s: Search):
         cache.set(
             key=filter_cache_key, timeout=FILTER_CACHE_TIMEOUT, value=filtered_providers
         )
-    to_exclude = [f["provider_identifier"] for f in filtered_providers]
-    if to_exclude:
-        s = s.exclude("terms", provider=to_exclude)
-    return s
-
-
-def _exclude_sensitive_by_param(s: Search, search_params):
-    if not search_params.validated_data["include_sensitive_results"]:
-        s = s.exclude("term", mature=True)
-    return s
+    return [f["provider_identifier"] for f in filtered_providers]
 
 
 def _resolve_index(
@@ -308,6 +265,133 @@ def _resolve_index(
         return f"{index}-filtered"
 
     return index
+
+
+def create_search_filter_queries(
+    search_params: media_serializers.MediaSearchRequestSerializer,
+) -> dict[str, list[Q]]:
+    """
+    Create a list of Elasticsearch queries for filtering search results.
+    The filter values are given in the request query string.
+    We use ES filters (`filter`, `must_not`) because we don't need to
+    compute the relevance score and the queries are cached for better
+    performance.
+    """
+    queries = {"filter": [], "must_not": []}
+    # Apply term filters. Each tuple pairs a filter's parameter name in the API
+    # with its corresponding field in Elasticsearch. "None" means that the
+    # names are identical.
+    query_filters = {
+        "filter": [
+            ("extension", None),
+            ("category", None),
+            ("source", None),
+            ("license", None),
+            ("license_type", "license"),
+            # Audio-specific filters
+            ("length", None),
+            # Image-specific filters
+            ("aspect_ratio", None),
+            ("size", None),
+        ],
+        "must_not": [
+            ("excluded_source", "source"),
+        ],
+    }
+    for behaviour, filters in query_filters.items():
+        for serializer_field, es_field in filters:
+            if not (arguments := search_params.data.get(serializer_field)):
+                continue
+            arguments = arguments.split(",")
+            parameter = es_field or serializer_field
+            queries[behaviour].append(Q("terms", **{parameter: arguments}))
+    return queries
+
+
+def create_ranking_queries(
+    search_params: media_serializers.MediaSearchRequestSerializer,
+) -> list[Q]:
+    queries = [Q("rank_feature", field="standardized_popularity", boost=DEFAULT_BOOST)]
+    if search_params.data["unstable__authority"]:
+        boost = int(search_params.data["unstable__authority_boost"] * DEFAULT_BOOST)
+        authority_query = Q("rank_feature", field="authority_boost", boost=boost)
+        queries.append(authority_query)
+    return queries
+
+
+def create_search_query(
+    search_params: media_serializers.MediaSearchRequestSerializer,
+) -> Q:
+    # Apply filters from the url query search parameters.
+    url_queries = create_search_filter_queries(search_params)
+    search_queries = {
+        "filter": url_queries["filter"],
+        "must_not": url_queries["must_not"],
+        "must": [],
+        "should": [],
+    }
+
+    # Exclude mature content
+    if not search_params.validated_data["include_sensitive_results"]:
+        search_queries["must_not"].append(Q("term", mature=True))
+    # Exclude dynamically disabled sources (see Redis cache)
+    if excluded_providers := get_dynamically_excluded_providers():
+        search_queries["must_not"].append(Q("terms", provider=excluded_providers))
+
+    # Search either by generic multimatch or by "advanced search" with
+    # individual field-level queries specified.
+    if "q" in search_params.data:
+        query = _quote_escape(search_params.data["q"])
+        base_query_kwargs = {
+            "query": query,
+            "fields": DEFAULT_SEARCH_FIELDS,
+            "default_operator": "AND",
+        }
+
+        if '"' in query:
+            base_query_kwargs["quote_field_suffix"] = ".exact"
+
+        search_queries["must"].append(Q("simple_query_string", **base_query_kwargs))
+        # Boost exact matches on the title
+        quotes_stripped = query.replace('"', "")
+        exact_match_boost = Q(
+            "simple_query_string",
+            fields=["title"],
+            query=f"{quotes_stripped}",
+            boost=10000,
+        )
+        search_queries["should"].append(exact_match_boost)
+    else:
+        for field, field_name in [
+            ("creator", "creator"),
+            ("title", "title"),
+            ("tags", "tags.name"),
+        ]:
+            if field_value := search_params.data.get(field):
+                search_queries["must"].append(
+                    Q(
+                        "simple_query_string",
+                        query=_quote_escape(field_value),
+                        fields=[field_name],
+                    )
+                )
+
+    if settings.USE_RANK_FEATURES:
+        search_queries["should"].extend(create_ranking_queries(search_params))
+
+    # If there are no must query clauses, only the results that match
+    # the`should` clause are returned. To avoid this, we add an empty
+    # query clause to the `must` list.
+    if not search_queries["must"]:
+        search_queries["must"].append(EMPTY_QUERY)
+
+    return Q(
+        "bool",
+        filter=search_queries["filter"],
+        must_not=search_queries["must_not"],
+        must=search_queries["must"],
+        should=search_queries["should"],
+    )
 
 
 def search(
@@ -340,95 +424,14 @@ def search(
     else:
         index = origin_index
 
-    search_client = Search(index=index)
+    s = Search(index=index)
 
-    s = search_client
-    # Apply term filters. Each tuple pairs a filter's parameter name in the API
-    # with its corresponding field in Elasticsearch. "None" means that the
-    # names are identical.
-    filters = [
-        ("extension", None),
-        ("category", None),
-        ("categories", "category"),
-        ("source", None),
-        ("license", None),
-        ("license_type", "license"),
-        # Audio-specific filters
-        ("length", None),
-        # Image-specific filters
-        ("aspect_ratio", None),
-        ("size", None),
-    ]
-    for serializer_field, es_field in filters:
-        if serializer_field in search_params.data:
-            s = _apply_filter(s, search_params, serializer_field, es_field)
-
-    exclude = [
-        ("excluded_source", "source"),
-    ]
-    for serializer_field, es_field in exclude:
-        if serializer_field in search_params.data:
-            s = _apply_filter(s, search_params, serializer_field, es_field, "exclude")
-
-    # Exclude mature content and disabled sources
-    s = _exclude_sensitive_by_param(s, search_params)
-    s = _exclude_filtered(s)
-
-    # Search either by generic multimatch or by "advanced search" with
-    # individual field-level queries specified.
-    search_fields = ["tags.name", "title", "description"]
-    if "q" in search_params.data:
-        query = _quote_escape(search_params.data["q"])
-        base_query_kwargs = {
-            "query": query,
-            "fields": search_fields,
-            "default_operator": "AND",
-        }
-
-        if '"' in query:
-            base_query_kwargs["quote_field_suffix"] = ".exact"
-
-        s = s.query(
-            "simple_query_string",
-            **base_query_kwargs,
-        )
-        # Boost exact matches on the title
-        quotes_stripped = query.replace('"', "")
-        exact_match_boost = Q(
-            "simple_query_string",
-            fields=["title"],
-            query=f"{quotes_stripped}",
-            boost=10000,
-        )
-        s = search_client.query(Q("bool", must=s.query, should=exact_match_boost))
-    else:
-        if "creator" in search_params.data:
-            creator = _quote_escape(search_params.data["creator"])
-            s = s.query("simple_query_string", query=creator, fields=["creator"])
-        if "title" in search_params.data:
-            title = _quote_escape(search_params.data["title"])
-            s = s.query("simple_query_string", query=title, fields=["title"])
-        if "tags" in search_params.data:
-            tags = _quote_escape(search_params.data["tags"])
-            s = s.query("simple_query_string", fields=["tags.name"], query=tags)
-
-    if settings.USE_RANK_FEATURES:
-        feature_boost = {"standardized_popularity": DEFAULT_BOOST}
-        if search_params.data["unstable__authority"]:
-            feature_boost["authority_boost"] = (
-                search_params.data["unstable__authority_boost"] * DEFAULT_BOOST
-            )
-
-        rank_queries = []
-        for field, boost in feature_boost.items():
-            rank_queries.append(Q("rank_feature", field=field, boost=boost))
-        s = search_client.query(
-            Q("bool", must=s.query or EMPTY_QUERY, should=rank_queries)
-        )
+    search_query = create_search_query(search_params)
+    s = s.query(search_query)
 
     # Use highlighting to determine which fields contribute to the selection of
     # top results.
-    s = s.highlight(*search_fields)
+    s = s.highlight(*DEFAULT_SEARCH_FIELDS)
     s = s.highlight_options(order="score")
     s.extra(track_scores=True)
     # Route users to the same Elasticsearch worker node to reduce
@@ -541,7 +544,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
     # Exclude the current item and mature content.
     s = s.query(related_query & ~Term(identifier=uuid) & ~Term(mature=True))
     # Exclude the dynamically disabled sources.
-    s = _exclude_filtered(s)
+    excluded_providers = get_dynamically_excluded_providers()
+    s = s.exclude(Terms(provider=excluded_providers))
 
     page, page_size = 1, 10
     start, end = _get_query_slice(s, page_size, page, filter_dead)

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -379,8 +379,8 @@ def create_search_query(
     if settings.USE_RANK_FEATURES:
         search_queries["should"].extend(create_ranking_queries(search_params))
 
-    # If there are no must query clauses, only the results that match
-    # the`should` clause are returned. To avoid this, we add an empty
+    # If there are no `must` query clauses, only the results that match
+    # the `should` clause are returned. To avoid this, we add an empty
     # query clause to the `must` list.
     if not search_queries["must"]:
         search_queries["must"].append(EMPTY_QUERY)

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -1,0 +1,240 @@
+from django.core.cache import cache
+
+import pytest
+
+from api.controllers import search_controller
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_create_search_query_empty(media_type_config):
+    serializer = media_type_config.search_request_serializer(data={})
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [{"match_all": {}}],
+        "should": [
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}
+        ],
+    }
+
+
+def test_create_search_query_empty_no_ranking(media_type_config, settings):
+    settings.USE_RANK_FEATURES = False
+    serializer = media_type_config.search_request_serializer(data={})
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [{"match_all": {}}],
+    }
+
+
+def test_create_search_query_q_search_no_filters(media_type_config):
+    serializer = media_type_config.search_request_serializer(data={"q": "cat"})
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [
+            {
+                "simple_query_string": {
+                    "default_operator": "AND",
+                    "fields": ["title", "description", "tags.name"],
+                    "query": "cat",
+                }
+            }
+        ],
+        "should": [
+            {
+                "simple_query_string": {
+                    "boost": 10000,
+                    "fields": ["title"],
+                    "query": "cat",
+                }
+            },
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
+        ],
+    }
+
+
+def test_create_search_query_q_search_with_quotes_adds_exact_suffix(media_type_config):
+    serializer = media_type_config.search_request_serializer(
+        data={"q": '"The cutest cat"'}
+    )
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [
+            {
+                "simple_query_string": {
+                    "default_operator": "AND",
+                    "fields": ["title", "description", "tags.name"],
+                    "query": '"The cutest cat"',
+                    "quote_field_suffix": ".exact",
+                }
+            }
+        ],
+        "should": [
+            {
+                "simple_query_string": {
+                    "boost": 10000,
+                    "fields": ["title"],
+                    "query": "The cutest cat",
+                }
+            },
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
+        ],
+    }
+
+
+def test_create_search_query_q_search_with_filters(image_media_type_config):
+    serializer = image_media_type_config.search_request_serializer(
+        data={
+            "q": "cat",
+            "license": "by-nc",
+            "aspect_ratio": "wide",
+            # this is a deprecated param, and it doesn't work because it doesn't exist in the serializer
+            "categories": "digitized_artwork",
+            "category": "illustration",
+            "excluded_source": "flickr",
+            "unstable__authority": True,
+            "unstable__authority_boost": "2.5",
+            "unstable__include_sensitive_results": True,
+        }
+    )
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "filter": [
+            {"terms": {"category": ["illustration"]}},
+            {"terms": {"license": ["by-nc"]}},
+            {"terms": {"aspect_ratio": ["wide"]}},
+        ],
+        "must_not": [{"terms": {"source": ["flickr"]}}],
+        "must": [
+            {
+                "simple_query_string": {
+                    "default_operator": "AND",
+                    "fields": ["title", "description", "tags.name"],
+                    "query": "cat",
+                }
+            }
+        ],
+        "should": [
+            {
+                "simple_query_string": {
+                    "boost": 10000,
+                    "fields": ["title"],
+                    "query": "cat",
+                }
+            },
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
+            {"rank_feature": {"boost": 25000, "field": "authority_boost"}},
+        ],
+    }
+
+
+def test_create_search_query_non_q_query(image_media_type_config):
+    serializer = image_media_type_config.search_request_serializer(
+        data={
+            "creator": "Artist From Openverse",
+            "title": "kitten🐱",
+            "tags": "cute",
+        }
+    )
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [
+            {
+                "simple_query_string": {
+                    "fields": ["creator"],
+                    "query": "Artist From Openverse",
+                }
+            },
+            {"simple_query_string": {"fields": ["title"], "query": "kitten🐱"}},
+            {"simple_query_string": {"fields": ["tags.name"], "query": "cute"}},
+        ],
+        "should": [
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
+        ],
+    }
+
+
+def test_create_search_query_q_search_license_license_type_creates_2_terms_filters(
+    image_media_type_config,
+):
+    serializer = image_media_type_config.search_request_serializer(
+        data={
+            "license": "by-nc",
+            "license_type": "commercial",
+        }
+    )
+    serializer.is_valid()
+    search_query = search_controller.create_search_query(serializer)
+    actual_query_clauses = search_query.to_dict()["bool"]
+
+    first_license_terms_filter = actual_query_clauses["filter"][0]
+    second_license_terms_filter_licenses = sorted(
+        actual_query_clauses["filter"][1]["terms"]["license"]
+    )
+    # Extracting these to make comparisons not dependent on list order.
+    assert first_license_terms_filter == {"terms": {"license": ["by-nc"]}}
+    assert second_license_terms_filter_licenses == [
+        "by",
+        "by-nd",
+        "by-sa",
+        "cc0",
+        "pdm",
+        "sampling+",
+    ]
+    actual_query_clauses.pop("filter", None)
+
+    assert actual_query_clauses == {
+        "must_not": [{"term": {"mature": True}}],
+        "must": [{"match_all": {}}],
+        "should": [
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
+        ],
+    }
+
+
+def test_create_search_query_empty_with_dynamically_excluded_providers(
+    image_media_type_config,
+):
+    excluded = {"provider_identifier": "flickr"}
+    cache.set(key="filtered_providers", timeout=1, value=[excluded])
+
+    serializer = image_media_type_config.search_request_serializer(data={})
+    serializer.is_valid()
+
+    search_query = search_controller.create_search_query(serializer)
+
+    actual_query_clauses = search_query.to_dict()["bool"]
+    assert actual_query_clauses == {
+        "must_not": [
+            {"term": {"mature": True}},
+            {"terms": {"provider": [excluded["provider_identifier"]]}},
+        ],
+        "must": [{"match_all": {}}],
+        "should": [
+            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}
+        ],
+    }

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 
 def test_create_search_query_empty(media_type_config):
     serializer = media_type_config.search_request_serializer(data={})
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -26,7 +26,7 @@ def test_create_search_query_empty(media_type_config):
 def test_create_search_query_empty_no_ranking(media_type_config, settings):
     settings.USE_RANK_FEATURES = False
     serializer = media_type_config.search_request_serializer(data={})
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -38,7 +38,7 @@ def test_create_search_query_empty_no_ranking(media_type_config, settings):
 
 def test_create_search_query_q_search_no_filters(media_type_config):
     serializer = media_type_config.search_request_serializer(data={"q": "cat"})
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -70,7 +70,7 @@ def test_create_search_query_q_search_with_quotes_adds_exact_suffix(media_type_c
     serializer = media_type_config.search_request_serializer(
         data={"q": '"The cutest cat"'}
     )
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -114,7 +114,7 @@ def test_create_search_query_q_search_with_filters(image_media_type_config):
             "unstable__include_sensitive_results": True,
         }
     )
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -156,7 +156,7 @@ def test_create_search_query_non_q_query(image_media_type_config):
             "tags": "cute",
         }
     )
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -187,7 +187,7 @@ def test_create_search_query_q_search_license_license_type_creates_2_terms_filte
             "license_type": "commercial",
         }
     )
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
     search_query = search_controller.create_search_query(serializer)
     actual_query_clauses = search_query.to_dict()["bool"]
 
@@ -223,7 +223,7 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
     cache.set(key="filtered_providers", timeout=1, value=[excluded])
 
     serializer = image_media_type_config.search_request_serializer(data={})
-    serializer.is_valid()
+    serializer.is_valid(raise_exception=True)
 
     search_query = search_controller.create_search_query(serializer)
 

--- a/documentation/api/reference/search_algorithm.md
+++ b/documentation/api/reference/search_algorithm.md
@@ -136,11 +136,12 @@ following fields:
 
 - Extension
 - Category
-- Length
-- Aspect ratio
-- Size
 - Source
 - License
+- License type
+- Length (audio only)
+- Aspect ratio (image only)
+- Size (image only)
 
 Source is the only field for which you can currently also specify exclusions.
 
@@ -152,12 +153,13 @@ field:
 - [Audio search](https://api.openverse.engineering/v1/#operation/audio_search)
 - [Image search](https://api.openverse.engineering/v1/#operation/image_search)
 
-Each of these fields are searched relatively strictly, primarily because the
-search domain in each is very small and "keyword" like. That is, there is a
-limited and specific set of terms that appear for the relevant document fields
-for each of these query parameters. All of them are validated to only allow
-specific options (documented in the API documentation links above), which
-enforces the "keyword" like nature of their usage.
+For each of these fields, there is a limited and specific set of terms that
+appear for the relevant document fields for each of these query parameters.
+These fields are matched exactly, using the filter context Elasticsearch queries
+("filter" or "must_not"). Filter-context queries can be cached by Elasticsearch,
+which improves their performance. All of these filters except for `extension`
+are validated to only allow specific options (documented in the API
+documentation links above).
 
 ### General "query" searching
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3243 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Instead of using `elasticsearch_dsl` for creating the search query, this PR uses a simple dictionary for the 4 query clauses: `filter`, `must_not`, `must` and `should`. This dictionary is then used to create a much cleaner query which is almost identical in function to the existing query. 

The biggest difference is that the url parameter queries (license, aspect ratio, width, extension, etc.) are actually filters. They remove all of the non-matching items from the results, instead of simply assigning them a lower score. Not calculating the score should also in theory make the filters faster.

### Query examples
To make these queries similar to the production queries, I checked "Hide content" in the Flickr ContentProvider object form in Django admin. This should dynamically add this provider to `exclude` query.
#### No parameters
http://localhost:50280/v1/images/?format=json&page_size=1
**Updated**
```
{'bool': {
    'must': [{'match_all': {}}],
    'must_not': [{'term': {'mature': True}}, {'terms': {'provider': ['flickr']}}],
    'should': [{'rank_feature': {'boost': 10000, 'field': 'standardized_popularity'}}]
}}
```
**Old**
```
{'bool': {'must': [{'bool': {'filter': [{'bool': {'must_not': [{'term': {'mature': True}}]}},
                                                  {'bool': {'must_not': [{'terms': {'provider': ['flickr']}}]}}]}}],
                    'should': [{'rank_feature': {'boost': 10000,
                                                 'field': 'standardized_popularity'}}]}}
```
#### `q` search with filters
http://localhost:50280/v1/images/?q=cat&format=json&license=by,cc0&aspect_ratio=wide&page_size=1
**Updated**
```
{'bool': {
    'filter': [{'terms': {'license': ['by', 'cc0']}}, {'terms': {'aspect_ratio': ['wide']}}],
    'must': [{'simple_query_string': {'default_operator': 'AND', 'fields': ['title', 'description', 'tags.name'], 'query': 'cat'}}],
    'must_not': [{'term': {'mature': True}}, {'terms': {'provider': ['flickr']}}],
    'should': [{'simple_query_string': {'boost': 10000, 'fields': ['title'], 'query': 'cat'}}, {'rank_feature': {'boost': 10000, 'field': 'standardized_popularity'}}]
}}
```
**Old**
```
{'bool': {
    'must': [{'bool': {'must': [{'bool': {
                 'filter': [
                   {'bool': {'should': [{'terms': {'license': ['by', 'cc0']}}]}},
                   {'bool': {'should': [{'terms': {'aspect_ratio': ['wide']}}]}},
                   {'bool': {'must_not': [{'term': {'mature': True}}]}},
                   {'bool': {'must_not': [{'terms': {'provider': ['flickr']}}]}}
                 ],
                 'must': [{'simple_query_string': {
                                 'default_operator': 'AND', 'fields': ['tags.name', 'title', 'description'],  'query': 'cat'}}]}}],
                 'should': [{'simple_query_string': {'boost': 10000,  'fields': ['title'], 'query': 'cat'}}]}}],
                  'should': [{'rank_feature': {'boost': 10000, 'field': 'standardized_popularity'}}]}},}
```

### `title` search (without `q`) with `excluded_source` param
http://localhost:50280/v1/images/?title=cat&format=json&excluded_source=stocksnap&page_size=1

**New**
```
{'query': {'bool': {
    'must': [{'simple_query_string': {'fields': ['title'], 'query': 'cat'}}],
    'must_not': [{'terms': {'source': ['stocksnap']}},{'terms': {'provider': ['flickr']}}, {'term': {'mature': True}}],
     'should': [{'rank_feature': {'boost': 10000, 'field': 'standardized_popularity'}}]}}
}
```
**Old**
```
{ 'query': {'bool': {
    'must': [{'bool': {'filter': [{'bool': {'must_not': [{'terms': {'source': ['stocksnap']}}]}},
                                                  {'bool': {'must_not': [{'term': {'mature': True}}]}},
                                                  {'bool': {'must_not': [{'terms': {'provider': ['flickr']}}]}}],
    'must': [{'simple_query_string': {'fields': ['title'], 'query': 'cat'}}]}}],
     'should': [{'rank_feature': {'boost': 10000, 'field': 'standardized_popularity'}}]
}}}
```

### Unit tests
I added unit tests for  the newly extracted `search_controller.create_search_query` method. I wish it was easy to parametrize these tests, but because we need to check the whole query for each test, it's not easy to do.

While writing the tests, I realized that the `categories` filter doesn't work anymore. In the `search_controller`, we still try to handle it converting the deprecated `categories` param to the current `category` parameter. However, the serializer does not pass the deprecated `categories` to the controller! So, I just removed the deprecated `categories` param from the controller.

Another thing I learned when writing the tests is that `license` and `license_type` filters don't interact at all, so they create 2 completely separate terms filters. We should probably combine them, taking an intersection of the two license lists as the ES query filter (e.g., if `license=by-nc&license_type=commercial` would not return any results with `by-nc` because the commercial filter would exclude them).


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Set `DEBUG_SCORES=True` to the `api/.env` file so that the Elasticsearch queries a logged in the `web` Docker container logs. 
Run the API using `just up`.
Go to localhost:50280/admin (use deploy/deploy to log in), and check "Hide content" for one of the providers so that one of the providers is excluded dynamically in the queries (to match the current prod settings).
Try the queries from the PR description and look at the queries logged in Docker logs.
Also compare the queries to the ones on the `main` branch and see that they are different.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
