### PR TITLE
Encode spaces in metropolitan urls

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -113,8 +113,8 @@ class MetMuseumDataIngester(ProviderDataIngester):
 
         return [
             {
-                "foreign_landing_url": foreign_landing_url,
-                "url": img,
+                "foreign_landing_url": foreign_landing_url.replace(" ", "%20"),
+                "url": img.replace(" ", "%20"),
                 "license_info": self.DEFAULT_LICENSE_INFO,
                 "foreign_identifier": self._get_foreign_id(object_id, img),
                 "creator": artist,

--- a/catalog/tests/dags/providers/provider_api_scripts/resources/metropolitan_museum_of_art/sample_additional_image_data.json
+++ b/catalog/tests/dags/providers/provider_api_scripts/resources/metropolitan_museum_of_art/sample_additional_image_data.json
@@ -57,9 +57,9 @@
   },
   {
     "creator": "Kiyohara Yukinobu",
-    "foreign_identifier": "45734-DP251120",
+    "foreign_identifier": "45734-1972",
     "foreign_landing_url": "https://wwwstg.metmuseum.org/art/collection/search/45734",
-    "url": "https://images.metmuseum.org/CRDImages/as/original/DP251120.jpg",
+    "url": "https://images.metmuseum.org/CRDImages/dp/original/1972.173%20RECTO.jpg",
     "license_info": {
       "license": "cc0",
       "url": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/catalog/tests/dags/providers/provider_api_scripts/resources/metropolitan_museum_of_art/sample_response.json
+++ b/catalog/tests/dags/providers/provider_api_scripts/resources/metropolitan_museum_of_art/sample_response.json
@@ -3,7 +3,7 @@
   "accessionYear": "1936",
   "additionalImages": [
     "https://images.metmuseum.org/CRDImages/as/original/DP251138.jpg",
-    "https://images.metmuseum.org/CRDImages/as/original/DP251120.jpg"
+    "https://images.metmuseum.org/CRDImages/dp/original/1972.173 RECTO.jpg"
   ],
   "artistAlphaSort": "Kiyohara Yukinobu",
   "artistBeginDate": "1643",


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

The Metropolitan DAG failed in production trying to ingest an image with url "https://images.metmuseum.org/CRDImages/dp/original/1972.173 RECTO.jpg"

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Urlencodes spaces in Metropolitan urls, as this is a valid url.

I noticed and opened #3263 while doing this. See discussion on that issue for why I don't think we should work on that now.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Should be covered by unit tests, but if you want to manually test you can run the metropolitan DAG locally. Set the ingestion date to `2023-10-25` in the conf options to test the day that caused a failure in prod.



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
