### PR TITLE
Simplify related query to remove nesting and make more performant

### DIFF
--- a/api/api/controllers/elasticsearch/helpers.py
+++ b/api/api/controllers/elasticsearch/helpers.py
@@ -4,10 +4,15 @@ import functools
 import logging as log
 import pprint
 import time
+from itertools import accumulate
+from math import ceil
 
 from django.conf import settings
 
 from elasticsearch import BadRequestError, NotFoundError
+from elasticsearch_dsl import Search
+
+from api.utils.dead_link_mask import get_query_hash, get_query_mask
 
 
 def log_timing_info(func):
@@ -55,3 +60,105 @@ def get_es_response(s, *args, **kwargs):
 @log_timing_info
 def get_raw_es_response(index, body, *args, **kwargs):
     return settings.ES.search(index=index, body=body, *args, **kwargs)
+
+
+ELASTICSEARCH_MAX_RESULT_WINDOW = 10000
+DEAD_LINK_RATIO = 1 / 2
+DEEP_PAGINATION_ERROR = "Deep pagination is not allowed."
+
+
+def _unmasked_query_end(page_size, page):
+    """
+    Calculate the upper index of results to retrieve from Elasticsearch.
+
+    Used to retrieve the upper index of results to retrieve from Elasticsearch under the
+    following conditions:
+    1. There is no query mask
+    2. The lower index is beyond the scope of the existing query mask
+    3. The lower index is within the scope of the existing query mask
+    but the upper index exceeds it
+
+    In all these cases, the query mask is not used to calculate the upper index.
+    """
+    return ceil(page_size * page / (1 - DEAD_LINK_RATIO))
+
+
+def _paginate_with_dead_link_mask(
+    s: Search, page_size: int, page: int
+) -> tuple[int, int]:
+    """
+    Return the start and end of the results slice, given the query, page and page size.
+
+    In almost all cases the ``DEAD_LINK_RATIO`` will effectively double
+    the page size (given the current configuration of 0.5).
+
+    The "branch X" labels are for cross-referencing with the tests.
+
+    :param s: The elasticsearch Search object
+    :param page_size: How big the page should be.
+    :param page: The page number.
+    :return: Tuple of start and end.
+    """
+    query_hash = get_query_hash(s)
+    query_mask = get_query_mask(query_hash)
+    if not query_mask:  # branch 1
+        start = 0
+        end = _unmasked_query_end(page_size, page)
+    elif page_size * (page - 1) > sum(query_mask):  # branch 2
+        start = len(query_mask)
+        end = _unmasked_query_end(page_size, page)
+    else:  # branch 3
+        # query_mask is a list of 0 and 1 where 0 indicates the result position
+        # for the given query will be an invalid link. If we accumulate a query
+        # mask you end up, at each index, with the number of live results you
+        # will get back when you query that deeply.
+        # We then query for the start and end index _of the results_ in ES based
+        # on the number of results that we think will be valid based on the query mask.
+        # If we're requesting `page=2 page_size=3` and the mask is [0, 1, 0, 1, 0, 1],
+        # then we know that we have to _start_ with at least the sixth result of the
+        # overall query to skip the first page of 3 valid results. The "end" of the
+        # query will then follow the same pattern to reach the number of valid results
+        # required to fill the requested page. If the mask is not deep enough to
+        # account for the entire range, then we follow the typical assumption when
+        # a mask is not available that the end should be `page * page_size / 0.5`
+        # (i.e., double the page size)
+        accu_query_mask = list(accumulate(query_mask))
+        start = 0
+        if page > 1:
+            try:  # branch 3_start_A
+                # find the index at which we can skip N valid results where N = all
+                # the results that would be skipped to arrive at the start of the
+                # requested page
+                # This will effectively be the index at which we have the number of
+                # previous valid results + 1 because we don't want to include the
+                # last valid result from the previous page
+                start = accu_query_mask.index(page_size * (page - 1) + 1)
+            except ValueError:  # branch 3_start_B
+                # Cannot fail because of the check on branch 2 which verifies that
+                # the query mask already includes at least enough masked valid
+                # results to fulfill the requested page size
+                start = accu_query_mask.index(page_size * (page - 1)) + 1
+        # else:  branch 3_start_C
+        # Always start page=1 queries at 0
+
+        if page_size * page > sum(query_mask):  # branch 3_end_A
+            end = _unmasked_query_end(page_size, page)
+        else:  # branch 3_end_B
+            end = accu_query_mask.index(page_size * page) + 1
+    return start, end
+
+
+def get_query_slice(
+    s: Search, page_size: int, page: int, filter_dead: bool | None = False
+) -> tuple[int, int]:
+    """Select the start and end of the search results for this query."""
+
+    if filter_dead:
+        start_slice, end_slice = _paginate_with_dead_link_mask(s, page_size, page)
+    else:
+        # Paginate search query.
+        start_slice = page_size * (page - 1)
+        end_slice = page_size * page
+    if start_slice + end_slice > ELASTICSEARCH_MAX_RESULT_WINDOW:
+        raise ValueError(DEEP_PAGINATION_ERROR)
+    return start_slice, end_slice

--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from elasticsearch_dsl import Search
+from elasticsearch_dsl.query import Match, Q, SimpleQueryString, Term
+from elasticsearch_dsl.response import Hit
+
+from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
+from api.controllers.search_controller import (
+    _post_process_results,
+    get_excluded_providers_query,
+)
+
+
+def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
+    """
+    Given a UUID, finds 10 related search results based on title and tags.
+
+    Uses Match query for title or SimpleQueryString for tags.
+    If the item has no title and no tags, returns items by the same creator.
+    If the item has no title, no tags or no creator, returns empty list.
+
+    :param uuid: The UUID of the item to find related results for.
+    :param index: The Elasticsearch index to search (e.g. 'image')
+    :param filter_dead: Whether dead links should be removed.
+    :return: List of related results.
+    """
+
+    # Search the default index for the item itself as it might be sensitive.
+    item_search = Search(index=index)
+    item_hit = item_search.query(Term(identifier=uuid)).execute().hits[0]
+
+    # Match related using title.
+    title = getattr(item_hit, "title", None)
+    tags = getattr(item_hit, "tags", None)
+    creator = getattr(item_hit, "creator", None)
+
+    related_query = {"must_not": [], "must": [], "should": []}
+
+    if not title and not tags:
+        if not creator:
+            return []
+        else:
+            # Only use `creator` query if there are no `title` and `tags`
+            related_query["should"].append(Term(creator=creator))
+    else:
+        if title:
+            related_query["should"].append(Match(title=title))
+
+        # Match related using tags, if the item has any.
+        if tags:
+            # Only use the first 10 tags
+            tags = " | ".join([tag.name for tag in tags[:10]])
+            tags_query = SimpleQueryString(fields=["tags.name"], query=tags)
+            related_query["should"].append(tags_query)
+
+    # Exclude the dynamically disabled sources.
+    if excluded_providers_query := get_excluded_providers_query():
+        related_query["must_not"].append(excluded_providers_query)
+    # Exclude the current item and mature content.
+    related_query["must_not"].extend(
+        [Q("term", mature=True), Q("term", identifier=uuid)]
+    )
+
+    # Search the filtered index for related items.
+    s = Search(index=f"{index}-filtered")
+    s = s.query("bool", **related_query)
+
+    page, page_size = 1, 10
+    start, end = get_query_slice(s, page_size, page, filter_dead)
+    s = s[start:end]
+
+    response = get_es_response(s, "related_media")
+    results = _post_process_results(s, start, end, page_size, response, filter_dead)
+    return results or []

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -127,7 +127,7 @@ def _post_process_results(
                 end = search_results.hits.total.value
 
             s = s[start:end]
-            search_response = get_es_response(s, "postprocess_search")
+            search_response = get_es_response(s, es_query="postprocess_search")
 
             return _post_process_results(
                 s, start, end, page_size, search_response, filter_dead

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from api.controllers import search_controller
+from api.controllers.elasticsearch.related import related_media
 from api.models import ContentProvider
 from api.models.media import AbstractMedia
 from api.serializers.provider_serializers import ProviderSerializer
@@ -158,7 +159,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def related(self, request, identifier=None, *_, **__):
         try:
-            results = search_controller.related_media(
+            results = related_media(
                 uuid=identifier,
                 index=self.default_index,
                 filter_dead=True,

--- a/api/test/factory/es_http.py
+++ b/api/test/factory/es_http.py
@@ -5,7 +5,9 @@ MOCK_LIVE_RESULT_URL_PREFIX = "https://example.com/openverse-live-image-result-u
 MOCK_DEAD_RESULT_URL_PREFIX = "https://example.com/openverse-dead-image-result-url"
 
 
-def create_mock_es_http_image_hit(_id: str, index: str, live: bool = True):
+def create_mock_es_http_image_hit(
+    _id: str, index: str, live: bool = True, identifier: str | None = None
+):
     return {
         "_index": index,
         "_type": "_doc",
@@ -20,7 +22,7 @@ def create_mock_es_http_image_hit(_id: str, index: str, live: bool = True):
             "max_boost": 85,
             "min_boost": 1,
             "id": _id,
-            "identifier": str(uuid4()),
+            "identifier": identifier or str(uuid4()),
             "title": "Bird Nature Photo",
             "foreign_landing_url": "https://example.com/photo/LYTN21EBYO",
             "creator": "Nature's Beauty",
@@ -77,5 +79,28 @@ def create_mock_es_http_image_search_response(
             "total": {"value": total_hits, "relation": "eq"},
             "max_score": 11.0007305,
             "hits": base_hits + live_hits + dead_hits,
+        },
+    }
+
+
+def create_mock_es_http_image_response_with_identifier(
+    index: str,
+    identifier: str,
+):
+    return {
+        "took": 3,
+        "timed_out": False,
+        "_shards": {"total": 18, "successful": 18, "skipped": 0, "failed": 0},
+        "hits": {
+            "total": {"value": 1, "relation": "eq"},
+            "max_score": 11.0007305,
+            "hits": [
+                create_mock_es_http_image_hit(
+                    _id="1",
+                    index=index,
+                    live=True,
+                    identifier=identifier,
+                )
+            ],
         },
     }

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -151,8 +151,12 @@ def uuid_validation(media_type, identifier):
 
 def related(fixture):
     related_url = fixture["results"][0]["related_url"]
-    response = requests.get(related_url)
-    assert response.status_code == 200
+    raw_response = requests.get(related_url)
+    response = raw_response.json()
+
+    assert raw_response.status_code == 200
+    assert response["result_count"] == len(response["results"]) == 10
+    assert response["page_count"] == 1
 
 
 def sensitive_search_and_detail(media_type):

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -150,13 +150,23 @@ def uuid_validation(media_type, identifier):
 
 
 def related(fixture):
-    related_url = fixture["results"][0]["related_url"]
+    item = fixture["results"][0]
+
+    def get_terms_set(item):
+        return set([t["name"] for t in item["tags"]] + item["title"].split(" "))
+
+    terms_set = get_terms_set(item)
+    related_url = item["related_url"]
     raw_response = requests.get(related_url)
     response = raw_response.json()
 
     assert raw_response.status_code == 200
     assert response["result_count"] == len(response["results"]) == 10
     assert response["page_count"] == 1
+
+    # Make sure each result has at least one word in common with the original item
+    for result in response["results"]:
+        assert len(terms_set.intersection(get_terms_set(result))) > 0
 
 
 def sensitive_search_and_detail(media_type):

--- a/api/test/test_dead_link_filter.py
+++ b/api/test/test_dead_link_filter.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 from fakeredis import FakeRedis
 
-from api.controllers.search_controller import DEAD_LINK_RATIO
+from api.controllers.elasticsearch.helpers import DEAD_LINK_RATIO
 
 
 @pytest.fixture(autouse=True)

--- a/api/test/test_image_integration.py
+++ b/api/test/test_image_integration.py
@@ -149,5 +149,5 @@ def test_image_related(image_fixture):
     related(image_fixture)
 
 
-def test_audio_sensitive_search_and_detail():
+def test_image_sensitive_search_and_detail():
     sensitive_search_and_detail("images")

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -1,0 +1,95 @@
+from test.factory.es_http import (
+    MOCK_LIVE_RESULT_URL_PREFIX,
+    create_mock_es_http_image_response_with_identifier,
+    create_mock_es_http_image_search_response,
+)
+from test.factory.models import ImageFactory
+from unittest import mock
+
+import pook
+import pytest
+
+from api.controllers import search_controller
+
+
+pytestmark = pytest.mark.django_db
+
+
+@mock.patch(
+    "api.controllers.search_controller.related_media",
+    wraps=search_controller.related_media,
+)
+@pook.on
+def test_related_media(
+    wrapped_related_results,
+    image_media_type_config,
+    settings,
+    # request the redis mock to auto-clean Redis between each test run
+    # otherwise the dead link query mask causes test details to leak
+    # between each run
+    redis,
+):
+    image = ImageFactory.create()
+
+    # Mock the ES response for the item itself
+    es_original_index_endpoint = (
+        f"{settings.ES_ENDPOINT}/{image_media_type_config.origin_index}/_search"
+    )
+    mock_es_hit_response = create_mock_es_http_image_response_with_identifier(
+        index=image_media_type_config.origin_index,
+        identifier=image.identifier,
+    )
+    pook.post(es_original_index_endpoint).times(1).reply(200).header(
+        "x-elastic-product", "Elasticsearch"
+    ).json(mock_es_hit_response)
+
+    # Mock the post process ES requests
+    pook.head(pook.regex(rf"{MOCK_LIVE_RESULT_URL_PREFIX}/\d")).times(20).reply(200)
+
+    # Related only queries the filtered index, so we mock that.
+    es_filtered_index_endpoint = (
+        f"{settings.ES_ENDPOINT}/{image_media_type_config.filtered_index}/_search"
+    )
+    mock_es_response = create_mock_es_http_image_search_response(
+        index=image_media_type_config.origin_index,
+        total_hits=20,
+        live_hit_count=20,
+        hit_count=10,
+    )
+
+    # Testing the ES query
+    es_related_query = {
+        "from": 0,
+        "query": {
+            "bool": {
+                "minimum_should_match": 1,
+                "must_not": [
+                    {"term": {"identifier": image.identifier}},
+                    {"term": {"mature": True}},
+                ],
+                "should": [
+                    {"match": {"title": "Bird Nature Photo"}},
+                    {"simple_query_string": {"fields": ["tags.name"], "query": "bird"}},
+                ],
+            }
+        },
+        "size": 20,
+    }
+    mock_related = (
+        pook.post(es_filtered_index_endpoint)
+        .json(es_related_query)  # Testing that ES query is correct
+        .times(1)
+        .reply(200)
+        .header("x-elastic-product", "Elasticsearch")
+        .json(mock_es_response)
+        .mock
+    )
+
+    results = search_controller.related_media(
+        uuid=image.identifier,
+        index=image_media_type_config.origin_index,
+        filter_dead=True,
+    )
+    assert len(results) == 10
+    assert wrapped_related_results.call_count == 1
+    assert mock_related.total_matches == 1

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -16,6 +16,7 @@ from django_redis import get_redis_connection
 from elasticsearch_dsl import Search
 
 from api.controllers import search_controller
+from api.controllers.elasticsearch import helpers as es_helpers
 from api.utils import tallies
 from api.utils.dead_link_mask import get_query_hash, save_query_mask
 from api.utils.search_context import SearchContext
@@ -150,7 +151,7 @@ def test_paginate_with_dead_link_mask_new_search(
     """
     start = 0
 
-    assert search_controller._paginate_with_dead_link_mask(
+    assert es_helpers._paginate_with_dead_link_mask(
         s=unique_search, page_size=page_size, page=page
     ) == (start, expected_end)
 
@@ -260,7 +261,7 @@ def test_paginate_with_dead_link_mask_query_mask_is_not_large_enough(
     """
     start = mask_size
     create_mask(s=unique_search, mask_size=mask_size, liveness_count=liveness_count)
-    assert search_controller._paginate_with_dead_link_mask(
+    assert es_helpers._paginate_with_dead_link_mask(
         s=unique_search, page_size=page_size, page=page
     ) == (start, expected_end)
 
@@ -383,7 +384,7 @@ def test_paginate_with_dead_link_mask_query_mask_overlaps_query_window(
         create_mask_kwargs.update(mask=mask_or_mask_size)
 
     create_mask(**create_mask_kwargs)
-    actual_range = search_controller._paginate_with_dead_link_mask(
+    actual_range = es_helpers._paginate_with_dead_link_mask(
         s=unique_search, page_size=page_size, page=page
     )
     assert (


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3306 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR refactors the way related query is created, using more low-level queries to make them less nested.

The main changes for this PR are within the `elasticsearch/related.py` file. All other changes are just moving the functions to a different file. The `related` function is moved from `search_controller` module to a separate file within `elsticsearch` folder, and some other common functions for pagination to `elasticsearch/helpers.py` file to make the files easier to read.

### Converting the simple search query to the terms query

After opening this PR, I also checked the queries logged by slowlog: all of the queries logged in the recent hours were related queries. 
Using the `simple_query_string` for the list of tags is not performant. This PR converts the query to use the terms query for tags. It will mean that the tags will not match if the form is different (so, `cat` will not match `cats`), but since we are trying to match all of the tags, I think we should still have enough matches. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Go to the `/admin` endpoint and set `hide content` for either Stocksnap or Flickr to true (in ContentModel).
Add logging to the related endpoint (`s.to_dict()` to view the ES query), and check that the query sent to ES when the related endpoint is requested does not have the nesting described in the issue.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
