### PR TITLE
Update TypeScript to v5.2.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         additional_dependencies:
           - prettier@2.8.3
           - prettier-plugin-tailwindcss@0.3.0
-          - typescript@4.9.5
+          - typescript@5.2.2
 
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.9.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -137,7 +137,7 @@
     "tailwindcss": "^3.3.5",
     "talkback": "^3.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "vue-demi": "^0.14.6",
     "vue-i18n-extract": "^2.0.7",
     "vue-jest": "^3.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -144,7 +144,7 @@
     "vue-loader": "^15.10.0",
     "vue-server-renderer": "^2.7.14",
     "vue-template-compiler": "^2.7.14",
-    "vue-tsc": "1.2.0",
+    "vue-tsc": "1.8.22",
     "webpack": "^4.46.0"
   },
   "browserslist": [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,6 @@
       "@pinia/nuxt",
       "@sentry/core"
     ],
-    "typeRoots": ["./typings", "./node_modules/@types"],
     "paths": {
       "~/*": ["./src/*"],
       "~~/*": ["./*"]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@openverse/eslint-plugin": "workspace:0.0.0",
     "prettier": "2.8.3",
     "prettier-plugin-tailwindcss": "0.4.1",
-    "typescript": "4.9.5",
+    "typescript": "5.2.2",
     "vue-tsc": "1.2.0"
   },
   "pnpm": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-unicorn": "^48.0.1",
     "eslint-plugin-vue": "^9.17.0",
     "eslint-plugin-vuejs-accessibility": "^2.2.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "vue-eslint-parser": "^9.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ importers:
       '@openverse/eslint-plugin': workspace:0.0.0
       prettier: 2.8.3
       prettier-plugin-tailwindcss: 0.4.1
-      typescript: 4.9.5
+      typescript: 5.2.2
       vue-tsc: 1.2.0
     devDependencies:
       '@openverse/eslint-plugin': link:packages/eslint-plugin
       prettier: 2.8.3
       prettier-plugin-tailwindcss: 0.4.1_prettier@2.8.3
-      typescript: 4.9.5
-      vue-tsc: 1.2.0_typescript@4.9.5
+      typescript: 5.2.2
+      vue-tsc: 1.2.0_typescript@5.2.2
 
   automations/js:
     specifiers:
@@ -112,7 +112,7 @@ importers:
       talkback: ^3.0.1
       throttle-debounce: ^5.0.0
       ts-node: ^10.9.1
-      typescript: ^4.9.5
+      typescript: ^5.2.2
       uuid: ^9.0.1
       vue: ^2.7.14
       vue-demi: ^0.14.6
@@ -152,8 +152,8 @@ importers:
       focus-visible: 5.2.0
       glob: 8.0.1
       node-html-parser: 5.3.3
-      nuxt: 2.17.0_463pqhi6eauw3mjqcyq4fuonrm
-      pinia: 2.0.33_hwpzsh6pnvsm3pjf2zi526hnzq
+      nuxt: 2.17.0_kmuxffuk3pvfietygrffekzqfq
+      pinia: 2.0.33_nfwcdbauhyorapgffjnvrr55lm
       portal-vue: 2.1.7_vue@2.7.14
       postcss-focus-visible: 6.0.4_postcss@8.4.31
       prom-client: 14.0.1
@@ -171,8 +171,8 @@ importers:
       '@babel/preset-typescript': 7.22.5_@babel+core@7.22.5
       '@itsjonq/remake': 2.0.0
       '@nuxt/types': 2.17.0
-      '@nuxt/typescript-build': 3.0.1_4iooitihkbuzmfdnjfckvzb5vi
-      '@nuxtjs/storybook': 4.3.2_gkvmblwwmcyxnycob2xhl3oupi
+      '@nuxt/typescript-build': 3.0.1_qivzaktjlxsjmkphimmjuetlne
+      '@nuxtjs/storybook': 4.3.2_u3d3wuhfaemawlidsotkco7eiy
       '@pinia/testing': 0.0.15_pinia@2.0.33+vue@2.7.14
       '@playwright/test': 1.30.0
       '@tailwindcss/typography': 0.5.10_tailwindcss@3.3.5
@@ -205,15 +205,15 @@ importers:
       rimraf: 3.0.2
       tailwindcss: 3.3.5_ts-node@10.9.1
       talkback: 3.0.1
-      ts-node: 10.9.1_ytxlagnlbjxf7pw6smm3knvnbq
-      typescript: 4.9.5
+      ts-node: 10.9.1_r5qwscu47punp5h2qfsidplebq
+      typescript: 5.2.2
       vue-demi: 0.14.6_vue@2.7.14
       vue-i18n-extract: 2.0.7
       vue-jest: 3.0.7_6lyp5kpyxwdnpoavxuvrwtd2je
       vue-loader: 15.10.0_uhs2gfg5l6piymj36axgkhxosy
       vue-server-renderer: 2.7.14
       vue-template-compiler: 2.7.14
-      vue-tsc: 1.2.0_typescript@4.9.5
+      vue-tsc: 1.2.0_typescript@5.2.2
       webpack: 4.46.0
 
   packages/eslint-plugin:
@@ -242,32 +242,32 @@ importers:
       jest: ^29.6.4
       jest-cli: ^29.6.4
       jest-resolve: ^29.6.4
-      typescript: ^4.9.5
+      typescript: ^5.2.2
       vue-eslint-parser: ^9.3.1
     dependencies:
       '@intlify/eslint-plugin-vue-i18n': 2.0.0_eslint@8.48.0
-      '@typescript-eslint/eslint-plugin': 6.5.0_s2ebrnfj2tchesaj5vnqubauu4
-      '@typescript-eslint/parser': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
-      '@typescript-eslint/utils': 6.6.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/eslint-plugin': 6.5.0_nvwva6txm3qs6xnog6dqanz5uy
+      '@typescript-eslint/parser': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/utils': 6.6.0_w2g2uv42be7wag4oipwkfv43p4
       eslint: 8.48.0
       eslint-config-prettier: 8.6.0_eslint@8.48.0
       eslint-import-resolver-typescript: 3.6.0_xogniai7ivsmhcskomnyvjougy
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.48.0
       eslint-plugin-import: 2.28.1_mr6vzeaukkr6z7mqm7nwr5uizy
-      eslint-plugin-jest: 27.2.3_frdmc5fow7hw6mhrjbgfacxwde
+      eslint-plugin-jest: 27.2.3_lc6ojpxl4p5tprs3dwctwb5p4a
       eslint-plugin-playwright: 0.16.0_vyvbrwx7pdmcuixip5p6fxnzty
       eslint-plugin-tsdoc: 0.2.17
       eslint-plugin-unicorn: 48.0.1_eslint@8.48.0
       eslint-plugin-vue: 9.17.0_eslint@8.48.0
       eslint-plugin-vuejs-accessibility: 2.2.0_eslint@8.48.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       vue-eslint-parser: 9.3.1_eslint@8.48.0
     devDependencies:
       '@eslint/eslintrc': 2.1.2
       '@swc/cli': 0.1.62_@swc+core@1.3.82
       '@swc/core': 1.3.82
       '@swc/jest': 0.2.29_@swc+core@1.3.82
-      '@typescript-eslint/rule-tester': 6.6.0_ie7etqmmmaf7kwvxr7rqvqsdvm
+      '@typescript-eslint/rule-tester': 6.6.0_qahjhkdlzal5li3y7ufgbb5cv4
       babel-plugin-add-module-exports: 1.0.4
       jest: 29.6.4
       jest-cli: 29.6.4
@@ -3236,14 +3236,14 @@ packages:
       - vue
     dev: false
 
-  /@nuxt/builder/2.17.0_463pqhi6eauw3mjqcyq4fuonrm:
+  /@nuxt/builder/2.17.0_kmuxffuk3pvfietygrffekzqfq:
     resolution: {integrity: sha512-yLTJiUqF3oQ7dOC2ql2rT9agap8aWpjmOef+dTf6jh8BFZ6Oc2NT/j8mWzo4ruo4YpFqw2FqoOLDW5fCDE1+Bw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/utils': 2.17.0
       '@nuxt/vue-app': 2.17.0
-      '@nuxt/webpack': 2.17.0_463pqhi6eauw3mjqcyq4fuonrm
+      '@nuxt/webpack': 2.17.0_kmuxffuk3pvfietygrffekzqfq
       chalk: 4.1.2
       chokidar: 3.5.3
       consola: 3.1.0
@@ -3544,7 +3544,7 @@ packages:
       '@types/webpack-hot-middleware': 2.25.5
     dev: true
 
-  /@nuxt/typescript-build/3.0.1_4iooitihkbuzmfdnjfckvzb5vi:
+  /@nuxt/typescript-build/3.0.1_qivzaktjlxsjmkphimmjuetlne:
     resolution: {integrity: sha512-+9mQuLlwYSDTesyt5lYjWzUit/DD78V+OSzaqGJUkybjS63YZUBcUw6Fr4jAeRreMlseFnJFIjtQQV1osunrhg==}
     peerDependencies:
       '@nuxt/types': '>=2.13.1'
@@ -3553,9 +3553,9 @@ packages:
       '@nuxt/types': 2.17.0
       consola: 2.15.3
       defu: 6.1.2
-      fork-ts-checker-webpack-plugin: 6.5.3_gs6d5ria4vrhid7ajofnihvx3i
-      ts-loader: 8.4.0_evijigonbo4skk2vlqtwtdqibu
-      typescript: 4.9.5
+      fork-ts-checker-webpack-plugin: 6.5.3_4bahxi54v6gjw3dpdudbqvdqji
+      ts-loader: 8.4.0_zvxmnv6uzujp376qwn3sf2czv4
+      typescript: 5.2.2
     transitivePeerDependencies:
       - eslint
       - vue-template-compiler
@@ -3613,7 +3613,7 @@ packages:
       vue-server-renderer: 2.7.14
     dev: false
 
-  /@nuxt/webpack/2.17.0_463pqhi6eauw3mjqcyq4fuonrm:
+  /@nuxt/webpack/2.17.0_kmuxffuk3pvfietygrffekzqfq:
     resolution: {integrity: sha512-abtLBtIgdMUyxHMcl6TilazulhSppaHIK4qexOuNkwJxy4DSbm1qPRMqu5w7rlTVBV86OkvFF/gAi1LMsSyVVg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     dependencies:
@@ -3638,7 +3638,7 @@ packages:
       memory-fs: 0.5.0
       optimize-css-assets-webpack-plugin: 6.0.1_webpack@4.46.0
       pify: 5.0.0
-      pnp-webpack-plugin: 1.7.0_typescript@4.9.5
+      pnp-webpack-plugin: 1.7.0_typescript@5.2.2
       postcss: 8.4.31
       postcss-import: 15.1.0_postcss@8.4.31
       postcss-import-resolver: 2.0.0
@@ -3741,7 +3741,7 @@ packages:
       estree-walker: 2.0.2
       fs-extra: 9.1.0
       magic-string: 0.26.3
-      nuxt: 2.17.0_463pqhi6eauw3mjqcyq4fuonrm
+      nuxt: 2.17.0_kmuxffuk3pvfietygrffekzqfq
       pathe: 0.3.5
       ufo: 0.8.5
       vue: 2.7.14
@@ -3815,15 +3815,15 @@ packages:
       sitemap: 4.1.1
     dev: false
 
-  /@nuxtjs/storybook/4.3.2_gkvmblwwmcyxnycob2xhl3oupi:
+  /@nuxtjs/storybook/4.3.2_u3d3wuhfaemawlidsotkco7eiy:
     resolution: {integrity: sha512-9XoHpJI6Xiy4g10kB4b+E0d+WfhZFC3Emv3+FIv6G4P3Wy+X6s8OBA6C7QQGDyThwrgWkRWaVD3mTzNRViN9WQ==}
     hasBin: true
     dependencies:
       '@nuxt/postcss8': 1.1.3_webpack@4.46.0
-      '@storybook/addon-essentials': 6.5.10_a4x3v6adgxliwn766i6wwhx27m
+      '@storybook/addon-essentials': 6.5.10_i3mt4jx4hkupelf7wklpwjc55a
       '@storybook/addon-postcss': 2.0.0_webpack@4.46.0
-      '@storybook/react-docgen-typescript-plugin': 1.0.1_evijigonbo4skk2vlqtwtdqibu
-      '@storybook/vue': 6.5.10_6rioei6fsu2ycw2qgbhtjc45ea
+      '@storybook/react-docgen-typescript-plugin': 1.0.1_zvxmnv6uzujp376qwn3sf2czv4
+      '@storybook/vue': 6.5.10_v5ihno2qikunx6vmhgtevp7qr4
       arg: 5.0.2
       consola: 2.15.3
       create-require: 1.1.1
@@ -4147,7 +4147,7 @@ packages:
     peerDependencies:
       pinia: '>=2.0.16'
     dependencies:
-      pinia: 2.0.33_hwpzsh6pnvsm3pjf2zi526hnzq
+      pinia: 2.0.33_nfwcdbauhyorapgffjnvrr55lm
       vue-demi: 0.14.6_vue@2.7.14
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -4159,7 +4159,7 @@ packages:
     peerDependencies:
       pinia: '>=2.0.31'
     dependencies:
-      pinia: 2.0.33_hwpzsh6pnvsm3pjf2zi526hnzq
+      pinia: 2.0.33_nfwcdbauhyorapgffjnvrr55lm
       vue-demi: 0.14.6_vue@2.7.14
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -4357,7 +4357,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.10_bn5ronxim3epa5r4ycosw3tauu:
+  /@storybook/addon-controls/6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu:
     resolution: {integrity: sha512-lC2y3XcolmQAJwFurIyGrynAHPWmfNtTCdu3rQBTVGwyxCoNwdOOeC2jV0BRqX2+CW6OHzJr9frNWXPSaZ8c4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4372,7 +4372,7 @@ packages:
       '@storybook/api': 6.5.10
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10
-      '@storybook/core-common': 6.5.10_bn5ronxim3epa5r4ycosw3tauu
+      '@storybook/core-common': 6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.10
       '@storybook/store': 6.5.10
@@ -4389,7 +4389,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.10_7wqumqllxhxl72w6jhhleol62i:
+  /@storybook/addon-docs/6.5.10_47hhczg65cssa6j2qdkpxnx73i:
     resolution: {integrity: sha512-1kgjo3f0vL6GN8fTwLL05M/q/kDdzvuqwhxPY/v5hubFb3aQZGr2yk9pRBaLAbs4bez0yG0ASXcwhYnrEZUppg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -4410,7 +4410,7 @@ packages:
       '@storybook/addons': 6.5.10
       '@storybook/api': 6.5.10
       '@storybook/components': 6.5.10
-      '@storybook/core-common': 6.5.10_bn5ronxim3epa5r4ycosw3tauu
+      '@storybook/core-common': 6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10
@@ -4442,7 +4442,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.10_a4x3v6adgxliwn766i6wwhx27m:
+  /@storybook/addon-essentials/6.5.10_i3mt4jx4hkupelf7wklpwjc55a:
     resolution: {integrity: sha512-PT2aiR4vgAyB0pl3HNBUa4/a7NDRxASxAazz7zt9ZDirkipDKfxwdcLeRoJzwSngVDWEhuz5/paN5x4eNp4Hww==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -4502,17 +4502,17 @@ packages:
       '@babel/core': 7.22.5
       '@storybook/addon-actions': 6.5.10
       '@storybook/addon-backgrounds': 6.5.10
-      '@storybook/addon-controls': 6.5.10_bn5ronxim3epa5r4ycosw3tauu
-      '@storybook/addon-docs': 6.5.10_7wqumqllxhxl72w6jhhleol62i
+      '@storybook/addon-controls': 6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu
+      '@storybook/addon-docs': 6.5.10_47hhczg65cssa6j2qdkpxnx73i
       '@storybook/addon-measure': 6.5.10
       '@storybook/addon-outline': 6.5.10
       '@storybook/addon-toolbars': 6.5.10
       '@storybook/addon-viewport': 6.5.10
       '@storybook/addons': 6.5.10
       '@storybook/api': 6.5.10
-      '@storybook/core-common': 6.5.10_bn5ronxim3epa5r4ycosw3tauu
+      '@storybook/core-common': 6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu
       '@storybook/node-logger': 6.5.10
-      '@storybook/vue': 6.5.10_6rioei6fsu2ycw2qgbhtjc45ea
+      '@storybook/vue': 6.5.10_v5ihno2qikunx6vmhgtevp7qr4
       core-js: 3.27.2
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
@@ -4741,7 +4741,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.10_3rrahh7ehosau7nstvpdbg72ey:
+  /@storybook/builder-webpack4/6.5.10_qsklokychrntxktl733ttsllia:
     resolution: {integrity: sha512-AoKjsCNoQQoZXYwBDxO8s+yVEd5FjBJAaysEuUTHq2fb81jwLrGcEOo6hjw4jqfugZQIzYUEjPazlvubS78zpw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4763,7 +4763,7 @@ packages:
       '@storybook/client-api': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/core-common': 6.5.10_qsklokychrntxktl733ttsllia
       '@storybook/core-events': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/preview-web': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
@@ -4781,12 +4781,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_gs6d5ria4vrhid7ajofnihvx3i
+      fork-ts-checker-webpack-plugin: 4.1.6_4bahxi54v6gjw3dpdudbqvdqji
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      pnp-webpack-plugin: 1.6.4_typescript@5.2.2
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -4797,7 +4797,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -4930,7 +4930,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.10_prilnw27wu4nsindseyg35liui:
+  /@storybook/core-client/6.5.10_kw2fh2z6sxbqrtlrgi4ihunzbm:
     resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4965,13 +4965,13 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
     dev: true
 
-  /@storybook/core-common/6.5.10_3rrahh7ehosau7nstvpdbg72ey:
+  /@storybook/core-common/6.5.10_6m3ycgp4ltirb6kc3cxy3i4udu:
     resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5019,7 +5019,80 @@ packages:
       express: 4.17.3
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_gs6d5ria4vrhid7ajofnihvx3i
+      fork-ts-checker-webpack-plugin: 6.5.3_4bahxi54v6gjw3dpdudbqvdqji
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      handlebars: 4.7.7
+      interpret: 2.2.0
+      json5: 2.2.3
+      lazy-universal-dotenv: 3.0.1
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      pretty-hrtime: 1.0.3
+      resolve-from: 5.0.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      typescript: 5.2.2
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/core-common/6.5.10_qsklokychrntxktl733ttsllia:
+    resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-proposal-decorators': 7.17.2_@babel+core@7.22.5
+      '@babel/plugin-proposal-export-default-from': 7.16.7_@babel+core@7.22.5
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.22.5
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.22.5
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.22.5
+      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-transform-block-scoping': 7.20.2_@babel+core@7.22.5
+      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.22.5
+      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.22.5
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.22.5
+      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.22.5
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.22.5
+      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.22.5
+      '@babel/preset-env': 7.22.5_@babel+core@7.22.5
+      '@babel/preset-react': 7.16.7_@babel+core@7.22.5
+      '@babel/preset-typescript': 7.22.5_@babel+core@7.22.5
+      '@babel/register': 7.17.0_@babel+core@7.22.5
+      '@storybook/node-logger': 6.5.10
+      '@storybook/semver': 7.3.2
+      '@types/node': 16.18.16
+      '@types/pretty-hrtime': 1.0.1
+      babel-loader: 8.2.5_rf5mwho5nu3s3spznxs3423x5y
+      babel-plugin-macros: 3.1.0
+      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.22.5
+      chalk: 4.1.2
+      core-js: 3.27.2
+      express: 4.17.3
+      file-system-cache: 1.0.5
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.3_4bahxi54v6gjw3dpdudbqvdqji
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -5035,80 +5108,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.9.5
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core-common/6.5.10_bn5ronxim3epa5r4ycosw3tauu:
-    resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.5
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-proposal-decorators': 7.17.2_@babel+core@7.22.5
-      '@babel/plugin-proposal-export-default-from': 7.16.7_@babel+core@7.22.5
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.22.5
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.22.5
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.22.5
-      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-transform-block-scoping': 7.20.2_@babel+core@7.22.5
-      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.22.5
-      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.22.5
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.22.5
-      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.22.5
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.22.5
-      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.22.5
-      '@babel/preset-env': 7.22.5_@babel+core@7.22.5
-      '@babel/preset-react': 7.16.7_@babel+core@7.22.5
-      '@babel/preset-typescript': 7.22.5_@babel+core@7.22.5
-      '@babel/register': 7.17.0_@babel+core@7.22.5
-      '@storybook/node-logger': 6.5.10
-      '@storybook/semver': 7.3.2
-      '@types/node': 16.18.16
-      '@types/pretty-hrtime': 1.0.1
-      babel-loader: 8.2.5_rf5mwho5nu3s3spznxs3423x5y
-      babel-plugin-macros: 3.1.0
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.22.5
-      chalk: 4.1.2
-      core-js: 3.27.2
-      express: 4.17.3
-      file-system-cache: 1.0.5
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_gs6d5ria4vrhid7ajofnihvx3i
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      handlebars: 4.7.7
-      interpret: 2.2.0
-      json5: 2.2.3
-      lazy-universal-dotenv: 3.0.1
-      picomatch: 2.3.1
-      pkg-dir: 5.0.0
-      pretty-hrtime: 1.0.3
-      resolve-from: 5.0.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -5125,7 +5125,7 @@ packages:
       core-js: 3.27.2
     dev: true
 
-  /@storybook/core-server/6.5.10_3rrahh7ehosau7nstvpdbg72ey:
+  /@storybook/core-server/6.5.10_qsklokychrntxktl733ttsllia:
     resolution: {integrity: sha512-jqwpA0ccA8X5ck4esWBid04+cEIVqirdAcqJeNb9IZAD+bRreO4Im8ilzr7jc5AmQ9fkqHs2NByFKh9TITp8NQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -5146,17 +5146,17 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
-      '@storybook/core-client': 6.5.10_prilnw27wu4nsindseyg35liui
-      '@storybook/core-common': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/builder-webpack4': 6.5.10_qsklokychrntxktl733ttsllia
+      '@storybook/core-client': 6.5.10_kw2fh2z6sxbqrtlrgi4ihunzbm
+      '@storybook/core-common': 6.5.10_qsklokychrntxktl733ttsllia
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.10
-      '@storybook/manager-webpack4': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/manager-webpack4': 6.5.10_qsklokychrntxktl733ttsllia
       '@storybook/node-logger': 6.5.10
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/telemetry': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/telemetry': 6.5.10_qsklokychrntxktl733ttsllia
       '@types/node': 16.18.16
       '@types/node-fetch': 2.6.1
       '@types/pretty-hrtime': 1.0.1
@@ -5187,7 +5187,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0
@@ -5206,7 +5206,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.10_fk5hi6rnorytxt3qdaxnsn4jcq:
+  /@storybook/core/6.5.10_k4gn5ljzeveefebov2fnqri2dm:
     resolution: {integrity: sha512-K86yYa0tYlMxADlwQTculYvPROokQau09SCVqpsLg3wJCTvYFL4+SIqcYoyBSbFmHOdnYbJgPydjN33MYLiOZQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -5227,11 +5227,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.10_prilnw27wu4nsindseyg35liui
-      '@storybook/core-server': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/core-client': 6.5.10_kw2fh2z6sxbqrtlrgi4ihunzbm
+      '@storybook/core-server': 6.5.10_qsklokychrntxktl733ttsllia
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -5310,7 +5310,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.10_3rrahh7ehosau7nstvpdbg72ey:
+  /@storybook/manager-webpack4/6.5.10_qsklokychrntxktl733ttsllia:
     resolution: {integrity: sha512-N/TlNDhuhARuFipR/ZJ/xEVESz23iIbCsZ4VNehLHm8PpiGlQUehk+jMjWmz5XV0bJItwjRclY+CU3GjZKblfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5328,8 +5328,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.22.5
       '@babel/preset-react': 7.16.7_@babel+core@7.22.5
       '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-client': 6.5.10_prilnw27wu4nsindseyg35liui
-      '@storybook/core-common': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/core-client': 6.5.10_kw2fh2z6sxbqrtlrgi4ihunzbm
+      '@storybook/core-common': 6.5.10_qsklokychrntxktl733ttsllia
       '@storybook/node-logger': 6.5.10
       '@storybook/theming': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/ui': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
@@ -5346,7 +5346,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      pnp-webpack-plugin: 1.6.4_typescript@5.2.2
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
       read-pkg-up: 7.0.1
@@ -5356,7 +5356,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -5467,7 +5467,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.1_evijigonbo4skk2vlqtwtdqibu:
+  /@storybook/react-docgen-typescript-plugin/1.0.1_zvxmnv6uzujp376qwn3sf2czv4:
     resolution: {integrity: sha512-dqbHa+5gaxaklFCuV1WTvljVPTo3QIJgpW4Ln+QeME7osPZUnUhjN2/djvo+sxrWUrTTuqX5jkn291aDngu9Tw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -5478,9 +5478,9 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.9.5
+      react-docgen-typescript: 2.2.2_typescript@5.2.2
       tslib: 2.3.1
-      typescript: 4.9.5
+      typescript: 5.2.2
       webpack: 4.46.0
     transitivePeerDependencies:
       - supports-color
@@ -5614,11 +5614,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.10_3rrahh7ehosau7nstvpdbg72ey:
+  /@storybook/telemetry/6.5.10_qsklokychrntxktl733ttsllia:
     resolution: {integrity: sha512-+M5HILDFS8nDumLxeSeAwi1MTzIuV6UWzV4yB2wcsEXOBTdplcl9oYqFKtlst78oOIdGtpPYxYfivDlqxC2K4g==}
     dependencies:
       '@storybook/client-logger': 6.5.10
-      '@storybook/core-common': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/core-common': 6.5.10_qsklokychrntxktl733ttsllia
       chalk: 4.1.2
       core-js: 3.27.2
       detect-package-manager: 2.0.1
@@ -5706,7 +5706,7 @@ packages:
       resolve-from: 5.0.0
     dev: true
 
-  /@storybook/vue/6.5.10_6rioei6fsu2ycw2qgbhtjc45ea:
+  /@storybook/vue/6.5.10_v5ihno2qikunx6vmhgtevp7qr4:
     resolution: {integrity: sha512-4MYYvRPkqTBqQUjCNXiTM/PJ6qfzKaECFtEe0H7TG+WP+TuKCCfTY2u1q4ru2qjf8BcSXUfpIWPlfEpZh7wdaQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -5721,8 +5721,8 @@ packages:
       '@babel/core': 7.22.5
       '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.10
-      '@storybook/core': 6.5.10_fk5hi6rnorytxt3qdaxnsn4jcq
-      '@storybook/core-common': 6.5.10_3rrahh7ehosau7nstvpdbg72ey
+      '@storybook/core': 6.5.10_k4gn5ljzeveefebov2fnqri2dm
+      '@storybook/core-common': 6.5.10_qsklokychrntxktl733ttsllia
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
@@ -5737,7 +5737,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      ts-loader: 8.3.0_evijigonbo4skk2vlqtwtdqibu
+      ts-loader: 8.3.0_zvxmnv6uzujp376qwn3sf2czv4
       vue: 2.7.14
       vue-docgen-api: 4.44.18_vue@2.7.14
       vue-docgen-loader: 1.5.0_j5ed4dj4suhyi3wzdvabtf7vta
@@ -6453,7 +6453,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/6.5.0_s2ebrnfj2tchesaj5vnqubauu4:
+  /@typescript-eslint/eslint-plugin/6.5.0_nvwva6txm3qs6xnog6dqanz5uy:
     resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6467,10 +6467,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.0
-      '@typescript-eslint/parser': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/parser': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       '@typescript-eslint/scope-manager': 6.5.0
-      '@typescript-eslint/type-utils': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
-      '@typescript-eslint/utils': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/type-utils': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/utils': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4
       eslint: 8.48.0
@@ -6478,13 +6478,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.2_typescript@4.9.5
-      typescript: 4.9.5
+      ts-api-utils: 1.0.2_typescript@5.2.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4:
+  /@typescript-eslint/parser/6.5.0_w2g2uv42be7wag4oipwkfv43p4:
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6498,16 +6498,16 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.5.0
       '@typescript-eslint/types': 6.5.0
-      '@typescript-eslint/typescript-estree': 6.5.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 6.5.0_typescript@5.2.2
       '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4
       eslint: 8.48.0
-      typescript: 4.9.5
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/rule-tester/6.6.0_ie7etqmmmaf7kwvxr7rqvqsdvm:
+  /@typescript-eslint/rule-tester/6.6.0_qahjhkdlzal5li3y7ufgbb5cv4:
     resolution: {integrity: sha512-eKxBRBOQbReGr1g+CFjKbK3XyVyBlkZV0ur1PJ3SXwsW3/fg4w6lA41GnnS2IBD15PUXRTAZ7AFBfvpoGfJIXw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6518,8 +6518,8 @@ packages:
         optional: true
     dependencies:
       '@eslint/eslintrc': 2.1.2
-      '@typescript-eslint/typescript-estree': 6.6.0_typescript@4.9.5
-      '@typescript-eslint/utils': 6.6.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/typescript-estree': 6.6.0_typescript@5.2.2
+      '@typescript-eslint/utils': 6.6.0_w2g2uv42be7wag4oipwkfv43p4
       ajv: 6.12.6
       eslint: 8.48.0
       lodash.merge: 4.6.2
@@ -6552,7 +6552,7 @@ packages:
       '@typescript-eslint/types': 6.6.0
       '@typescript-eslint/visitor-keys': 6.6.0
 
-  /@typescript-eslint/type-utils/6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4:
+  /@typescript-eslint/type-utils/6.5.0_w2g2uv42be7wag4oipwkfv43p4:
     resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6564,12 +6564,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.5.0_typescript@4.9.5
-      '@typescript-eslint/utils': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/typescript-estree': 6.5.0_typescript@5.2.2
+      '@typescript-eslint/utils': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       debug: 4.3.4
       eslint: 8.48.0
-      ts-api-utils: 1.0.2_typescript@4.9.5
-      typescript: 4.9.5
+      ts-api-utils: 1.0.2_typescript@5.2.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6588,7 +6588,7 @@ packages:
     resolution: {integrity: sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree/5.62.0_typescript@4.9.5:
+  /@typescript-eslint/typescript-estree/5.62.0_typescript@5.2.2:
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6603,13 +6603,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.2.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/6.5.0_typescript@4.9.5:
+  /@typescript-eslint/typescript-estree/6.5.0_typescript@5.2.2:
     resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6624,13 +6624,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.2_typescript@4.9.5
-      typescript: 4.9.5
+      ts-api-utils: 1.0.2_typescript@5.2.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/6.6.0_typescript@4.9.5:
+  /@typescript-eslint/typescript-estree/6.6.0_typescript@5.2.2:
     resolution: {integrity: sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6645,12 +6645,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.2_typescript@4.9.5
-      typescript: 4.9.5
+      ts-api-utils: 1.0.2_typescript@5.2.2
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.62.0_cgvy6hrg3pjeapqw5wnuqcmdo4:
+  /@typescript-eslint/utils/5.62.0_w2g2uv42be7wag4oipwkfv43p4:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6664,7 +6664,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.2.2
       eslint: 8.48.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -6673,7 +6673,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils/6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4:
+  /@typescript-eslint/utils/6.5.0_w2g2uv42be7wag4oipwkfv43p4:
     resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6687,7 +6687,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.5.0
       '@typescript-eslint/types': 6.5.0
-      '@typescript-eslint/typescript-estree': 6.5.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 6.5.0_typescript@5.2.2
       eslint: 8.48.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -6695,7 +6695,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils/6.6.0_cgvy6hrg3pjeapqw5wnuqcmdo4:
+  /@typescript-eslint/utils/6.6.0_w2g2uv42be7wag4oipwkfv43p4:
     resolution: {integrity: sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6709,7 +6709,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.6.0
       '@typescript-eslint/types': 6.6.0
-      '@typescript-eslint/typescript-estree': 6.6.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 6.6.0_typescript@5.2.2
       eslint: 8.48.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -10795,7 +10795,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/parser': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-typescript: 3.6.0_xogniai7ivsmhcskomnyvjougy
@@ -10824,7 +10824,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/parser': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
@@ -10859,7 +10859,7 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/parser': 6.5.0_w2g2uv42be7wag4oipwkfv43p4
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
       array.prototype.flat: 1.3.1
@@ -10884,7 +10884,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jest/27.2.3_frdmc5fow7hw6mhrjbgfacxwde:
+  /eslint-plugin-jest/27.2.3_lc6ojpxl4p5tprs3dwctwb5p4a:
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -10899,8 +10899,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.5.0_s2ebrnfj2tchesaj5vnqubauu4
-      '@typescript-eslint/utils': 5.62.0_cgvy6hrg3pjeapqw5wnuqcmdo4
+      '@typescript-eslint/eslint-plugin': 6.5.0_nvwva6txm3qs6xnog6dqanz5uy
+      '@typescript-eslint/utils': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
       eslint: 8.48.0
       jest: 29.6.4
     transitivePeerDependencies:
@@ -10934,7 +10934,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.48.0
-      eslint-plugin-jest: 27.2.3_frdmc5fow7hw6mhrjbgfacxwde
+      eslint-plugin-jest: 27.2.3_lc6ojpxl4p5tprs3dwctwb5p4a
     dev: false
 
   /eslint-plugin-tsdoc/0.2.17:
@@ -11649,7 +11649,7 @@ packages:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
 
-  /fork-ts-checker-webpack-plugin/4.1.6_gs6d5ria4vrhid7ajofnihvx3i:
+  /fork-ts-checker-webpack-plugin/4.1.6_4bahxi54v6gjw3dpdudbqvdqji:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11669,7 +11669,7 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.9.5
+      typescript: 5.2.2
       vue-template-compiler: 2.7.14
       webpack: 4.46.0
       worker-rpc: 0.1.1
@@ -11677,7 +11677,7 @@ packages:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_gs6d5ria4vrhid7ajofnihvx3i:
+  /fork-ts-checker-webpack-plugin/6.5.3_4bahxi54v6gjw3dpdudbqvdqji:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11704,7 +11704,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 4.9.5
+      typescript: 5.2.2
       vue-template-compiler: 2.7.14
       webpack: 4.46.0
     dev: true
@@ -13357,7 +13357,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.5
       pretty-format: 26.6.2
-      ts-node: 10.9.1_ytxlagnlbjxf7pw6smm3knvnbq
+      ts-node: 10.9.1_r5qwscu47punp5h2qfsidplebq
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -15419,13 +15419,13 @@ packages:
       commander: 5.1.0
     dev: false
 
-  /nuxt/2.17.0_463pqhi6eauw3mjqcyq4fuonrm:
+  /nuxt/2.17.0_kmuxffuk3pvfietygrffekzqfq:
     resolution: {integrity: sha512-+xEB8VReXqvSVvizBQ2mpV4nW8U3o2r4fctJ1XIzxgvYszrUSXeQf2mfF/1kKpJJTdReNMspaF6UCB7qz2bkYw==}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@nuxt/babel-preset-app': 2.17.0_vue@2.7.14
-      '@nuxt/builder': 2.17.0_463pqhi6eauw3mjqcyq4fuonrm
+      '@nuxt/builder': 2.17.0_kmuxffuk3pvfietygrffekzqfq
       '@nuxt/cli': 2.17.0
       '@nuxt/components': 2.2.1
       '@nuxt/config': 2.17.0
@@ -15438,7 +15438,7 @@ packages:
       '@nuxt/utils': 2.17.0
       '@nuxt/vue-app': 2.17.0
       '@nuxt/vue-renderer': 2.17.0
-      '@nuxt/webpack': 2.17.0_463pqhi6eauw3mjqcyq4fuonrm
+      '@nuxt/webpack': 2.17.0_kmuxffuk3pvfietygrffekzqfq
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - arc-templates
@@ -16042,7 +16042,7 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /pinia/2.0.33_hwpzsh6pnvsm3pjf2zi526hnzq:
+  /pinia/2.0.33_nfwcdbauhyorapgffjnvrr55lm:
     resolution: {integrity: sha512-HOj1yVV2itw6rNIrR2f7+MirGNxhORjrULL8GWgRwXsGSvEqIQ+SE0MYt6cwtpegzCda3i+rVTZM+AM7CG+kRg==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -16055,7 +16055,7 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.5.0
-      typescript: 4.9.5
+      typescript: 5.2.2
       vue: 2.7.14
       vue-demi: 0.14.6_vue@2.7.14
 
@@ -16127,20 +16127,20 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.9.5:
+  /pnp-webpack-plugin/1.6.4_typescript@5.2.2:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.9.5
+      ts-pnp: 1.2.0_typescript@5.2.2
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /pnp-webpack-plugin/1.7.0_typescript@4.9.5:
+  /pnp-webpack-plugin/1.7.0_typescript@5.2.2:
     resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.9.5
+      ts-pnp: 1.2.0_typescript@5.2.2
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -16553,7 +16553,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.9.1_ytxlagnlbjxf7pw6smm3knvnbq
+      ts-node: 10.9.1_r5qwscu47punp5h2qfsidplebq
       yaml: 2.3.1
     dev: true
 
@@ -17800,12 +17800,12 @@ packages:
       flat: 5.0.2
     dev: false
 
-  /react-docgen-typescript/2.2.2_typescript@4.9.5:
+  /react-docgen-typescript/2.2.2_typescript@5.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.2.2
     dev: true
 
   /react-dom/16.14.0_react@16.14.0:
@@ -19674,13 +19674,13 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: true
 
-  /ts-api-utils/1.0.2_typescript@4.9.5:
+  /ts-api-utils/1.0.2_typescript@5.2.2:
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.2.2
 
   /ts-dedent/2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -19691,7 +19691,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-loader/8.3.0_evijigonbo4skk2vlqtwtdqibu:
+  /ts-loader/8.3.0_zvxmnv6uzujp376qwn3sf2czv4:
     resolution: {integrity: sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -19703,11 +19703,11 @@ packages:
       loader-utils: 2.0.2
       micromatch: 4.0.5
       semver: 7.5.4
-      typescript: 4.9.5
+      typescript: 5.2.2
       webpack: 4.46.0
     dev: true
 
-  /ts-loader/8.4.0_evijigonbo4skk2vlqtwtdqibu:
+  /ts-loader/8.4.0_zvxmnv6uzujp376qwn3sf2czv4:
     resolution: {integrity: sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -19719,7 +19719,7 @@ packages:
       loader-utils: 2.0.2
       micromatch: 4.0.5
       semver: 7.3.8
-      typescript: 4.9.5
+      typescript: 5.2.2
       webpack: 4.46.0
     dev: true
 
@@ -19727,7 +19727,7 @@ packages:
     resolution: {integrity: sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==}
     dev: true
 
-  /ts-node/10.9.1_ytxlagnlbjxf7pw6smm3knvnbq:
+  /ts-node/10.9.1_r5qwscu47punp5h2qfsidplebq:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -19753,12 +19753,12 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.2.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
-  /ts-pnp/1.2.0_typescript@4.9.5:
+  /ts-pnp/1.2.0_typescript@5.2.2:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -19767,7 +19767,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.2.2
 
   /tsconfig-paths/3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
@@ -19797,14 +19797,14 @@ packages:
   /tslib/2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
-  /tsutils/3.21.0_typescript@4.9.5:
+  /tsutils/3.21.0_typescript@5.2.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.2.2
     dev: false
 
   /tty-browserify/0.0.0:
@@ -19892,9 +19892,9 @@ packages:
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /ua-parser-js/1.0.35:
@@ -20630,7 +20630,7 @@ packages:
   /vue-template-es2015-compiler/1.9.1:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
 
-  /vue-tsc/1.2.0_typescript@4.9.5:
+  /vue-tsc/1.2.0_typescript@5.2.2:
     resolution: {integrity: sha512-rIlzqdrhyPYyLG9zxsVRa+JEseeS9s8F2BbVVVWRRsTZvJO2BbhLEb2HW3MY+DFma0378tnIqs+vfTzbcQtRFw==}
     hasBin: true
     peerDependencies:
@@ -20638,7 +20638,7 @@ packages:
     dependencies:
       '@volar/vue-language-core': 1.2.0
       '@volar/vue-typescript': 1.2.0
-      typescript: 4.9.5
+      typescript: 5.2.2
     dev: true
 
   /vue/2.7.14:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
       vue-plausible: ^1.3.2
       vue-server-renderer: ^2.7.14
       vue-template-compiler: ^2.7.14
-      vue-tsc: 1.2.0
+      vue-tsc: 1.8.22
       webpack: ^4.46.0
     dependencies:
       '@nuxt/components': 2.2.1
@@ -213,7 +213,7 @@ importers:
       vue-loader: 15.10.0_uhs2gfg5l6piymj36axgkhxosy
       vue-server-renderer: 2.7.14
       vue-template-compiler: 2.7.14
-      vue-tsc: 1.2.0_typescript@5.2.2
+      vue-tsc: 1.8.22_typescript@5.2.2
       webpack: 4.46.0
 
   packages/eslint-plugin:
@@ -6739,16 +6739,35 @@ packages:
       '@typescript-eslint/types': 6.6.0
       eslint-visitor-keys: 3.4.3
 
+  /@volar/language-core/1.10.10:
+    resolution: {integrity: sha512-nsV1o3AZ5n5jaEAObrS3MWLBWaGwUj/vAsc15FVNIv+DbpizQRISg9wzygsHBr56ELRH8r4K75vkYNMtsSNNWw==}
+    dependencies:
+      '@volar/source-map': 1.10.10
+    dev: true
+
   /@volar/language-core/1.3.0-alpha.0:
     resolution: {integrity: sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==}
     dependencies:
       '@volar/source-map': 1.3.0-alpha.0
     dev: true
 
+  /@volar/source-map/1.10.10:
+    resolution: {integrity: sha512-GVKjLnifV4voJ9F0vhP56p4+F3WGf+gXlRtjFZsv6v3WxBTWU3ZVeaRaEHJmWrcv5LXmoYYpk/SC25BKemPRkg==}
+    dependencies:
+      muggle-string: 0.3.1
+    dev: true
+
   /@volar/source-map/1.3.0-alpha.0:
     resolution: {integrity: sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==}
     dependencies:
       muggle-string: 0.2.2
+    dev: true
+
+  /@volar/typescript/1.10.10:
+    resolution: {integrity: sha512-4a2r5bdUub2m+mYVnLu2wt59fuoYWe7nf0uXtGHU8QQ5LDNfzAR0wK7NgDiQ9rcl2WT3fxT2AA9AylAwFtj50A==}
+    dependencies:
+      '@volar/language-core': 1.10.10
+      path-browserify: 1.0.1
     dev: true
 
   /@volar/typescript/1.3.0-alpha.0:
@@ -7117,6 +7136,25 @@ packages:
 
   /@vue/devtools-api/6.5.0:
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
+
+  /@vue/language-core/1.8.22_typescript@5.2.2:
+    resolution: {integrity: sha512-bsMoJzCrXZqGsxawtUea1cLjUT9dZnDsy5TuZ+l1fxRMzUGQUG9+Ypq4w//CqpWmrx7nIAJpw2JVF/t258miRw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@volar/language-core': 1.10.10
+      '@volar/source-map': 1.10.10
+      '@vue/compiler-dom': 3.3.4
+      '@vue/shared': 3.3.4
+      computeds: 0.0.1
+      minimatch: 9.0.3
+      muggle-string: 0.3.1
+      typescript: 5.2.2
+      vue-template-compiler: 2.7.14
+    dev: true
 
   /@vue/reactivity-transform/3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
@@ -9010,6 +9048,10 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  /computeds/0.0.1:
+    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
+    dev: true
 
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -14983,6 +15025,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch/9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist-options/3.0.2:
     resolution: {integrity: sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==}
     engines: {node: '>= 4'}
@@ -15120,6 +15169,10 @@ packages:
 
   /muggle-string/0.2.2:
     resolution: {integrity: sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==}
+    dev: true
+
+  /muggle-string/0.3.1:
+    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
 
   /mustache/2.3.2:
@@ -15926,6 +15979,10 @@ packages:
 
   /path-browserify/0.0.1:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
+
+  /path-browserify/1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
 
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -20638,6 +20695,18 @@ packages:
     dependencies:
       '@volar/vue-language-core': 1.2.0
       '@volar/vue-typescript': 1.2.0
+      typescript: 5.2.2
+    dev: true
+
+  /vue-tsc/1.8.22_typescript@5.2.2:
+    resolution: {integrity: sha512-j9P4kHtW6eEE08aS5McFZE/ivmipXy0JzrnTgbomfABMaVKx37kNBw//irL3+LlE3kOo63XpnRigyPC3w7+z+A==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@volar/typescript': 1.10.10
+      '@vue/language-core': 1.8.22_typescript@5.2.2
+      semver: 7.5.4
       typescript: 5.2.2
     dev: true
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

No issue for this update

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the TypeScript version to the latest stable, v5.2.2.

I removed `typeRoots` setting from `tsconfig` because with it, type checks were failing with 
```
 error TS2688: Cannot find type definition file for '@nuxt/types
│   The file is in the program because
│     Entry point of type library '@nuxt/types' specified in compilerOptions
│ error TS2688: Cannot find type definition file for '@nuxtjs/i18n
│   The file is in the program because
│     Entry point of type library '@nuxtjs/i18n' specified in compilerOptions
│ error TS2688: Cannot find type definition file for '@pinia/nuxt
│   The file is in the program because
│     Entry point of type library '@pinia/nuxt' specified in compilerOptions
│ error TS2688: Cannot find type definition file for '@sentry/core
│   The file is in the program because
│     Entry point of type library '@sentry/core' specified in compilerOptions
│ error TS2688: Cannot find type definition file for '@types/jest
│   The file is in the program because
│     Entry point of type library '@types/jest' specified in compilerOptions
```
This happens if types are specified in `types` parameter in tsconfig, but not included in the `typeRoots` [^1].

@sarayourfriend, I'm not sure what effect excluding `typeRoots` will have.
I found a very old note about this setting being added for backward compatibility with typings: https://github.com/Microsoft/TypeScript/issues/22217#issuecomment-370019383
And here are the docs about the change that caused the new behavior during resolution, in TS 5.1: https://devblogs.microsoft.com/typescript/announcing-typescript-5-1-rc/#typeroots-are-consulted-in-module-resolution


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass, both VS Code and WebStorm should not have additional warnings about TS or unresolved files in JS.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

[^1]: [Related test file in TS repository](https://github.com/microsoft/TypeScript/blob/d2fdf851cc630d812b7b336a43cc1f363ba25083/tests/baselines/reference/tscWatch/programUpdates/types-should-not-load-from-config-file-path-if-config-exists-but-does-not-specifies-typeRoots.js#L38)