### PR TITLE
Include media provider in thumbnail failure logging and tallying

### DIFF
--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -64,6 +64,7 @@ def get(
     accept_header: str = "image/*",
     is_full_size: bool = False,
     is_compressed: bool = True,
+    media_provider: str = None,
 ) -> HttpResponse:
     """
     Proxy an image through Photon if its file type is supported, else return the
@@ -101,6 +102,11 @@ def get(
             f"thumbnail_response_code_by_domain:{domain}:"
             f"{month}:{upstream_response.status_code}"
         )
+        if media_provider:
+            tallies.incr(
+                f"thumbnail_response_code_by_provider:{media_provider}:"
+                f"{month}:{upstream_response.status_code}"
+            )
         upstream_response.raise_for_status()
     except Exception as exc:
         exception_name = f"{exc.__class__.__module__}.{exc.__class__.__name__}"
@@ -123,8 +129,12 @@ def get(
                 )
                 sentry_sdk.capture_exception(exc)
         if isinstance(exc, requests.exceptions.HTTPError):
+            code = exc.response.status_code
             tallies.incr(
-                f"thumbnail_http_error:{domain}:{month}:{exc.response.status_code}:{exc.response.text}"
+                f"thumbnail_http_error:{domain}:{month}:{code}:{exc.response.text}"
+            )
+            logger.warning(
+                f"Failed to render thumbnail {upstream_url=} {code=} {media_provider=}"
             )
         raise UpstreamThumbnailException(f"Failed to render thumbnail. {exc}")
 

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -193,6 +193,7 @@ class MediaViewSet(ReadOnlyModelViewSet):
         return image_proxy.get(
             image_url,
             media_obj.identifier,
+            media_provider=media_obj.provider,
             accept_header=request.headers.get("Accept", "image/*"),
             **serializer.validated_data,
         )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

No direct issue for this, but it was something I noticed while trying to debug a thumbnail incident earlier this week. We track a number of thumbnail statistics by _domain_, which is effectively a _proxy_ for provider but isn't actually logging the provider itself. Here are the current ways we're tallying thumbnail metrics in Redis:

- `thumbnail_http_error | domain | month | code`
- `thumbnail_error | exception | domain | month`
- `thumbnail_response_code_by_domain | domain | month | code`
- `thumbnail_response_code | month | code`

The problem here is that the number of possible `domain` values is quite a bit larger than our number of providers, so it makes navigating that hierarchy difficult. Additionally, the current monthly-binning of thumbnail tallies makes it hard to uncover issues with providers in real time.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the image proxy function so that `media_provider` is handed into the `.get` call for the thumbnail generation function. This lets us, where available, log the provider for a given failure rather than just the domain. The additional `logger.warning` call will make it easier to use something like Cloudwatch Log Insights to do binned queries for failures by provider over a certain period of time. This could help us, in the future, identify thumbnail issues that might be occurring on a specific provider.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Modify a stocksnap URL in the `sample_image.csv` file (I added a few characters right before the extension of the URL)
2. `j down -v && j api/init`
3. Visit the thumbnail URL for the URL you modified (e.g. `http://localhost:50270/v1/images/00252271-e1dc-4faf-b840-7fcc386f2529/thumb/`)
4. Run `j logs web` and see a log line like the following:

```
openverse-web-1  | [2023-11-07 20:26:59,118 - api.utils.image_proxy.get - 136][WARNING] [093ec5827d504350a3444c4ffc1c1d09] Failed to render thumbnail upstream_url='https://i0.wp.com/cdn.stocksnap.io/img-thumbs/960w/7HHEXNL6AQAAA.jpg' code=403 media_provider='stocksnap'
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
