### PR TITLE
Use a default for `HOST_NETWORK_ADDRESS` to hide warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,7 +331,7 @@ services:
     ports:
       - "50290:8080"
     environment:
-      OPENVERSE_NGINX_UPSTREAM_URL: ${HOST_NETWORK_ADDRESS}:8443
+      OPENVERSE_NGINX_UPSTREAM_URL: ${HOST_NETWORK_ADDRESS:-172.17.0.1}:8443
       OPENVERSE_NGINX_PLAUSIBLE_EVENT_URL: http://plausible:8000/api/event
       # Set to Docker network resolver to be able to resolve the `plausible` container.
       # This would be the default but Nginx requires it to be explicitly set when

--- a/justfile
+++ b/justfile
@@ -10,8 +10,6 @@ PROD_ENV := env_var_or_default("PROD_ENV", "")
 IS_CI := env_var_or_default("CI", "")
 DC_USER := env_var_or_default("DC_USER", "opener")
 
-export HOST_NETWORK_ADDRESS := if os() == "macos" { "host.docker.internal" } else { "172.17.0.1" }
-
 # Show all available recipes, also recurses inside nested justfiles
 @_default:
     just --list --unsorted
@@ -127,6 +125,8 @@ export API_PY_VERSION := `just api/py-version`
 export INGESTION_PY_VERSION := `just ingestion_server/py-version`
 export FRONTEND_NODE_VERSION := `just frontend/node-version`
 export FRONTEND_PNPM_VERSION := `just frontend/pnpm-version`
+
+export HOST_NETWORK_ADDRESS := if os() == "macos" { "host.docker.internal" } else { "172.17.0.1" }
 
 versions:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Docker Compose performs all env var interpolation in the full `docker-compose.yml` file regardless of which services are being started. When using a recipe like `api/init` (that does not refer to the root `justfile`), the vars are not set and Docker Composes raises warnings for missing `HOST_NETWORK_ADDRESS`.

This PR
- sets a default for the `HOST_NETWORK_ADDRESS` env var to suppress warnings raised by Docker Compose
- moves the env var export in the root to the Docker section

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You should no longer see errors like the following when running `api/init`.

<img width="730" alt="Screenshot 2023-11-10 at 11 11 11 AM" src="https://github.com/WordPress/openverse/assets/16580576/10342605-84cd-4da1-b012-1c00a934d912">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
