### PR TITLE
Configure the number of proxies to fix anon rate limiting

### DIFF
--- a/api/conf/settings/rest_framework.py
+++ b/api/conf/settings/rest_framework.py
@@ -57,3 +57,5 @@ if config("DISABLE_GLOBAL_THROTTLING", default=True, cast=bool):
         **{k: None for k, _ in REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"].items()}
     )
     del REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]
+
+NUM_PROXIES = config("NUM_PROXIES", default=3, cast=int)

--- a/api/conf/settings/rest_framework.py
+++ b/api/conf/settings/rest_framework.py
@@ -58,4 +58,6 @@ if config("DISABLE_GLOBAL_THROTTLING", default=True, cast=bool):
     )
     del REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]
 
-NUM_PROXIES = config("NUM_PROXIES", default=3, cast=int)
+# https://www.django-rest-framework.org/api-guide/throttling/#how-clients-are-identified
+# We override this in live environments to an appropriate number based on our deployment
+NUM_PROXIES = config("NUM_PROXIES", default=0, cast=int)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Anonymous throttling is currently broken and only works by chance. Given our live API configuration, where we always have X-Forwarded-For, and do not have `NUM_PROXIES` set, DRF's default `get_ident` implementation is using the entire X-Forwarded-For header to build the client identifier. This is a problem because X-Forwarded-For will always include three additional IPs for the reverse proxies in our live environment: Cloudflare's proxy, the AWS load balancer and finally Nginx (which handles static files). The resulting X-Forwarded-For header will look something like this once it reaches Django: `<client IP>, <Cloudflare IP>, <load balancer IP>, <Nginx IP>`.

The most problematic of these are really the load balancer and the nginx IP, because there are 6 load balancers (one for each availability zone) and it's purely chance which one you get, and additionally there are 5 API tasks, and which of those you get is also up to chance. The Cloudflare IP might be stable for requesters within a geographic area, but I'm not 100% sure if that's true. Assuming it is, the chances of the other two are not necessarily evenly weighted, because it's dependent on request volume, so it isn't a clean 1/(5 tasks * 6 lbs) (or 1/30) chance of having the same identifier. Still the chances are high that you'll get a different identifier anyway!

Indeed, I tried three different anonymous requests that all missed the cache and I got the same rate limiting response each time, indicating that I'd only use 1 of my request quota for sustained anonymous.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
N/A. This is just adding a rest framework setting. The implementation details are all in the rest framework code, so there's nothing for us to test.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
