### PR TITLE
Add gc debugging flag to help debug prod thumbnails leak

### DIFF
--- a/api/conf/asgi.py
+++ b/api/conf/asgi.py
@@ -20,3 +20,17 @@ application = get_asgi_application()
 
 if settings.ENVIRONMENT == "local":
     static_files_application = ASGIStaticFilesHandler(application)
+
+
+if settings.GC_DEBUG_LOGGING:
+    import gc
+
+    flags = []
+    for flag_name in settings.GC_DEBUG_LOGGING:
+        flags.append(getattr(gc, flag_name))
+
+    setting = flags[0]
+    for flag in flags[1:]:
+        setting |= flag
+
+    gc.set_debug(setting)

--- a/api/conf/asgi.py
+++ b/api/conf/asgi.py
@@ -25,12 +25,8 @@ if settings.ENVIRONMENT == "local":
 if settings.GC_DEBUG_LOGGING:
     import gc
 
-    flags = []
-    for flag_name in settings.GC_DEBUG_LOGGING:
-        flags.append(getattr(gc, flag_name))
-
-    setting = flags[0]
-    for flag in flags[1:]:
-        setting |= flag
+    setting = 0
+    for flag in settings.GC_DEBUG_LOGGING:
+        setting |= getattr(gc, flag)
 
     gc.set_debug(setting)

--- a/api/conf/settings/logging.py
+++ b/api/conf/settings/logging.py
@@ -13,6 +13,9 @@ def health_check_filter(record: LogRecord) -> bool:
 
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
 DJANGO_DB_LOGGING = config("DJANGO_DB_LOGGING", cast=bool, default=False)
+
+# Set to a pipe-delimited string of gc debugging flags
+# https://docs.python.org/3/library/gc.html#gc.DEBUG_STATS
 GC_DEBUG_LOGGING = config(
     "GC_DEBUG_LOGGING", cast=lambda x: x.split("|") if x else [], default=""
 )

--- a/api/conf/settings/logging.py
+++ b/api/conf/settings/logging.py
@@ -13,6 +13,9 @@ def health_check_filter(record: LogRecord) -> bool:
 
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
 DJANGO_DB_LOGGING = config("DJANGO_DB_LOGGING", cast=bool, default=False)
+GC_DEBUG_LOGGING = config(
+    "GC_DEBUG_LOGGING", cast=lambda x: x.split("|") if x else [], default=""
+)
 
 # https://github.com/dabapps/django-log-request-id#logging-all-requests
 LOG_REQUESTS = True


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse/issues/3353

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We want to debug the memory leak behaviour in production. To do so, we'll enable garbage collection debug logging available in Python's `gc` module.

https://docs.python.org/3/library/gc.html#gc.set_debug

The flags are documented here:

https://docs.python.org/3/library/gc.html#gc.DEBUG_UNCOLLECTABLE

Because `DEBUG_LEAK` logs all collected objects, which is an overwhelming amount of logging, we'll start off with just `DEBUG_UNCOLLECTABLE` and `DEBUG_SAVEALL` first, to see if we can find dangling objects. If that doesn't work, we'll enable `DEBUG_LEAK` for a few hours to see if we get any useful information from it.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
First try the application on this branch with no changes to environment settings and ensure things work as expected. You should not see any new logging from the Django API (`just logs web`).

Next, add `GC_DEBUG_LOGGING` in your `api/.env` setting and set it to `DEBUG_UNCOLLECTABLE|DEBUG_SAVEALL` and restart your API (`just api/up` should recreate it). You probably will not see logs here, but that's good, because it means there isn't an easily reproducible memory leak.

Now set it to `DEBUG_UNCOLLECTABLE|DEBUG_SAVEALL|DEBUG_COLLECTABLE`, the equivalent of `DEBUG_LEAK`. The idea behind setting this explicitly while testing is to make sure that the flag aggregation is working, because collectable logging is conspicuous. Restart your local API and view the logs when making a search request. You should see heaps of logging about the collected objects (and now see why we won't enable COLLECTABLE at first).

Now set it to an empty string and restart. You should no longer see logging in the webapp.

Now set it to `DEBUG_LEAK` and restart. You should see the same behaviour as when you set uncollectable, saveall, and collectable.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
