### PR TITLE
Do not Merge: Remove dynamic provider filtering

### DIFF
--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -5,10 +5,7 @@ from elasticsearch_dsl.query import Match, Q, Term
 from elasticsearch_dsl.response import Hit
 
 from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
-from api.controllers.search_controller import (
-    _post_process_results,
-    get_excluded_providers_query,
-)
+from api.controllers.search_controller import _post_process_results
 
 
 def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
@@ -52,9 +49,6 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
             tags = [tag["name"] for tag in tags[:10]]
             related_query["should"].append(Q("terms", tags__name__keyword=tags))
 
-    # Exclude the dynamically disabled sources.
-    if excluded_providers_query := get_excluded_providers_query():
-        related_query["must_not"].append(excluded_providers_query)
     # Exclude the current item and mature content.
     related_query["must_not"].extend(
         [Q("term", mature=True), Q("term", identifier=uuid)]

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -6,8 +6,6 @@ from test.factory.es_http import (
 from test.factory.models import ImageFactory
 from unittest import mock
 
-from django.core.cache import cache
-
 import pook
 import pytest
 
@@ -15,18 +13,6 @@ from api.controllers.elasticsearch import related
 
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def excluded_providers_cache():
-    cache_key = "filtered_providers"
-    excluded_provider = "excluded_provider"
-    cache_value = [{"provider_identifier": excluded_provider}]
-    cache.set(cache_key, cache_value, timeout=1)
-
-    yield excluded_provider
-
-    cache.delete(cache_key)
 
 
 @mock.patch(
@@ -38,7 +24,6 @@ def test_related_media(
     wrapped_related_results,
     image_media_type_config,
     settings,
-    excluded_providers_cache,
 ):
     image = ImageFactory.create()
 
@@ -74,7 +59,6 @@ def test_related_media(
         "query": {
             "bool": {
                 "must_not": [
-                    {"terms": {"provider": [excluded_providers_cache]}},
                     {"term": {"mature": True}},
                     {"term": {"identifier": image.identifier}},
                 ],

--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -91,8 +91,12 @@ def delete_records_from_media_table(
 
 
 @task
-def notify_slack(text: str) -> str:
+def notify_slack(deleted_records_count: int, table_name: str, select_query: str) -> str:
     """Send a message to Slack."""
+    text = (
+        f"Deleted {deleted_records_count:,} records from the"
+        f" {table_name} table matching query: `{select_query}`"
+    )
     slack.send_message(
         text,
         username=constants.SLACK_USERNAME,

--- a/catalog/dags/database/delete_records/delete_records_dag.py
+++ b/catalog/dags/database/delete_records/delete_records_dag.py
@@ -102,10 +102,9 @@ def delete_records():
     )(table="{{ params.table_name }}", select_query="{{ params.select_query }}")
 
     notify_complete = notify_slack(
-        text=(
-            f"Deleted {delete_records} records from the"
-            " {{ params.table_name }} table matching query: `{{ params.select_query }}`"
-        ),
+        deleted_records_count=delete_records,
+        table_name="{{ params.table_name }}",
+        select_query="{{ params.select_query }}",
     )
 
     insert_into_deleted_media_table >> delete_records >> notify_complete


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Part of #3257 by @stacimc
Follow up to #3259

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR removes dynamic provider filtering in the API, following the work in #3257. This dynamic filtering was *only* being used to filter out archived providers, who have all now been removed from the dataset at the catalog level. After the image data refresh is run, those records will not even be available in the API db & elasticsearch indices, so filtering them is no longer necessary at the API level. This PR entirely gets rid of that filter in the API

As I started to post this, however, I realized that the dynamic provider filtering can still be useful because it allows us to immediately stop serving results for a provider without needing to wait for a `delete_records` run + data refresh. It's also more flexible because we can turn the filtering on and back off again instantly. This is an important tool we shouldn't remove.

So I think the correct solution here is actually to:
* Wait for the image data refresh to finish.
* Remove the affected image providers from the `content_provider` table in the API. This makes sense because no records from those providers will be in the API anymore.
* Leave the filtering as is

As long as no providers have `filter_content` enabled, we won't have any additional ES filters applied. We should note that removing records at the catalog level is preferred for this reason, but the ES filter can be used for hiding records quickly (or when data refreshes aren't running) or temporarily.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
