### PR TITLE
Fix delete_records slack formatting

### DIFF
--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -91,8 +91,12 @@ def delete_records_from_media_table(
 
 
 @task
-def notify_slack(text: str) -> str:
+def notify_slack(deleted_records_count: int, table_name: str, select_query: str) -> str:
     """Send a message to Slack."""
+    text = (
+        f"Deleted {deleted_records_count:,} records from the"
+        f" {table_name} table matching query: `{select_query}`"
+    )
     slack.send_message(
         text,
         username=constants.SLACK_USERNAME,

--- a/catalog/dags/database/delete_records/delete_records.py
+++ b/catalog/dags/database/delete_records/delete_records.py
@@ -95,7 +95,7 @@ def notify_slack(deleted_records_count: int, table_name: str, select_query: str)
     """Send a message to Slack."""
     text = (
         f"Deleted {deleted_records_count:,} records from the"
-        f" {table_name} table matching query: `{select_query}`"
+        f" `{table_name}` table matching query: `{select_query}`"
     )
     slack.send_message(
         text,

--- a/catalog/dags/database/delete_records/delete_records_dag.py
+++ b/catalog/dags/database/delete_records/delete_records_dag.py
@@ -102,10 +102,9 @@ def delete_records():
     )(table="{{ params.table_name }}", select_query="{{ params.select_query }}")
 
     notify_complete = notify_slack(
-        text=(
-            f"Deleted {delete_records} records from the"
-            " {{ params.table_name }} table matching query: `{{ params.select_query }}`"
-        ),
+        deleted_records_count=delete_records,
+        table_name="{{ params.table_name }}",
+        select_query="{{ params.select_query }}",
     )
 
     insert_into_deleted_media_table >> delete_records >> notify_complete

--- a/catalog/tests/dags/database/test_delete_records.py
+++ b/catalog/tests/dags/database/test_delete_records.py
@@ -9,6 +9,7 @@ from common.storage.db_columns import DELETED_IMAGE_TABLE_COLUMNS, IMAGE_TABLE_C
 from database.delete_records.delete_records import (
     create_deleted_records,
     delete_records_from_media_table,
+    notify_slack,
 )
 
 
@@ -246,3 +247,11 @@ def test_delete_no_records_from_media_table(
 
     # All three records are left in the image table
     assert len(actual_rows) == 3
+
+
+def test_notify_slack():
+    message = notify_slack.function(123456789, "audio", "WHERE provider='foo';")
+    assert message == (
+        "Deleted 123,456,789 records from the audio table matching query: "
+        "`WHERE provider='foo';`"
+    )

--- a/catalog/tests/dags/database/test_delete_records.py
+++ b/catalog/tests/dags/database/test_delete_records.py
@@ -252,6 +252,6 @@ def test_delete_no_records_from_media_table(
 def test_notify_slack():
     message = notify_slack.function(123456789, "audio", "WHERE provider='foo';")
     assert message == (
-        "Deleted 123,456,789 records from the audio table matching query: "
+        "Deleted 123,456,789 records from the `audio` table matching query: "
         "`WHERE provider='foo';`"
     )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Very small change to fix the formatting of the reported `record_count` in the Slack message from the `delete_records` DAG.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Unit test should pass. If you'd like, you can also run the `delete_records` DAG locally with a conf that will select >=1k records, example:

```
{
  "reason":"deadlink"
  "select_query":"WHERE provider in ('freesound', 'wikimedia_audio');"
  "table_name":"audio"
}
```

Then look at the message for the final, `notify_slack` task and it should be formatted properly (`Deleted 4,172 records from the audio table matching query: 'WHERE provider in ('jamendo', 'wikimedia_audio')'`)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
