### PR TITLE
Add middleware to log application name and verification status

### DIFF
--- a/api/api/middleware/client_application_middleware.py
+++ b/api/api/middleware/client_application_middleware.py
@@ -1,0 +1,16 @@
+from api.utils.oauth2_helper import get_token_info
+
+
+def client_application_middleware(get_response):
+    def middleware(request):
+        response = get_response(request)
+
+        if hasattr(request, "auth") and request.auth:
+            token_info = get_token_info(str(request.auth))
+            if token_info:
+                response["x-ov-client-application-name"] = token_info.application_name
+                response["x-ov-client-application-verified"] = token_info.verified
+
+        return response
+
+    return middleware

--- a/api/api/middleware/response_headers_middleware.py
+++ b/api/api/middleware/response_headers_middleware.py
@@ -1,7 +1,16 @@
 from api.utils.oauth2_helper import get_token_info
 
 
-def client_application_middleware(get_response):
+def response_headers_middleware(get_response):
+    """
+    Add standard response headers used by Nginx logging.
+
+    These headers help Openverse more easily and directly connect
+    individual requests to each other. This is particularly useful
+    when evaluating traffic patterns from individual source IPs
+    to identify malicious requesters or request patterns.
+    """
+
     def middleware(request):
         response = get_response(request)
 

--- a/api/conf/settings/base.py
+++ b/api/conf/settings/base.py
@@ -22,6 +22,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "api.middleware.client_application_middleware.client_application_middleware",
 ]
 
 # Storage

--- a/api/conf/settings/base.py
+++ b/api/conf/settings/base.py
@@ -22,7 +22,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "api.middleware.client_application_middleware.client_application_middleware",
+    "api.middleware.response_headers_middleware.response_headers_middleware",
 ]
 
 # Storage

--- a/api/nginx.conf.template
+++ b/api/nginx.conf.template
@@ -17,10 +17,14 @@ log_format json_combined escape=json
     '"host_header": "$host",'
     '"body_bytes_sent":$body_bytes_sent,'
     '"request_time":"$request_time",'
+    '"upstream_response_time":$upstream_response_time,'
     '"http_referrer":"$http_referer",'
     '"http_user_agent":"$http_user_agent",'
-    '"upstream_response_time":$upstream_response_time,'
-    '"http_x_forwarded_for":"$http_x_forwarded_for"'
+    '"http_x_forwarded_for":"$http_x_forwarded_for",'
+    '"http_authorization":"$http_authorization",'
+    '"request_id":"$sent_http_x_request_id",'
+    '"client_application_name":"$sent_http_x_ov_client_application_name",'
+    '"client_application_verified":"$sent_http_x_ov_client_application_verified"'
     '}';
 
 access_log  /var/log/nginx/access.log  json_combined;


### PR DESCRIPTION
Also add authorization, app name and verified status to nginx logs

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Closes https://github.com/WordPress/openverse/issues/2246 by @sarayourfriend 
Fixes #3368 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Add logging as described in the issue.

To add the application name and verified status, I added a new middleware. The tests for this are in the `test_auth` suite.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
You need to rebuild the nginx image to get the new logging: `just build nginx`. Afterwards, make requests to your local API via the nginx container: `localhost:50270`. Follow that container's logs (`just logs nginx`) and confirm that you see the following JSON log properties:

- `request_id`
- `client_application_name`
- `client_application_verified`

These come from the following headers, respectively, which you should also see on responses:

- `x-request-id`
- `x-ov-client-application-name`
- `x-ov-client-application-verified`

Note that the last two are only present on authorized requests. Nginx will log an empty string when those headers are not present, but if you make an authorized request locally (by following the auth flow), you'll be able to see these populated both in your response headers and in Nginx's logs.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
