### PR TITLE
Fix dynamically excluded providers caching

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -177,10 +177,11 @@ def get_excluded_providers_query() -> Q | None:
 
     filtered_providers = cache.get(key=FILTERED_PROVIDERS_CACHE_KEY)
     if not filtered_providers:
-        filtered_providers = list(models.ContentProvider.objects.filter(filter_content=True).values_list(
-            "provider_identifier",
-            flat=True,
-        ))
+        filtered_providers = list(
+            models.ContentProvider.objects.filter(filter_content=True).values_list(
+                "provider_identifier", flat=True
+            )
+        )
         cache.set(
             key=FILTERED_PROVIDERS_CACHE_KEY,
             timeout=FILTER_CACHE_TIMEOUT,

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -177,10 +177,10 @@ def get_excluded_providers_query() -> Q | None:
 
     filtered_providers = cache.get(key=FILTERED_PROVIDERS_CACHE_KEY)
     if not filtered_providers:
-        providers = models.ContentProvider.objects.filter(filter_content=True).values(
-            "provider_identifier"
-        )
-        filtered_providers = [p["provider_identifier"] for p in providers]
+        filtered_providers = list(models.ContentProvider.objects.filter(filter_content=True).values_list(
+            "provider_identifier",
+            flat=True,
+        ))
         cache.set(
             key=FILTERED_PROVIDERS_CACHE_KEY,
             timeout=FILTER_CACHE_TIMEOUT,

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -50,6 +50,7 @@ module_logger = logging.getLogger(__name__)
 NESTING_THRESHOLD = config("POST_PROCESS_NESTING_THRESHOLD", cast=int, default=5)
 SOURCE_CACHE_TIMEOUT = 60 * 60 * 4  # 4 hours
 FILTER_CACHE_TIMEOUT = 30
+FILTERED_PROVIDERS_CACHE_KEY = "filtered_providers"
 THUMBNAIL = "thumbnail"
 URL = "url"
 PROVIDER = "provider"
@@ -170,19 +171,23 @@ def get_excluded_providers_query() -> Q | None:
     Hide data sources from the catalog dynamically.
     To exclude a provider, set ``filter_content`` to ``True`` in the
     ``ContentProvider`` model in Django admin.
+    The list of ``provider_identifier``s is cached in Redis with
+    `:1:FILTER_CACHE_KEY` key.
     """
 
-    filter_cache_key = "filtered_providers"
-    filtered_providers = cache.get(key=filter_cache_key)
+    filtered_providers = cache.get(key=FILTERED_PROVIDERS_CACHE_KEY)
     if not filtered_providers:
-        filtered_providers = models.ContentProvider.objects.filter(
-            filter_content=True
-        ).values("provider_identifier")
-        cache.set(
-            key=filter_cache_key, timeout=FILTER_CACHE_TIMEOUT, value=filtered_providers
+        providers = models.ContentProvider.objects.filter(filter_content=True).values(
+            "provider_identifier"
         )
-    if provider_list := [f["provider_identifier"] for f in filtered_providers]:
-        return Q("terms", provider=provider_list)
+        filtered_providers = [p["provider_identifier"] for p in providers]
+        cache.set(
+            key=FILTERED_PROVIDERS_CACHE_KEY,
+            timeout=FILTER_CACHE_TIMEOUT,
+            value=filtered_providers,
+        )
+    if filtered_providers:
+        return Q("terms", provider=filtered_providers)
     return None
 
 

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.django_db
 def excluded_providers_cache():
     cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
-    cache_value = [{"provider_identifier": excluded_provider}]
+    cache_value = [excluded_provider]
     cache.set(cache_key, cache_value, timeout=1)
 
     yield excluded_provider

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -12,6 +12,7 @@ import pook
 import pytest
 
 from api.controllers.elasticsearch import related
+from api.controllers.search_controller import FILTERED_PROVIDERS_CACHE_KEY
 
 
 pytestmark = pytest.mark.django_db
@@ -19,14 +20,13 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def excluded_providers_cache():
-    cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
     cache_value = [excluded_provider]
-    cache.set(cache_key, cache_value, timeout=1)
+    cache.set(FILTERED_PROVIDERS_CACHE_KEY, cache_value, timeout=1)
 
     yield excluded_provider
 
-    cache.delete(cache_key)
+    cache.delete(FILTERED_PROVIDERS_CACHE_KEY)
 
 
 @mock.patch(

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 def excluded_providers_cache():
     cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
-    cache_value = [{"provider_identifier": excluded_provider}]
+    cache_value = [excluded_provider]
     cache.set(cache_key, cache_value, timeout=1)
 
     yield excluded_provider

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -4,6 +4,7 @@ import pytest
 from elasticsearch_dsl import Q
 
 from api.controllers import search_controller
+from api.controllers.search_controller import FILTERED_PROVIDERS_CACHE_KEY
 
 
 pytestmark = pytest.mark.django_db
@@ -11,14 +12,13 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def excluded_providers_cache():
-    cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
     cache_value = [excluded_provider]
-    cache.set(cache_key, cache_value, timeout=1)
+    cache.set(FILTERED_PROVIDERS_CACHE_KEY, cache_value, timeout=1)
 
     yield excluded_provider
 
-    cache.delete(cache_key)
+    cache.delete(FILTERED_PROVIDERS_CACHE_KEY)
 
 
 def test_create_search_query_empty(media_type_config):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3380 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR saves a list of `provider_identifier`s for the dynamically-excluded providers to the redis cache, instead of saving the QuerySet.
It also adds two unit tests for the specific functions, but there are also several other tests that test dynamically excluded providers using both cache and the `ContentProvider` model saved in the database.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app, go to `http://localhost:50280/admin`, select one of the `ContentProvider` models and check its "Hide Content" property.
<img width="633" alt="Screenshot 2023-11-21 at 5 22 01 PM" src="https://github.com/WordPress/openverse/assets/15233243/6d638fc6-9973-419e-a7e2-819dc5ac5cea">

 Execute a search (http://localhost:50280/v1/images). Check Redis value for `:1:filtered_providers` (I used the RedisInsights GUI): 

<img width="599" alt="Screenshot 2023-11-21 at 5 23 35 PM" src="https://github.com/WordPress/openverse/assets/15233243/bb787267-b91f-44a8-941c-414133ba9583">

Also, check that on `main`, if you set "Hide content" to true for one of the providers, the value saved in Redis should look like the one in the related issue instead of a list of filtered providers.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
