### PR TITLE
Convert entire image proxy route async

### DIFF
--- a/api/api/utils/asyncio.py
+++ b/api/api/utils/asyncio.py
@@ -1,0 +1,29 @@
+import asyncio
+import logging
+from collections.abc import Awaitable
+
+
+parent_logger = logging.getLogger(__name__)
+
+
+_fire_and_forget_logger = parent_logger.getChild("fire_and_forget")
+
+
+def fire_and_forget(awaitable: Awaitable) -> None:
+    """
+    Consume an awaitable without waiting for it to finish.
+
+    This allows us to "fire and forget" an async function that
+    we don't care about the result of. This is useful, for example,
+    if some operation creates a side effect that isn't necessary for
+    the response we're processing (e.g., Redis tallying).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError as exc:
+        _fire_and_forget_logger.error(
+            "`fire_and_forget` must be called inside a running" " event loop."
+        )
+        raise exc
+
+    loop.create_task(awaitable)

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import urlparse
@@ -7,11 +8,15 @@ from django.conf import settings
 from django.http import HttpResponse
 from rest_framework.exceptions import UnsupportedMediaType
 
+import aiohttp
 import django_redis
 import requests
 import sentry_sdk
+from asgiref.sync import sync_to_async
 from sentry_sdk import push_scope, set_context
 
+from api.utils.aiohttp import get_aiohttp_session
+from api.utils.asyncio import fire_and_forget
 from api.utils.image_proxy.exception import UpstreamThumbnailException
 from api.utils.image_proxy.extension import get_image_extension
 from api.utils.image_proxy.photon import get_photon_request_params
@@ -75,11 +80,40 @@ def get_request_params_for_extension(
     )
 
 
-def get(
+@sync_to_async
+def _tally_response(
+    tallies,
+    media_info: MediaInfo,
+    month: str,
+    domain: str,
+    response: aiohttp.ClientResponse,
+):
+    """
+    Tally image proxy response without waiting for Redis to respond.
+
+    Pulled into a separate function to help reduce overload when skimming
+    the `get` function, which is complex enough as is.
+    """
+    tallies.incr(f"thumbnail_response_code:{month}:{response.status}"),
+    tallies.incr(
+        f"thumbnail_response_code_by_domain:{domain}:" f"{month}:{response.status}"
+    )
+    tallies.incr(
+        f"thumbnail_response_code_by_provider:{media_info.media_provider}:"
+        f"{month}:{response.status}"
+    )
+
+
+_UPSTREAM_TIMEOUT = aiohttp.ClientTimeout(15)
+
+
+async def get(
     media_info: MediaInfo,
     request_config: RequestConfig = RequestConfig(),
 ) -> HttpResponse:
     """
+    Retrieve proxied image from site accelerator.
+
     Proxy an image through Photon if its file type is supported, else return the
     original image if the file type is SVG. Otherwise, raise an exception.
     """
@@ -88,9 +122,10 @@ def get(
 
     logger = parent_logger.getChild("get")
     tallies = django_redis.get_redis_connection("tallies")
+    tallies_incr = sync_to_async(tallies.incr)
     month = get_monthly_timestamp()
 
-    image_extension = get_image_extension(image_url, media_identifier)
+    image_extension = await get_image_extension(image_url, media_identifier)
 
     headers = {"Accept": request_config.accept_header} | HEADERS
 
@@ -106,26 +141,36 @@ def get(
     )
 
     try:
-        upstream_response = requests.get(
+        # todo: refactor to use aiohttp shared session
+        session = await get_aiohttp_session()
+
+        upstream_response = await session.get(
             upstream_url,
-            timeout=15,
+            timeout=_UPSTREAM_TIMEOUT,
             params=params,
             headers=headers,
         )
-        tallies.incr(f"thumbnail_response_code:{month}:{upstream_response.status_code}")
-        tallies.incr(
-            f"thumbnail_response_code_by_domain:{domain}:"
-            f"{month}:{upstream_response.status_code}"
-        )
-        tallies.incr(
-            f"thumbnail_response_code_by_provider:{media_info.media_provider}:"
-            f"{month}:{upstream_response.status_code}"
+        fire_and_forget(
+            _tally_response(tallies, media_info, month, domain, upstream_response)
         )
         upstream_response.raise_for_status()
+        status_code = upstream_response.status
+        content_type = upstream_response.headers.get("Content-Type")
+        logger.debug(
+            "Image proxy response status: %s, content-type: %s",
+            status_code,
+            content_type,
+        )
+        content = await upstream_response.content.read()
+        return HttpResponse(
+            content,
+            status=status_code,
+            content_type=content_type,
+        )
     except Exception as exc:
         exception_name = f"{exc.__class__.__module__}.{exc.__class__.__name__}"
         key = f"thumbnail_error:{exception_name}:{domain}:{month}"
-        count = tallies.incr(key)
+        count = await tallies_incr(key)
         if count <= settings.THUMBNAIL_ERROR_INITIAL_ALERT_THRESHOLD or (
             count % settings.THUMBNAIL_ERROR_REPEATED_ALERT_FREQUENCY == 0
         ):
@@ -144,8 +189,10 @@ def get(
                 sentry_sdk.capture_exception(exc)
         if isinstance(exc, requests.exceptions.HTTPError):
             code = exc.response.status_code
-            tallies.incr(
-                f"thumbnail_http_error:{domain}:{month}:{code}:{exc.response.text}"
+            fire_and_forget(
+                tallies_incr(
+                    f"thumbnail_http_error:{domain}:{month}:{code}:{exc.response.text}"
+                )
             )
             logger.warning(
                 f"Failed to render thumbnail "
@@ -153,15 +200,3 @@ def get(
                 f"{media_info.media_provider=}"
             )
         raise UpstreamThumbnailException(f"Failed to render thumbnail. {exc}")
-
-    res_status = upstream_response.status_code
-    content_type = upstream_response.headers.get("Content-Type")
-    logger.debug(
-        f"Image proxy response status: {res_status}, content-type: {content_type}"
-    )
-
-    return HttpResponse(
-        upstream_response.content,
-        status=res_status,
-        content_type=content_type,
-    )

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -1,14 +1,20 @@
 from os.path import splitext
 from urllib.parse import urlparse
 
+import aiohttp
 import django_redis
-import requests
 import sentry_sdk
+from asgiref.sync import sync_to_async
 
+from api.utils.aiohttp import get_aiohttp_session
+from api.utils.asyncio import fire_and_forget
 from api.utils.image_proxy.exception import UpstreamThumbnailException
 
 
-def get_image_extension(image_url: str, media_identifier: str) -> str | None:
+_HEAD_TIMEOUT = aiohttp.ClientTimeout(10)
+
+
+async def get_image_extension(image_url: str, media_identifier) -> str | None:
     cache = django_redis.get_redis_connection("default")
     key = f"media:{media_identifier}:thumb_type"
 
@@ -16,28 +22,29 @@ def get_image_extension(image_url: str, media_identifier: str) -> str | None:
 
     if not ext:
         # If the extension is not present in the URL, try to get it from the redis cache
-        ext = cache.get(key)
+        ext = await sync_to_async(cache.get)(key)
         ext = ext.decode("utf-8") if ext else None
 
     if not ext:
         # If the extension is still not present, try getting it from the content type
         try:
-            response = requests.head(image_url, timeout=10)
+            session = await get_aiohttp_session()
+            response = await session.head(image_url, timeout=_HEAD_TIMEOUT)
             response.raise_for_status()
-        except Exception as exc:
-            sentry_sdk.capture_exception(exc)
-            raise UpstreamThumbnailException(
-                "Failed to render thumbnail due to inability to check media "
-                f"type. {exc}"
-            )
-        else:
             if response.headers and "Content-Type" in response.headers:
                 content_type = response.headers["Content-Type"]
                 ext = _get_file_extension_from_content_type(content_type)
             else:
                 ext = None
 
-            cache.set(key, ext if ext else "unknown")
+            fire_and_forget(sync_to_async(cache.set)(key, ext if ext else "unknown"))
+        except Exception as exc:
+            sentry_sdk.capture_exception(exc)
+            raise UpstreamThumbnailException(
+                "Failed to render thumbnail due to inability to check media "
+                f"type. {exc}"
+            )
+
     return ext
 
 

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -40,9 +40,6 @@ class InvalidSource(APIException):
     default_code = "invalid_source"
 
 
-image_proxy_aget = sync_to_async(image_proxy.get)
-
-
 class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
     view_is_async = True
 
@@ -296,7 +293,7 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
 
         media_info = await self.get_image_proxy_media_info()
 
-        return await image_proxy_aget(
+        return await image_proxy.get(
             media_info,
             request_config=image_proxy.RequestConfig(
                 accept_header=request.headers.get("Accept", "image/*"),


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2789 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR converts `image_proxy::get` to an asynchronous function. This makes the entire `thumbnails` route fully asynchronous, meaning we finally start to gain benefits from running the application under ASGI. We should see increased thumbnail throughput after this (though, it might not be noticeable because we probably won't receive more traffic), but as a result, we should be able to lower the number of thumbnail tasks in the mean time.

We should assume this will increase CPU and memory usage, however, as now each thumbnails worker will be able to handle multiple requests, which will require more context switching (read: increased memory). This is really the first "real" async benefit we get though, because the thumbnails route is _heavily_ asynchronous. The vast majority of time our servers are handling thumbnail requests they're merely waiting for an upstream response! That means they're wasting cycles that could be spent serving (preparing) additional requests to the proxy.

This PR will finalise the Django ASGI project as far as the currently created issues. However, I want to clarify something about the project, and have done so in the project thread.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Everything should continue to work as before. You should be able to follow the testing instructions in #3020, but on top of that you should also test to confirm that Redis tallying, in particular the "fire and forget" parts, are still working. You can do this via the redis cli: `just exec cache redis-cli -n 3` and reading the relevant keys before/after a request to ensure they've incremented as expected.

This PR is a draft for now because I still need to refactor the unit tests to handle the new async function. I ran out of time today but wanted to get the working code up in the meantime. I'll work on the automated tests later this week and hopefully have this ready to review by end of week.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
