### PR TITLE
Fix dynamically excluded providers

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -173,7 +173,7 @@ def get_excluded_providers_query() -> Q | None:
     To exclude a provider, set ``filter_content`` to ``True`` in the
     ``ContentProvider`` model in Django admin.
     The list of ``provider_identifier``s is cached in Redis with
-    `:<version>:FILTER_CACHE_KEY` key.
+    `:FILTERED_PROVIDERS_CACHE_VERSION:FILTERED_PROVIDERS_CACHE_KEY` key.
     """
 
     filtered_providers = cache.get(

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -50,6 +50,8 @@ module_logger = logging.getLogger(__name__)
 NESTING_THRESHOLD = config("POST_PROCESS_NESTING_THRESHOLD", cast=int, default=5)
 SOURCE_CACHE_TIMEOUT = 60 * 60 * 4  # 4 hours
 FILTER_CACHE_TIMEOUT = 30
+FILTERED_PROVIDERS_CACHE_KEY = "filtered_providers"
+FILTERED_PROVIDERS_CACHE_VERSION = 2
 THUMBNAIL = "thumbnail"
 URL = "url"
 PROVIDER = "provider"
@@ -170,19 +172,27 @@ def get_excluded_providers_query() -> Q | None:
     Hide data sources from the catalog dynamically.
     To exclude a provider, set ``filter_content`` to ``True`` in the
     ``ContentProvider`` model in Django admin.
+    The list of ``provider_identifier``s is cached in Redis with
+    `:<version>:FILTER_CACHE_KEY` key.
     """
 
-    filter_cache_key = "filtered_providers"
-    filtered_providers = cache.get(key=filter_cache_key)
+    filtered_providers = cache.get(
+        key=FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION
+    )
     if not filtered_providers:
-        filtered_providers = models.ContentProvider.objects.filter(
-            filter_content=True
-        ).values("provider_identifier")
-        cache.set(
-            key=filter_cache_key, timeout=FILTER_CACHE_TIMEOUT, value=filtered_providers
+        filtered_providers = list(
+            models.ContentProvider.objects.filter(filter_content=True).values_list(
+                "provider_identifier", flat=True
+            )
         )
-    if provider_list := [f["provider_identifier"] for f in filtered_providers]:
-        return Q("terms", provider=provider_list)
+        cache.set(
+            key=FILTERED_PROVIDERS_CACHE_KEY,
+            version=FILTERED_PROVIDERS_CACHE_VERSION,
+            timeout=FILTER_CACHE_TIMEOUT,
+            value=filtered_providers,
+        )
+    if filtered_providers:
+        return Q("terms", provider=filtered_providers)
     return None
 
 

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -12,6 +12,10 @@ import pook
 import pytest
 
 from api.controllers.elasticsearch import related
+from api.controllers.search_controller import (
+    FILTERED_PROVIDERS_CACHE_KEY,
+    FILTERED_PROVIDERS_CACHE_VERSION,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -19,14 +23,18 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def excluded_providers_cache():
-    cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
-    cache_value = [{"provider_identifier": excluded_provider}]
-    cache.set(cache_key, cache_value, timeout=1)
+    cache_value = [excluded_provider]
+    cache.set(
+        key=FILTERED_PROVIDERS_CACHE_KEY,
+        version=FILTERED_PROVIDERS_CACHE_VERSION,
+        value=cache_value,
+        timeout=1,
+    )
 
     yield excluded_provider
 
-    cache.delete(cache_key)
+    cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
 
 
 @mock.patch(

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -11,19 +11,36 @@ from test.factory.es_http import (
 from unittest import mock
 from uuid import uuid4
 
+from django.core.cache import cache
+
 import pook
 import pytest
 from django_redis import get_redis_connection
 from elasticsearch_dsl import Search
+from elasticsearch_dsl.query import Terms
 
 from api.controllers import search_controller
 from api.controllers.elasticsearch import helpers as es_helpers
+from api.controllers.search_controller import FILTERED_PROVIDERS_CACHE_KEY
 from api.utils import tallies
 from api.utils.dead_link_mask import get_query_hash, save_query_mask
 from api.utils.search_context import SearchContext
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def cache_setter():
+    keys = []
+
+    def _cache_setter(key, value, version=1):
+        keys.append((key, version))
+        cache.set(key, value=value, version=version, timeout=1)
+
+    yield _cache_setter
+    for key, version in keys:
+        cache.delete(key, version=version)
 
 
 @pytest.mark.parametrize(
@@ -807,3 +824,14 @@ def test_excessive_recursion_in_post_process(
             filter_dead=True,
         )
     assert "Nesting threshold breached" in caplog.text
+
+
+def test_get_excluded_providers_query_returns_None_when_no_provider_is_excluded():
+    assert search_controller.get_excluded_providers_query() is None
+
+
+def test_get_excluded_providers_query_returns_when_cache_is_set(cache_setter):
+    cache_setter(FILTERED_PROVIDERS_CACHE_KEY, ["provider1", "provider2"], version=2)
+    assert search_controller.get_excluded_providers_query() == Terms(
+        provider=["provider1", "provider2"]
+    )

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -4,6 +4,10 @@ import pytest
 from elasticsearch_dsl import Q
 
 from api.controllers import search_controller
+from api.controllers.search_controller import (
+    FILTERED_PROVIDERS_CACHE_KEY,
+    FILTERED_PROVIDERS_CACHE_VERSION,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -11,14 +15,18 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def excluded_providers_cache():
-    cache_key = "filtered_providers"
     excluded_provider = "excluded_provider"
-    cache_value = [{"provider_identifier": excluded_provider}]
-    cache.set(cache_key, cache_value, timeout=1)
+    cache_value = [excluded_provider]
+    cache.set(
+        key=FILTERED_PROVIDERS_CACHE_KEY,
+        version=FILTERED_PROVIDERS_CACHE_VERSION,
+        value=cache_value,
+        timeout=1,
+    )
 
     yield excluded_provider
 
-    cache.delete(cache_key)
+    cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
 
 
 def test_create_search_query_empty(media_type_config):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3380 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is the updated version of #3381 that uses a new version for the cache key.
Previously saved value is a pickled `QuerySet`, and it doesn't work with the updated code (see https://openverse.sentry.io/share/issue/d5341bad88cf421081b2551b36ef8c33/)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On main, start the api and then go to `https://localhost:50280/admin`. Check "Hide content" for Flickr in `ContentProvider`s and execute a search. It should not return images from Flickr. Log into redis cache and get the value for the 2 versions of the key:

```
just exec cache redis-cli
127.0.0.1:6379 > GET ":1:filtered_providers"
"\x80\x04\x95\xc3\x05\x00\x00\x00\x00\x00\x00\x8c\x16django.db.models.query\x94\x8c\bQuerySet\x94\x93\x94)\x81\x94}\x94(\x8c\x05model\x94\x8c\x11api.models.models\x94\x8c\x0fContentProvider\x94\x93\x94\x8c\x03_db\x94N\x8c\x06_hints\x94}\x94\x8c\x06_query\x94\x8c\x1adjango.db.models.sql.query\x94\x8c\x05Query\x94\x93\x94)\x81\x94}\x94(h\x05h\b\x8c\x0ealias_refcount\x94}\x94\x8c\x10content_provider\x94K\x02s\x8c\talias_map\x94}\x94h\x14\x8c#django.db.models.sql.datastructures\x94\x8c\tBaseTable\x94\x93\x94)\x81\x94}\x94(\x8c\ntable_name\x94h\x14\x8c\x0btable_alias\x94h\x14ubs\x8c\nalias_cols\x94\x88\x8c\x10external_aliases\x94}\x94\x8c\ttable_map\x94}\x94h\x14]\x94h\x14as\x8c\x0cused_aliases\x94\x8f\x94\x8c\x05where\x94\x8c\x1adjango.db.models.sql.where\x94\x8c\tWhereNode\x94\x93\x94)\x81\x94}\x94(\x8c\bchildren\x94]\x94\x8c\x18django.db.models.lookups\x94\x8c\x05Exact\x94\x93\x94)\x81\x94}\x94(\x8c\x11_constructor_args\x94\x8c\x1cdjango.db.models.expressions\x94\x8c\x03Col\x94\x93\x94)\x81\x94}\x94(h3h\x14\x8c\x17django.db.models.fields\x94\x8c\x0b_load_field\x94\x93\x94\x8c\x03api\x94h\a\x8c\x0efilter_content\x94\x87\x94R\x94\x86\x94}\x94\x86\x94\x8c\x0coutput_field\x94h?\x8c\x05alias\x94h\x14\x8c\x06target\x94h?\x8c\x12contains_aggregate\x94\x89\x8c\x14contains_over_clause\x94\x89ub\x88\x86\x94}\x94\x86\x94\x8c\x03lhs\x94h7\x8c\x03rhs\x94\x88\x8c\x14bilateral_transforms\x94]\x94hF\x89hG\x89uba\x8c\tconnector\x94\x8c\x03AND\x94\x8c\anegated\x94\x89hF\x89hG\x89ub\x8c\x0bannotations\x94}\x94\x8c\x05extra\x94}\x94\x8c\x13_filtered_relations\x94}\x94\x8c\x18_annotation_select_cache\x94N\x8c\x10filter_is_sticky\x94\x89\x8c\r_lookup_joins\x94]\x94h\x14a\x8c\x0eselect_related\x94\x89\x8c\x10deferred_loading\x94(\x91\x94\x88\x86\x94\x8c\x06select\x94h6)\x81\x94}\x94(h3h\x14h;h<h\a\x8c\x13provider_identifier\x94\x87\x94R\x94\x86\x94}\x94\x86\x94hChehDh\x14hEheub\x85\x94\x8c\rvalues_select\x94hc\x85\x94\x8c\x11has_select_fields\x94\x88\x8c\x11extra_select_mask\x94\x8f\x94\x8c\x13_extra_select_cache\x94N\x8c\x16annotation_select_mask\x94\x8f\x94\x8c\nbase_table\x94h\x14\x8c\x0cdefault_cols\x94\x89ub\x8c\r_result_cache\x94]\x94}\x94hc\x8c\x06flickr\x94sa\x8c\x0e_sticky_filter\x94\x89\x8c\n_for_write\x94\x89\x8c\x19_prefetch_related_lookups\x94)\x8c\x0e_prefetch_done\x94\x89\x8c\x16_known_related_objects\x94}\x94\x8c\x0f_iterable_class\x94h\x00\x8c\x0eValuesIterable\x94\x93\x94\x8c\a_fields\x94hc\x85\x94\x8c\x12_defer_next_filter\x94\x89\x8c\x10_deferred_filter\x94N\x8c\x0f_django_version\x94\x8c\x054.2.7\x94ub."
127.0.0.1:6379 > GET ":2:filtered_providers"
(nil)
```

Then, check out this branch and repeat search and check the redis keys. The search should not throw an error, and redis cache should be updated:

```
just exec cache redis-cli
127.0.0.1:6379 > GET ":1:filtered_providers"
(nil)
127.0.0.1:6379 > GET ":2:filtered_providers"
"\x80\x04\x95\r\x00\x00\x00\x00\x00\x00\x00]\x94\x8c\x06flickr\x94a."
```

This PR should also be tested in staging after it's deployed to make sure that it works with the saved cached values.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
