### PR TITLE
Add source and provider definition tooltips

### DIFF
--- a/frontend/src/components/VIconButton/VIconButton.vue
+++ b/frontend/src/components/VIconButton/VIconButton.vue
@@ -44,7 +44,7 @@ export default defineComponent({
      * The size of the button, matches the sizes of VButton component.
      */
     size: {
-      type: String as PropType<Exclude<ButtonSize, "disabled">>,
+      type: String as PropType<ButtonSize>,
       required: true,
     },
     /**

--- a/frontend/src/components/VMediaInfo/VMetadata.vue
+++ b/frontend/src/components/VMediaInfo/VMetadata.vue
@@ -4,7 +4,7 @@
       <VSourceProviderTooltip
         v-if="tooltipId(datum)"
         :describedby="tooltipId(datum)"
-        class="label-regular mb-1 flex flex-row ps-1"
+        class="label-regular mb-1 flex flex-row items-center ps-1"
         :datum="datum"
       />
       <dt v-else class="label-regular mb-1 flex flex-row ps-1">
@@ -22,7 +22,7 @@
         v-if="tooltipId(datum)"
         :key="datum.label"
         :describedby="tooltipId(datum)"
-        class="label-regular flex flex-row pt-1"
+        class="label-regular flex flex-row items-center p-1 sm:py-0 sm:pe-0"
         :datum="datum"
       />
       <dt

--- a/frontend/src/components/VMediaInfo/VMetadata.vue
+++ b/frontend/src/components/VMediaInfo/VMetadata.vue
@@ -3,7 +3,7 @@
     <div v-for="datum in metadata" :key="datum.label">
       <VSourceProviderTooltip
         v-if="tooltipId(datum)"
-        :describedby="tooltipId(datum)"
+        :described-by="tooltipId(datum)"
         class="label-regular mb-1 flex flex-row items-center ps-1"
         :datum="datum"
       />
@@ -21,7 +21,7 @@
       <VSourceProviderTooltip
         v-if="tooltipId(datum)"
         :key="datum.label"
-        :describedby="tooltipId(datum)"
+        :described-by="tooltipId(datum)"
         class="label-regular flex flex-row items-center p-1 sm:py-0 sm:pe-0"
         :datum="datum"
       />

--- a/frontend/src/components/VMediaInfo/VMetadata.vue
+++ b/frontend/src/components/VMediaInfo/VMetadata.vue
@@ -1,7 +1,15 @@
 <template>
   <dl v-if="isSm" class="metadata grid gap-8" :style="columnCount">
-    <div v-for="datum in metadata" :key="`${datum.label}`">
-      <dt class="label-regular mb-1 ps-1">{{ $t(datum.label) }}</dt>
+    <div v-for="datum in metadata" :key="datum.label">
+      <VSourceProviderTooltip
+        v-if="tooltipId(datum)"
+        :describedby="tooltipId(datum)"
+        class="label-regular mb-1 flex flex-row ps-1"
+        :datum="datum"
+      />
+      <dt v-else class="label-regular mb-1 flex flex-row ps-1">
+        {{ $t(datum.label) }}
+      </dt>
       <VMetadataValue
         :datum="datum"
         @click="sendVisitSourceLinkEvent(datum.source)"
@@ -10,7 +18,19 @@
   </dl>
   <dl v-else class="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2">
     <template v-for="datum in metadata">
-      <dt :key="`${datum.label}`" class="label-regular pt-1">
+      <VSourceProviderTooltip
+        v-if="tooltipId(datum)"
+        :key="datum.label"
+        :describedby="tooltipId(datum)"
+        class="label-regular flex flex-row pt-1"
+        :datum="datum"
+      />
+      <dt
+        v-else
+        :id="datum.label"
+        :key="datum.label"
+        class="label-regular flex flex-row pt-1"
+      >
         {{ $t(datum.label) }}
       </dt>
       <VMetadataValue
@@ -30,10 +50,11 @@ import { useAnalytics } from "~/composables/use-analytics"
 import { useUiStore } from "~/stores/ui"
 
 import VMetadataValue from "~/components/VMediaInfo/VMetadataValue.vue"
+import VSourceProviderTooltip from "~/components/VMediaInfo/VSourceProviderTooltip.vue"
 
 export default defineComponent({
   name: "VMetadata",
-  components: { VMetadataValue },
+  components: { VSourceProviderTooltip, VMetadataValue },
   props: {
     metadata: {
       type: Array as PropType<Metadata[]>,
@@ -45,6 +66,15 @@ export default defineComponent({
     const uiStore = useUiStore()
 
     const isSm = computed(() => uiStore.isBreakpoint("sm"))
+    const tooltipId = (datum: Metadata): "source" | "provider" | "" => {
+      if (
+        datum.name &&
+        (datum.name === "source" || datum.name === "provider")
+      ) {
+        return datum.name
+      }
+      return ""
+    }
 
     const columnCount = computed(() => ({
       "--column-count": props.metadata.length,
@@ -63,6 +93,7 @@ export default defineComponent({
 
     return {
       sendVisitSourceLinkEvent,
+      tooltipId,
       isSm,
       columnCount,
     }

--- a/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
+++ b/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
@@ -1,0 +1,54 @@
+<template>
+  <dt>
+    {{ $t(datum.label) }}
+    <VTooltip placement="top" :describedby="describedby" class="ms-2">
+      <template #default>
+        <p
+          class="caption-regular rounded-sm bg-dark-charcoal px-2 py-1 text-white"
+        >
+          {{ description }}
+        </p>
+      </template>
+    </VTooltip>
+  </dt>
+</template>
+<script lang="ts">
+import { computed, defineComponent, PropType } from "vue"
+
+import { Metadata } from "~/types/media"
+import { useI18n } from "~/composables/use-i18n"
+
+import VTooltip from "~/components/VTooltip/VTooltip.vue"
+
+export default defineComponent({
+  name: "VSourceProviderTooltip",
+  components: { VTooltip },
+  props: {
+    datum: {
+      type: Object as PropType<Metadata>,
+      required: true,
+    },
+    describedby: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const i18n = useI18n()
+    const description = computed(() => {
+      if (!props.datum.name) {
+        return ""
+      }
+      return i18n.t(
+        props.datum.name === "source"
+          ? "mediaDetails.sourceDescription"
+          : "mediaDetails.providerDescription"
+      )
+    })
+
+    return {
+      description,
+    }
+  },
+})
+</script>

--- a/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
+++ b/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <dt>
     {{ $t(datum.label) }}
-    <VTooltip placement="top" :describedby="describedby" class="ms-1">
+    <VTooltip placement="top" :described-by="describedBy" class="ms-1">
       <template #default>
         <p
           class="caption-regular rounded-sm bg-dark-charcoal px-2 py-1 text-white"
@@ -28,7 +28,7 @@ export default defineComponent({
       type: Object as PropType<Metadata>,
       required: true,
     },
-    describedby: {
+    describedBy: {
       type: String,
       required: true,
     },

--- a/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
+++ b/frontend/src/components/VMediaInfo/VSourceProviderTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <dt>
     {{ $t(datum.label) }}
-    <VTooltip placement="top" :describedby="describedby" class="ms-2">
+    <VTooltip placement="top" :describedby="describedby" class="ms-1">
       <template #default>
         <p
           class="caption-regular rounded-sm bg-dark-charcoal px-2 py-1 text-white"

--- a/frontend/src/components/VPopover/VPopover.vue
+++ b/frontend/src/components/VPopover/VPopover.vue
@@ -6,10 +6,6 @@
       ref="triggerContainerRef"
       class="flex w-min items-stretch whitespace-nowrap"
       @click="onTriggerClick"
-      @mouseenter="onTriggerMouseEnter"
-      @focusin="onTriggerMouseEnter"
-      @mouseleave="onTriggerMouseLeave"
-      @focusout="onTriggerMouseLeave"
     >
       <!--
         @slot The trigger, should be a button 99.99% of the time. If you need custom event handling on the trigger button, ensure bubbling is not prevented or else the popover will not open
@@ -180,17 +176,6 @@ export default defineComponent({
       emit: emit as SetupContext["emit"],
     })
 
-    const onTriggerMouseEnter = () => {
-      if (props.activateOnHover) {
-        open()
-      }
-    }
-    const onTriggerMouseLeave = () => {
-      if (props.activateOnHover) {
-        close()
-      }
-    }
-
     return {
       open,
       close,
@@ -198,8 +183,6 @@ export default defineComponent({
       triggerContainerRef,
       triggerRef,
       onTriggerClick,
-      onTriggerMouseEnter,
-      onTriggerMouseLeave,
       triggerA11yProps,
     }
   },

--- a/frontend/src/components/VTooltip/VTooltip.vue
+++ b/frontend/src/components/VTooltip/VTooltip.vue
@@ -14,8 +14,8 @@
       -->
       <slot name="trigger" :open="open">
         <VIconButton
-          :label="describedby"
-          :aria-describedby="describedby"
+          :label="describedBy"
+          :aria-describedby="describedBy"
           variant="bordered-white"
           size="disabled"
           class="h-4 w-4 hover:!border-tx"
@@ -26,7 +26,7 @@
     </div>
     <div
       v-show="visibleRef"
-      :id="describedby"
+      :id="describedBy"
       ref="tooltipRef"
       role="tooltip"
       :class="`z-${zIndex} w-max-content absolute left-0 top-0`"
@@ -89,7 +89,7 @@ export default defineComponent({
      * The id of the element labelling the popover content.
      * The owning element must have `aria-describedby` set to this value.
      */
-    describedby: {
+    describedBy: {
       type: String,
       required: true,
     },

--- a/frontend/src/components/VTooltip/VTooltip.vue
+++ b/frontend/src/components/VTooltip/VTooltip.vue
@@ -1,0 +1,180 @@
+<template>
+  <div>
+    <!-- re: disabled static element interactions rule https://github.com/WordPress/openverse/issues/2906 -->
+    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+    <div
+      ref="triggerContainerRef"
+      class="flex w-min items-stretch whitespace-nowrap"
+      @keydown.esc="handleEscape"
+    >
+      <!--
+        @slot The trigger, should be a button 99.99% of the time. If you need custom event handling on the trigger button, ensure bubbling is not prevented or else the tooltip will not open
+          @binding {object} a11yProps
+          @binding {boolean} visible
+      -->
+      <slot name="trigger" :open="open">
+        <VIconButton
+          :label="describedby"
+          :aria-describedby="describedby"
+          variant="bordered-white"
+          size="disabled"
+          class="h-4 w-4 hover:!border-tx"
+          :icon-props="{ name: 'info', size: 4 }"
+          @click="open"
+        />
+      </slot>
+    </div>
+    <div
+      v-show="visibleRef"
+      :id="describedby"
+      ref="tooltipRef"
+      role="tooltip"
+      :class="`z-${zIndex} w-max-content absolute left-0 top-0`"
+      :style="{ ...style }"
+      :aria-hidden="!visibleRef"
+    >
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  ref,
+  PropType,
+  watch,
+  toRefs,
+  onBeforeUnmount,
+} from "vue"
+
+import { zIndexValidator } from "~/constants/z-indices"
+
+import { useFloatingUi } from "~/composables/use-floating-ui"
+import { hasFocusWithin } from "~/utils/reakit-utils/focus"
+
+import VIconButton from "~/components/VIconButton/VIconButton.vue"
+
+import type { Placement, Strategy } from "@floating-ui/dom"
+
+export default defineComponent({
+  name: "VTooltip",
+  components: { VIconButton },
+  props: {
+    /**
+     * The placement of the tooltip relative to the trigger. Should be one of the options
+     * for `placement` passed to floating-ui.
+     *
+     * @see https://floating-ui.com/docs/tutorial#placements
+     *
+     * @default 'bottom'
+     */
+    placement: {
+      type: String as PropType<Placement>,
+      default: "bottom",
+    },
+    /**
+     * The positioning strategy of the tooltip. If your reference element is in a fixed container
+     * use the fixed strategy; otherwise use the default, absolute strategy.
+     *
+     * @see https://floating-ui.com/docs/computeposition#strategy
+     *
+     * @default 'absolute'
+     */
+    strategy: {
+      type: String as PropType<Strategy>,
+      default: "absolute",
+    },
+    /**
+     * The id of the element labelling the popover content.
+     * The owning element must have `aria-describedby` set to this value.
+     */
+    describedby: {
+      type: String,
+      required: true,
+    },
+    /**
+     * the z-index to apply to the tooltip content
+     */
+    zIndex: {
+      type: [Number, String],
+      default: "popover", // named z-index
+      validator: zIndexValidator,
+    },
+  },
+  setup(props) {
+    const visibleRef = ref(false)
+    const triggerContainerRef = ref<HTMLElement | null>(null)
+
+    const closeIfNeeded = () => {
+      if (triggerRef.value && !hasFocusWithin(triggerRef.value)) {
+        visibleRef.value = false
+      }
+    }
+
+    const open = () => {
+      visibleRef.value = true
+    }
+
+    const listeners = {
+      mouseover: open,
+      mouseout: closeIfNeeded,
+      focus: open,
+      blur: closeIfNeeded,
+    }
+
+    const setTrigger = (triggerElement: HTMLElement) => {
+      triggerRef.value = triggerElement
+      for (const [event, listener] of Object.entries(listeners)) {
+        triggerElement.addEventListener(event, listener)
+      }
+    }
+
+    const triggerRef = ref<HTMLElement | null>(null)
+    watch(triggerContainerRef, (container) => {
+      if (container) {
+        setTrigger(container.firstElementChild as HTMLElement)
+      }
+    })
+
+    onBeforeUnmount(() => {
+      if (triggerRef.value) {
+        for (const [event, listener] of Object.entries(listeners)) {
+          triggerRef.value.removeEventListener(event, listener)
+        }
+      }
+    })
+
+    const tooltipRef = ref<HTMLElement | null>(null)
+    const propsRefs = toRefs(props)
+
+    const { style } = useFloatingUi({
+      floatingElRef: tooltipRef,
+      floatingPropsRefs: {
+        placement: propsRefs.placement,
+        strategy: propsRefs.strategy,
+        clippable: ref(false),
+        visible: visibleRef,
+        triggerElement: triggerRef,
+      },
+    })
+
+    const handleEscape = () => {
+      if (visibleRef.value) {
+        visibleRef.value = false
+      }
+    }
+
+    return {
+      visibleRef,
+      triggerContainerRef,
+      triggerRef,
+      tooltipRef,
+      style,
+
+      open,
+      handleEscape,
+    }
+  },
+})
+</script>

--- a/frontend/src/composables/use-floating-ui.ts
+++ b/frontend/src/composables/use-floating-ui.ts
@@ -12,24 +12,17 @@ import {
   Strategy,
 } from "@floating-ui/dom"
 
-export type PopoverContentProps = {
+export type UseFloatingProps = {
   visible: boolean
-  hide: () => void
-  hideOnEsc: boolean
-  hideOnClickOutside: boolean
-  autoFocusOnShow: boolean
-  autoFocusOnHide: boolean
   triggerElement: HTMLElement | null
   placement: Placement
   strategy: Strategy
   clippable: boolean
-  trapFocus: boolean
-  zIndex: number | string
 }
 
 type Props = {
   floatingElRef: Ref<HTMLElement | null>
-  floatingPropsRefs: ToRefs<PopoverContentProps>
+  floatingPropsRefs: ToRefs<UseFloatingProps>
 }
 
 // A constant offset to ensure there's a gap between

--- a/frontend/src/composables/use-popover-content.ts
+++ b/frontend/src/composables/use-popover-content.ts
@@ -1,16 +1,28 @@
 import { computed, ref } from "vue"
 
-import {
-  PopoverContentProps,
-  useFloatingUi,
-} from "~/composables/use-floating-ui"
+import { useFloatingUi } from "~/composables/use-floating-ui"
 
 import { useDialogContent } from "~/composables/use-dialog-content"
 
 import type { Properties as CSSProperties } from "csstype"
 
 import type { Ref, ToRefs, SetupContext } from "vue"
+import type { Placement, Strategy } from "@floating-ui/dom"
 
+export type PopoverContentProps = {
+  visible: boolean
+  hide: () => void
+  hideOnEsc: boolean
+  hideOnClickOutside: boolean
+  autoFocusOnShow: boolean
+  autoFocusOnHide: boolean
+  triggerElement: HTMLElement | null
+  placement: Placement
+  strategy: Strategy
+  clippable: boolean
+  trapFocus: boolean
+  zIndex: number | string
+}
 type Props = {
   popoverRef: Ref<HTMLElement | null>
   popoverPropsRefs: ToRefs<PopoverContentProps>

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -486,6 +486,8 @@
     },
     providerLabel: "Provider",
     sourceLabel: "Source",
+    providerDescription: "Website where the content is hosted",
+    sourceDescription: "Organization that created or owns the original content",
     loading: "Loading...",
     relatedError: "Error fetching related media",
     aria: {

--- a/frontend/src/types/media.ts
+++ b/frontend/src/types/media.ts
@@ -131,6 +131,7 @@ export const isMediaDetail = <T extends SupportedMediaType>(
 }
 
 export type Metadata = {
+  name?: string
   label: string
   url?: string
   value: string

--- a/frontend/src/utils/metadata.ts
+++ b/frontend/src/utils/metadata.ts
@@ -41,6 +41,7 @@ export const getMediaMetadata = (
   const metadata: Metadata[] = []
   if (media.source && media.providerName !== media.sourceName) {
     metadata.push({
+      name: "provider",
       label: "mediaDetails.providerLabel",
       value: media.providerName || media.provider,
     })
@@ -51,6 +52,7 @@ export const getMediaMetadata = (
   )
   const sourceName = media.sourceName ?? media.providerName ?? media.provider
   metadata.push({
+    name: "source",
     label: "mediaDetails.sourceLabel",
     source: media.source ?? media.provider,
     url: sourceUrl,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2775 by @fcoveram
Fixes #2840 by @fcoveram 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the tooltip that opens when you focus or hover over the (i) symbol next to the Provider or Source in the single result page:
<img width="588" alt="Screenshot 2023-12-18 at 2 43 16 PM" src="https://github.com/WordPress/openverse/assets/15233243/93ea2249-054e-4ddc-a31f-596fee0ca979">

I just realized that the provider definition would not be correct when/if we extract sources from Europeana: here, Europeana is an aggregator which allows us to search for images, but the images themselves are hosted on the __source__ sites, not Europeana.

### The tooltip
Here are the Figma links to: 
* [Tooltip component](https://www.figma.com/file/GIIQ4sDbaToCfFQyKMvzr8/Openverse-Design-Library?type=design&node-id=5354-29979&mode=dev)
* [Help component](https://www.figma.com/file/GIIQ4sDbaToCfFQyKMvzr8/Openverse-Design-Library?type=design&node-id=2484-22552&mode=dev). Tooltip is visible in `hover` state

### Accessibility considerations
[WAI ARIA guidelines](https://www.w3.org/TR/wai-aria-1.1/#tooltip)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
