### PR TITLE
Allow None value for `NUM_PROXIES`

### DIFF
--- a/api/conf/settings/rest_framework.py
+++ b/api/conf/settings/rest_framework.py
@@ -50,7 +50,9 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "api.docs.base_docs.MediaSchema",
     # https://www.django-rest-framework.org/api-guide/throttling/#how-clients-are-identified
     # Live environments should configure this to an appropriate number
-    "NUM_PROXIES": config("NUM_PROXIES", default=0, cast=int),
+    "NUM_PROXIES": config(
+        "NUM_PROXIES", default=None, cast=lambda x: int(x) if x is not None else None
+    ),
 }
 
 if config("DISABLE_GLOBAL_THROTTLING", default=True, cast=bool):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #3398 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
`NUM_PROXIES` needs to be able to be `None` to disable the feature. I got mixed up about the behaviour of 0 value for it and thought it was the same as `None`, but it's drastically different. `None` falls back to default, but `0` tells DRF to use the remote address (IP) of the request, which in the case of requests via proxy, is always the last proxy that handled the request. If you set it to 0, then everyone is getting throttled based on the proxy they went through, meaning they're sharing throttle quotas, rather than through their individual IP.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the application and use ipython to verify that `NUM_PROXIES` defaults to None:

```python
In [1]: from conf.settings import rest_framework
In [2]: rest_framework.REST_FRAMEWORK
Out[2]: 
{'DEFAULT_AUTHENTICATION_CLASSES': ('oauth2_provider.contrib.rest_framework.OAuth2Authentication',),
 'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
 'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',
  'api.utils.drf_renderer.BrowsableAPIRendererWithoutForms'),
 'DEFAULT_THROTTLE_RATES': {'anon_burst': None,
  'anon_sustained': None,
  'anon_healthcheck': None,
  'anon_thumbnail': None,
  'oauth2_client_credentials_thumbnail': None,
  'oauth2_client_credentials_sustained': None,
  'oauth2_client_credentials_burst': None,
  'enhanced_oauth2_client_credentials_sustained': None,
  'enhanced_oauth2_client_credentials_burst': None,
  'exempt_oauth2_client_credentials': None},
 'EXCEPTION_HANDLER': 'api.utils.exceptions.exception_handler',
 'DEFAULT_SCHEMA_CLASS': 'api.docs.base_docs.MediaSchema',
 'NUM_PROXIES': None}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
