### PR TITLE
Handle existing stack label in CI labelling job

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -64,6 +64,7 @@ mgmt:
   - .github/**
   - .devcontainer/**
   - automations/**
+  - utilities/**
 ci_cd:
   - .github/actions/**
   - .github/workflows/ci_cd.yml

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -134,11 +134,12 @@ jobs:
           # - list of stack filters: `.github/filters.yml`
           # - list of stack labels: https://github.com/WordPress/openverse/labels?q=stack
           script: |
-            const labels = await octokit.rest.issues.listLabelsOnIssue({
+            const labels = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
+            console.log(labels.data)
             if (labels.data.some(label => label.name.startsWith("🧱 stack: "))) {
               console.log("Stack label already applied, skipping.")
             } else {

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -139,7 +139,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
-            if labels.data.some(label => label.name.startsWith("🧱 stack: ")) {
+            if (labels.data.some(label => label.name.startsWith("🧱 stack: "))) {
               console.log("Stack label already applied, skipping.")
             } else {
               const stacks = ["catalog", "api", "ingestion_server", "frontend", "documentation", "mgmt"]

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -134,20 +134,30 @@ jobs:
           # - list of stack filters: `.github/filters.yml`
           # - list of stack labels: https://github.com/WordPress/openverse/labels?q=stack
           script: |
-            const stacks = ["catalog", "api", "ingestion_server", "frontend", "documentation", "mgmt"]
-            const labels = JSON
-              .parse('${{ needs.get-changes.outputs.changes }}')
-              .filter(change => stacks.includes(change))
-              .map(change => `🧱 stack: ${change.replace("_", " ")}`)
-            if (!labels.length) {
-              labels.push("🚦 status: awaiting triage", "🏷 status: label work required")
-            }
-            github.rest.issues.addLabels({
+            const labels = await octokit.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels,
             })
+            if labels.data.some(label => label.name.startsWith("🧱 stack: ")) {
+              console.log("Stack label already applied, skipping.")
+            } else {
+              const stacks = ["catalog", "api", "ingestion_server", "frontend", "documentation", "mgmt"]
+              const labels = JSON
+                .parse('${{ needs.get-changes.outputs.changes }}')
+                .filter(change => stacks.includes(change))
+                .map(change => `🧱 stack: ${change.replace("_", " ")}`)
+              if (!labels.length) {
+                console.log("Couldn't determine stack, applying triage labels.")
+                labels.push("🚦 status: awaiting triage", "🏷 status: label work required")
+              }
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels,
+              })
+            }
 
   build-images:
     name: Build Docker images


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- makes the CI job 'Apply stack labels' do nothing if the stack label is already applied
- classifies `utilities/` under the 'mgmt' stack so that future PRs affecting them are properly labelled automatically

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
