### PR TITLE
Fix loading skeletons

### DIFF
--- a/frontend/src/components/VSkeleton/VGridSkeleton.vue
+++ b/frontend/src/components/VSkeleton/VGridSkeleton.vue
@@ -4,12 +4,12 @@
       v-if="isForTab === 'all'"
       class="grid grid-cols-2 gap-4 lg:grid-cols-5"
     >
-      <VBone v-for="idx in numElems" :key="idx" class="square" />
+      <VBone v-for="idx in elementCount" :key="idx" class="square" />
     </div>
 
     <div v-if="isForTab === 'image'" class="masonry">
       <VBone
-        v-for="idx in numElems"
+        v-for="idx in elementCount"
         :key="idx"
         class="mb-4"
         :style="{ height: `${getRandomSize()}px` }"
@@ -17,7 +17,7 @@
     </div>
 
     <template v-if="isForTab === 'audio'">
-      <VAudioTrackSkeleton v-for="idx in numElems" :key="idx" />
+      <VAudioTrackSkeleton v-for="idx in elementCount" :key="idx" />
     </template>
   </section>
 </template>


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Follow up on #3341

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The linked PR removed the deprecated usage of `this` in a prop validator. However, the template wasn't updated, so the grid skeleton does not show up anymore. This PR fixes it, replacing `numElemss` with `elementCount` in the template.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the Nuxt app and search for something. You should see the loading skeletons before the results load. You can use throttling in the browser developer tools if your network is too fast to see the loading skeletons.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
