### PR TITLE
Fix incorrectly parsed license url by-nc-nd for Flickr

### DIFF
--- a/catalog/dags/common/licenses/constants.py
+++ b/catalog/dags/common/licenses/constants.py
@@ -79,7 +79,6 @@ _SPECIAL_CASE_LICENSE_PATHS = {
     # set the license and/or version manually, and for which we can
     # recover the path from a valid license_, license_version pair.
     "licenses/by-nd-nc/1.0": ("by-nc-nd", "1.0"),
-    "licenses/by-nd-nc/2.0/jp": ("by-nc-nd", "2.0"),
     "licenses/publicdomain": ("publicdomain", NO_VERSION),
     "publicdomain/mark/1.0": ("pdm", "1.0"),
     "publicdomain/zero/1.0": ("cc0", "1.0"),


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

I noticed this problem while testing locally in Flickr.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In the Flickr DAG, we often get the following error (which is currently silenced in production):

```
Failed to rewrite URL: https://creativecommons.org/licenses/by-nd-nc/2.0/jp/
```

That URL is indeed invalid. These urls, however, are correct (note the swapped components, `by-nc-nd` vs `by-nd-nc`):

- https://creativecommons.org/licenses/by-nc-nd/2.0/jp
- https://creativecommons.org/licenses/by-nc-nd/2.0/

In the Flickr DAG, for each record we get a `license` and `license_version` from the Flickr API. We use our [`get_license_info`](https://github.com/WordPress/openverse/blob/adb56f128ca9f0835e0e882fbe960539a0076a37/catalog/dags/common/licenses/licenses.py#L41) utility to parse out the `license_url` (which ends up being stored in the `meta_data` column).

`get_license_info` attempts to look up the license url in a reverse mapping of (license, license_version) pair to url, which is built [here](https://github.com/WordPress/openverse/blob/adb56f128ca9f0835e0e882fbe960539a0076a37/catalog/dags/common/licenses/constants.py#L119) by merging two hard-coded dicts of simple cases and special cases. We had an entry in the _SPECIAL_CASE_LICENSE_PATHS mapping `by-nd-nc/2.0/jp` (the invalid url) to `('by-nc-nd', '2.0')`, but we _also_ had an entry in _SIMPLE_LICENSE_PATHS mapping the correct, generic license url `by-nc-nd/2.0` to the same `('by-nc-nd', '2.0')` pair. Because special cases are applied after simple cases when building the mappings, the special case (with the invalid url) overrides the simple (with the valid). So when Flickr calls `get_license_info` with that license/version pair, it always gets the invalid URL from the mapping and then fails when trying to validate it.

**This PR handles this by just getting rid of that invalid special case**. When a DAG such as flickr ingests a record with license `by-nc-nd` and version `2.0` and uses `get_license_info` to look up the URL, it will now always return the valid, generic URL https://creativecommons.org/licenses/by-nc-nd/2.0/

### Mapping from license url to license/version

Note that DAGs may also ingest just the URL from their provider API, and use `get_license_info` instead to parse out the type and version (for which we maintain the mapping in the other direction, defined [here](https://github.com/WordPress/openverse/blob/adb56f128ca9f0835e0e882fbe960539a0076a37/catalog/dags/common/licenses/constants.py#L109)).
* If passed the incorrect url, on `main` it will return `('by-nc-nd', '2.0')` for the license/version pair __but preserve the invalid URL in meta_data without validating it__
* On this branch, it will instead **raise an error** (because the invalid url is no longer present in the mapping)

This change should be okay (and in fact, what we *want* to happen), because I checked the production catalog and found 0 records outside of Flickr that have this URL:
```sql
openledger> select count(*) from image where meta_data->>'license_url' = 'https:/
 /creativecommons.org/licenses/by-nd-nc/2.0/jp' and provider != 'flickr';
l+-------+
| count |
|-------|
| 0     |
+-------+
openledger> select count(*) from audio where meta_data->>'license_url' = 'https:/
 /creativecommons.org/licenses/by-nd-nc/2.0/jp';
+-------+
| count |
|-------|
| 0     |
+-------+
```

If we do encounter this in the future (a DAG that gets the slightly invalid URL from its provider), then #3080 could be implemented to handle that situation flexibly. But I do not believe it is currently a problem.

TL;DR, this change should fix the error in Flickr and should *not* cause problems with any other DAGs.  

### Backfilling old Flickr records

A final note: We *do* have many Flickr records containing the invalid `license_url` in `meta_data`, with the license components swapped. I haven’t looked too deeply into the history of how this happened, but it seems in a previous implementation of either the Flickr DAG or the license utilities, we allowed this license_url to get written to records.

Here's an example you can see in our API: https://api.openverse.engineering/v1/images/85c1bedb-a32c-4ff7-8e97-0d04d55cfd31/ The license url is invalid, and the attribution uses this invalid url. For thoroughness, I checked out this image [on Flickr](https://www.flickr.com/photos/47651805@N00/3834147370) and verified that the license given there is the generic https://creativecommons.org/licenses/by-nc-nd/2.0/.

In conclusion: after merging this change, we’ll need to backfill these flickr records. We can do that via the `batched_update` DAG with this config:

```
{
    "query_id": “update-invalid-flickr-licenses”,
    "table_name": “image”,
    "select_query": "WHERE provider='flickr' and meta_data->>'license_url' = 'https:/
 /creativecommons.org/licenses/by-nd-nc/2.0/jp'",
    "update_query": "SET meta_data->>'license_url' = 'https:/
 /creativecommons.org/licenses/by-nc-nd/2.0'",
    "batch_size": 10000,
    "update_timeout": 3600,
    "resume_update": false,
    "dry_run": false
}
```

We should also remove the `SILENCED_SLACK_NOTIFICATIONS` configuration in prod that's currently silencing this issue for Flickr. Unfortunately, I think this has been incorrectly silenced and we have probably been failing to ingest many valid Flickr records during that time.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Try running Flickr locally using `date`: 2023-11-30. On main, it should fail very quickly with the `InvalidLicense` error (because it is not silenced in local environments). Check out this branch and re-run the dagrun for a few minutes to see that it passes the step successfully.

This isn't really unit-testable as far as I can see, but please verify my explanation in the description makes sense and that I am not misunderstanding something fundamental!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
