### PR TITLE
Make punctuation marks consistent for singular & plural strings

### DIFF
--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -804,24 +804,24 @@
       source: {
         audio: {
           zero: "No audio files provided by this source",
-          count: "{count} audio file provided by this source.|{count} audio files provided by this source",
+          count: "{count} audio file provided by this source.|{count} audio files provided by this source.",
           countMore: "Over {count} audio files provided by this source",
         },
         image: {
           zero: "No images provided by this source",
-          count: "{count} image provided by this source.|{count} images provided by this source",
+          count: "{count} image provided by this source.|{count} images provided by this source.",
           countMore: "Over {count} images provided by this source",
         },
       },
       tag: {
         audio: {
           zero: "No audio files with the selected tag",
-          count: "{count} audio file with the selected tag.|{count} audio files with the selected tag",
+          count: "{count} audio file with the selected tag.|{count} audio files with the selected tag.",
           countMore: "Over {count} audio files with the selected tag",
         },
         image: {
           zero: "No images with the selected tag",
-          count: "{count} image with the selected tag.|{count} images with the selected tag",
+          count: "{count} image with the selected tag.|{count} images with the selected tag.",
           countMore: "Over {count} images with the selected tag",
         },
       },

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -821,7 +821,7 @@
         },
         image: {
           zero: "No images with the selected tag",
-          count: "{count} image with the selected tag.|{count} images with the selected tag.",
+          count: "{count} image with the selected tag|{count} images with the selected tag",
           countMore: "Over {count} images with the selected tag",
         },
       },

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -804,7 +804,7 @@
       source: {
         audio: {
           zero: "No audio files provided by this source",
-          count: "{count} audio file provided by this source.|{count} audio files provided by this source.",
+          count: "{count} audio file provided by this source|{count} audio files provided by this source",
           countMore: "Over {count} audio files provided by this source",
         },
         image: {

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -816,7 +816,7 @@
       tag: {
         audio: {
           zero: "No audio files with the selected tag",
-          count: "{count} audio file with the selected tag.|{count} audio files with the selected tag.",
+          count: "{count} audio file with the selected tag|{count} audio files with the selected tag",
           countMore: "Over {count} audio files with the selected tag",
         },
         image: {

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -809,7 +809,7 @@
         },
         image: {
           zero: "No images provided by this source",
-          count: "{count} image provided by this source.|{count} images provided by this source.",
+          count: "{count} image provided by this source|{count} images provided by this source",
           countMore: "Over {count} images provided by this source",
         },
       },


### PR DESCRIPTION
## Fixes
Fixes #3377 by @Presskopp 

## Description
This would solve https://github.com/WordPress/openverse/issues/3377. Small simple fix.
