### PR TITLE
Add IDs for the maintainer attention labels

### DIFF
--- a/automations/js/src/label_pr.mjs
+++ b/automations/js/src/label_pr.mjs
@@ -73,7 +73,7 @@ export const main = async (octokit, core) => {
   // Then we compile all the labels of all the linked issues into a pool. This
   // will be used to find the labels that satisfy the requirements.
   const labelPool = pr.linkedIssues.flatMap((issue) => issue.labels)
-  core.debug(`Label pool: ${labelPool}`)
+  core.debug(`Label pool: ${labelPool.map((label) => label.name).join(',')}`)
 
   // For each label that we only need one of, we check if the PR already has
   // such a label. If not, we check if the label pool contains any valid labels
@@ -94,7 +94,11 @@ export const main = async (octokit, core) => {
   // from the label pool. Our ID set implementation will weed out duplicates.
   for (let rule of atleastOne) {
     const validLabels = labelPool.filter((label) => label.name.includes(rule))
-    core.info(`Adding labels "${validLabels}" to PR.`)
+    core.info(
+      `Adding labels "${validLabels
+        .map((label) => label.name)
+        .join(',')}" to PR.`
+    )
     validLabels.forEach((label) => {
       finalLabels.add(label)
     })
@@ -105,9 +109,15 @@ export const main = async (octokit, core) => {
   if (!getIsFullyLabeled(finalLabels.items)) {
     let attnLabel
     if (isTriaged) {
-      attnLabel = '🏷 status: label work required'
+      attnLabel = {
+        id: 'MDU6TGFiZWwzMDI5NTEyMjMw',
+        name: '🏷 status: label work required',
+      }
     } else {
-      attnLabel = '🚦 status: awaiting triage'
+      attnLabel = {
+        id: 'MDU6TGFiZWwzMDI5NTEyMjc1',
+        name: '🚦 status: awaiting triage',
+      }
     }
     core.info(`Pull not fully labelled so adding "${attnLabel}".`)
     finalLabels.add(attnLabel)


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the issue where the lack of IDs for the maintainer labels caused the labelling script to fail. All labels must have a node ID to be applied via the GraphQL API.

The PR also improves the logging to show label names instead of the "[object Object]" that is otherwise printed on non-interactive consoles.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
