### PR TITLE
Add referrer based throttle scope

### DIFF
--- a/api/api/utils/throttle.py
+++ b/api/api/utils/throttle.py
@@ -129,9 +129,14 @@ class AbstractOAuth2IdRateThrottle(SimpleRateThrottle, metaclass=abc.ABCMeta):
     """
 
     scope: str
-    # The name of the scope. Used to retrieve the rate limit from settings.
-    applies_to_rate_limit_model: str
-    # The ``ThrottledApplication.rate_limit_model`` to which the scope applies.
+    """The name of the scope. Used to retrieve the rate limit from settings."""
+    applies_to_rate_limit_model: set[str]
+    """
+    The set of ``ThrottledApplication.rate_limit_model`` to which the scope applies.
+
+    Use a ``set`` specifically to make checks O(1). All default throttles run on
+    almost every single request and must be performant.
+    """
 
     def get_cache_key(self, request, view):
         # Find the client ID associated with the access token.
@@ -147,30 +152,30 @@ class AbstractOAuth2IdRateThrottle(SimpleRateThrottle, metaclass=abc.ABCMeta):
 
 
 class OAuth2IdThumbnailRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = ["standard", "enhanced"]
+    applies_to_rate_limit_model = {"standard", "enhanced"}
     scope = "oauth2_client_credentials_thumbnail"
 
 
 class OAuth2IdSustainedRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "standard"
+    applies_to_rate_limit_model = {"standard"}
     scope = "oauth2_client_credentials_sustained"
 
 
 class OAuth2IdBurstRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "standard"
+    applies_to_rate_limit_model = {"standard"}
     scope = "oauth2_client_credentials_burst"
 
 
 class EnhancedOAuth2IdSustainedRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "enhanced"
+    applies_to_rate_limit_model = {"enhanced"}
     scope = "enhanced_oauth2_client_credentials_sustained"
 
 
 class EnhancedOAuth2IdBurstRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "enhanced"
+    applies_to_rate_limit_model = {"enhanced"}
     scope = "enhanced_oauth2_client_credentials_burst"
 
 
 class ExemptOAuth2IdRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "exempt"
+    applies_to_rate_limit_model = {"exempt"}
     scope = "exempt_oauth2_client_credentials"

--- a/api/api/utils/throttle.py
+++ b/api/api/utils/throttle.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 
-from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.throttling import SimpleRateThrottle as BaseSimpleRateThrottle
 
 from api.utils.oauth2_helper import get_token_info
 
@@ -9,7 +9,7 @@ from api.utils.oauth2_helper import get_token_info
 parent_logger = logging.getLogger(__name__)
 
 
-class SimpleRateThrottleHeader(SimpleRateThrottle, metaclass=abc.ABCMeta):
+class SimpleRateThrottle(BaseSimpleRateThrottle, metaclass=abc.ABCMeta):
     """
     Extends the ``SimpleRateThrottle`` class to provide additional functionality such as
     rate-limit headers in the response.
@@ -36,29 +36,53 @@ class SimpleRateThrottleHeader(SimpleRateThrottle, metaclass=abc.ABCMeta):
         else:
             return {}
 
+    def has_valid_token(self, request):
+        if not request.auth:
+            return False
 
-class AbstractAnonRateThrottle(SimpleRateThrottleHeader, metaclass=abc.ABCMeta):
+        token_info = get_token_info(str(request.auth))
+        return token_info and token_info.valid
+
+    def get_cache_key(self, request, view):
+        ident = self.get_ident(request)
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": ident,
+        }
+
+
+class AbstractAnonRateThrottle(SimpleRateThrottle, metaclass=abc.ABCMeta):
     """
     Limits the rate of API calls that may be made by a anonymous users.
 
     The IP address of the request will be used as the unique cache key.
     """
 
-    logger = parent_logger.getChild("AnonRateThrottle")
+    def get_cache_key(self, request, view):
+        # Do not apply this throttle to requests with valid tokens
+        if self.has_valid_token(request):
+            return None
+
+        if request.headers.get("referrer") == "openverse.org":
+            # Use `ov_referrer` throttles instead
+            return None
+
+        return super().get_cache_key(request, view)
+
+
+class AbstractOpenverseReferrerRateThrottle(SimpleRateThrottle, metaclass=abc.ABCMeta):
+    """Use a different limit for requests that appear to come from Openverse.org."""
 
     def get_cache_key(self, request, view):
-        self.logger.getChild("get_cache_key")
-        # Do not apply anonymous throttle to request with valid tokens.
-        if request.auth:
-            token_info = get_token_info(str(request.auth))
-            if token_info and token_info.valid:
-                return None
+        # Do not apply this throttle to requests with valid tokens
+        if self.has_valid_token(request):
+            return None
 
-        ident = self.get_ident(request)
-        return self.cache_format % {
-            "scope": self.scope,
-            "ident": ident,
-        }
+        if request.headers.get("referrer") != "openverse.org":
+            # Use regular anon throttles instead
+            return None
+
+        return super().get_cache_key(request, view)
 
 
 class BurstRateThrottle(AbstractAnonRateThrottle):
@@ -77,6 +101,18 @@ class AnonThumbnailRateThrottle(AbstractAnonRateThrottle):
     scope = "anon_thumbnail"
 
 
+class OpenverseReferrerBurstRateThrottle(AbstractOpenverseReferrerRateThrottle):
+    scope = "ov_referrer_burst"
+
+
+class OpenverseReferrerSustainedRateThrottle(AbstractOpenverseReferrerRateThrottle):
+    scope = "ov_referrer_sustained"
+
+
+class OpenverseReferrerAnonThumbnailRateThrottle(AbstractOpenverseReferrerRateThrottle):
+    scope = "ov_referrer_thumbnail"
+
+
 class TenPerDay(AbstractAnonRateThrottle):
     rate = "10/day"
 
@@ -85,7 +121,7 @@ class OnePerSecond(AbstractAnonRateThrottle):
     rate = "1/second"
 
 
-class AbstractOAuth2IdRateThrottle(SimpleRateThrottleHeader, metaclass=abc.ABCMeta):
+class AbstractOAuth2IdRateThrottle(SimpleRateThrottle, metaclass=abc.ABCMeta):
     """
     Ties a particular throttling scope from ``settings.py`` to a rate limit model.
 
@@ -104,14 +140,14 @@ class AbstractOAuth2IdRateThrottle(SimpleRateThrottleHeader, metaclass=abc.ABCMe
         if not (token_info and token_info.valid):
             return None
 
-        if token_info.rate_limit_model != self.applies_to_rate_limit_model:
+        if token_info.rate_limit_model not in self.applies_to_rate_limit_model:
             return None
 
         return self.cache_format % {"scope": self.scope, "ident": token_info.client_id}
 
 
 class OAuth2IdThumbnailRateThrottle(AbstractOAuth2IdRateThrottle):
-    applies_to_rate_limit_model = "standard"
+    applies_to_rate_limit_model = ["standard", "enhanced"]
     scope = "oauth2_client_credentials_thumbnail"
 
 

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -22,7 +22,11 @@ from api.serializers.provider_serializers import ProviderSerializer
 from api.utils import image_proxy
 from api.utils.pagination import StandardPagination
 from api.utils.search_context import SearchContext
-from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
+from api.utils.throttle import (
+    AnonThumbnailRateThrottle,
+    OAuth2IdThumbnailRateThrottle,
+    OpenverseReferrerAnonThumbnailRateThrottle,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -300,7 +304,11 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
         url_path="thumb",
         url_name="thumb",
         serializer_class=media_serializers.MediaThumbnailRequestSerializer,
-        throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
+        throttle_classes=[
+            AnonThumbnailRateThrottle,
+            OpenverseReferrerAnonThumbnailRateThrottle,
+            OAuth2IdThumbnailRateThrottle,
+        ],
     )
 
     async def thumbnail(self, request, *_, **__):

--- a/api/conf/settings/rest_framework.py
+++ b/api/conf/settings/rest_framework.py
@@ -13,6 +13,45 @@ THROTTLE_ANON_THUMBS = config("THROTTLE_ANON_THUMBS", default="150/minute")
 THROTTLE_OAUTH2_THUMBS = config("THROTTLE_OAUTH2_THUMBS", default="500/minute")
 THROTTLE_ANON_HEALTHCHECK = config("THROTTLE_ANON_HEALTHCHECK", default="3/minute")
 
+THROTTLE_OV_REFERRER_BURST = config(
+    "THROTTLE_OV_REFERRER_BURST", default=THROTTLE_ANON_BURST
+)
+THROTTLE_OV_REFERRER_SUSTAINED = config(
+    "THROTTLE_OV_REFERRER_SUSTAINED", default=THROTTLE_ANON_SUSTAINED
+)
+THROTTLE_OV_REFERRER_THUMBS = config(
+    "THROTTLE_OV_REFERRER_THUMBS", default=THROTTLE_ANON_THUMBS
+)
+
+DEFAULT_THROTTLE_RATES = {
+    "anon_burst": THROTTLE_ANON_BURST,
+    "anon_sustained": THROTTLE_ANON_SUSTAINED,
+    "anon_healthcheck": THROTTLE_ANON_HEALTHCHECK,
+    "anon_thumbnail": THROTTLE_ANON_THUMBS,
+    "ov_referrer_burst": THROTTLE_OV_REFERRER_BURST,
+    "ov_referrer_sustained": THROTTLE_OV_REFERRER_SUSTAINED,
+    "ov_referrer_thumbnail": THROTTLE_OV_REFERRER_THUMBS,
+    "oauth2_client_credentials_thumbnail": THROTTLE_OAUTH2_THUMBS,
+    "oauth2_client_credentials_sustained": "10000/day",
+    "oauth2_client_credentials_burst": "100/min",
+    "enhanced_oauth2_client_credentials_sustained": "20000/day",
+    "enhanced_oauth2_client_credentials_burst": "200/min",
+    # ``None`` completely by-passes the rate limiting
+    "exempt_oauth2_client_credentials": None,
+}
+
+DEFAULT_THROTTLE_CLASSES = (
+    "api.utils.throttle.BurstRateThrottle",
+    "api.utils.throttle.SustainedRateThrottle",
+    "api.utils.throttle.OpenverseReferrerBurstRateThrottle",
+    "api.utils.throttle.OpenverseReferrerSustainedRateThrottle",
+    "api.utils.throttle.OAuth2IdBurstRateThrottle",
+    "api.utils.throttle.OAuth2IdSustainedRateThrottle",
+    "api.utils.throttle.EnhancedOAuth2IdBurstRateThrottle",
+    "api.utils.throttle.EnhancedOAuth2IdSustainedRateThrottle",
+    "api.utils.throttle.ExemptOAuth2IdRateThrottle",
+)
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
@@ -22,30 +61,8 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
         "api.utils.drf_renderer.BrowsableAPIRendererWithoutForms",
     ),
-    "DEFAULT_THROTTLE_CLASSES": (
-        "api.utils.throttle.BurstRateThrottle",
-        "api.utils.throttle.SustainedRateThrottle",
-        "api.utils.throttle.AnonThumbnailRateThrottle",
-        "api.utils.throttle.OAuth2IdThumbnailRateThrottle",
-        "api.utils.throttle.OAuth2IdSustainedRateThrottle",
-        "api.utils.throttle.OAuth2IdBurstRateThrottle",
-        "api.utils.throttle.EnhancedOAuth2IdSustainedRateThrottle",
-        "api.utils.throttle.EnhancedOAuth2IdBurstRateThrottle",
-        "api.utils.throttle.ExemptOAuth2IdRateThrottle",
-    ),
-    "DEFAULT_THROTTLE_RATES": {
-        "anon_burst": THROTTLE_ANON_BURST,
-        "anon_sustained": THROTTLE_ANON_SUSTAINED,
-        "anon_healthcheck": THROTTLE_ANON_HEALTHCHECK,
-        "anon_thumbnail": THROTTLE_ANON_THUMBS,
-        "oauth2_client_credentials_thumbnail": THROTTLE_OAUTH2_THUMBS,
-        "oauth2_client_credentials_sustained": "10000/day",
-        "oauth2_client_credentials_burst": "100/min",
-        "enhanced_oauth2_client_credentials_sustained": "20000/day",
-        "enhanced_oauth2_client_credentials_burst": "200/min",
-        # ``None`` completely by-passes the rate limiting
-        "exempt_oauth2_client_credentials": None,
-    },
+    "DEFAULT_THROTTLE_CLASSES": DEFAULT_THROTTLE_CLASSES,
+    "DEFAULT_THROTTLE_RATES": DEFAULT_THROTTLE_RATES.copy(),
     "EXCEPTION_HANDLER": "api.utils.exceptions.exception_handler",
     "DEFAULT_SCHEMA_CLASS": "api.docs.base_docs.MediaSchema",
     # https://www.django-rest-framework.org/api-guide/throttling/#how-clients-are-identified


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3484 by @sarayourfriend 
Fixes #3485 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a new set of throttle classes to match requests with the `openverse.org` referrer header. Refer to the issue for rationale behind this approach. Keep in mind it is a temporary stop gap with known issues we seek to resolve with more advanced approaches later on.

The rollout for this will need infrastructure updates to include the new rate limiting scope environment variables.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check over the new unit tests. I made significant modifications here to remove artificiallity from the tests. Instead, the tests run against endpoints known to have specific rate limiting configuration (whether the default or otherwise) and confirms that those rate limit scopes are used, based on the rate limiting headers).

To manually test the new throttle, run the API with `DISABLE_GLOBAL_THROTTLING=False` in your `api/.env` file (`just api/up` to get the new setting loaded). Then make a request to localhost:50280/v1/ in your browser and inspect the response. Confirm that the anon rate limit scope is applied based on the X-RateLimit headers. Now use your browser's dev tools to edit and resend the request, but set the referrer header to `openverse.org`. Inspect the response, and confirm that the `ov_referrer` scope is used instead, with separate rate limit counts. If you made a single anon request, you should see 4 remaining burst requests for `ov_referrer`. For extra confidence, run out of requests on the anon by refreshing the page 5 times (then once more to show the rate limit response) and then make the request with the referrer header. You should now have a separate limit.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
