### PR TITLE
Use `.rest` in Octokit calls

### DIFF
--- a/automations/js/src/label_pr.mjs
+++ b/automations/js/src/label_pr.mjs
@@ -36,7 +36,7 @@ function getIsFullyLabeled(labels) {
  */
 async function getLabel(octokit, repository, name) {
   const [owner, repo] = repository.split('/')
-  const res = await octokit.issues.getLabel({ owner, repo, name })
+  const res = await octokit.rest.issues.getLabel({ owner, repo, name })
   return {
     id: res.data.node_id,
     name,

--- a/automations/js/src/sync_labels.mjs
+++ b/automations/js/src/sync_labels.mjs
@@ -48,7 +48,7 @@ export const main = async (octokit, core) => {
   // We assume that both repos have < 100 labels and do not paginate.
 
   /** @type {Label[]} */
-  const { data: monoLabels } = await octokit.issues.listLabelsForRepo({
+  const { data: monoLabels } = await octokit.rest.issues.listLabelsForRepo({
     ...monoRepo,
     per_page: 100,
   })
@@ -56,7 +56,7 @@ export const main = async (octokit, core) => {
   core.info(`Found ${monoLabels.length} labels in the monorepo.`)
 
   /** @type {Label[]} */
-  const { data: infraLabels } = await octokit.issues.listLabelsForRepo({
+  const { data: infraLabels } = await octokit.rest.issues.listLabelsForRepo({
     ...infraRepo,
     per_page: 100,
   })
@@ -87,11 +87,11 @@ export const main = async (octokit, core) => {
       if (diff.length) {
         const diffs = diff.join(', ')
         core.info(`Label "${label.name}" differs in ${diffs}. Updating.`)
-        await octokit.issues.updateLabel(newLabel)
+        await octokit.rest.issues.updateLabel(newLabel)
       }
     } else {
       core.info(`Label "${label.name}" does not exist. Creating.`)
-      await octokit.issues.createLabel(newLabel)
+      await octokit.rest.issues.createLabel(newLabel)
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the `.rest` part in Octokit calls which is required by the Octokit version supplied by the `actions/github-script` action. This is different from the `@octokit/rest` used in testing that can work without the `.rest` part.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Refer to the examples for `actions/github-script`. All of them contain `.rest` in the call chain. This must be important.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
