### PR TITLE
Fix incorrect default production data refresh limit of 0

### DIFF
--- a/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
+++ b/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
@@ -42,9 +42,11 @@ def _assign_work(db_conn, workers, model_name, table_name, target_index):
         cur.execute(est_records_query)
         estimated_records = cur.fetchone()[0]
 
-    records_per_worker = math.floor(
-        min(estimated_records, get_record_limit()) / len(workers)
-    )
+    # If a record_limit has been set, cap the number of records to be indexed.
+    if record_limit := get_record_limit():
+        estimated_records = min(estimated_records, record_limit)
+
+    records_per_worker = math.floor(estimated_records / len(workers))
 
     worker_url_template = "http://{}:8002"
     # Wait for the workers to start.

--- a/ingestion_server/ingestion_server/utils/config.py
+++ b/ingestion_server/ingestion_server/utils/config.py
@@ -14,6 +14,6 @@ def get_record_limit():
 
     environment = config("ENVIRONMENT", default="local").lower()
     if environment in {"prod", "production"}:
-        return 0
+        return None
 
     return 100_000


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
#3232
The ingestion server allows setting a `DATA_REFRESH_LIMIT` used to cap the number of records processed in a data refresh. By default on production we don't have a limit. Historically we have represented this by setting the limit to `0`. The copy data step has a simple[ if conditional ](https://github.com/WordPress/openverse/blob/c6ce2c6d819c0c316f64bdd616cf1378976fa766/ingestion_server/ingestion_server/queries.py#L184)before applying limits which meant that 0 was correctly considered "no limit".

When #3232 added logic to the reindexing step to also apply the record limit here, it did not have a similar check. The result is that in production, the default of 0 is applied... and 0 records are reindexed, effectively totally breaking the data refresh.

This PR:
* Adds a check to the index worker scheduler to only apply the record limit if in fact one has been set
* Changes the default limit in production from 0 to None, as this is more intuitive.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Locally, explicitly set `DATA_REFRESH_LIMIT` to None in your `ingestion_server/.env` to imitate production. Then run a data refresh and ensure that records make it all the way to the new es index.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
