### PR TITLE
Remove mysql from apt repository sources for catalog due to expired key

### DIFF
--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -39,7 +39,9 @@ ENV AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://openverse-airflow-logs
 
 
 USER root
-RUN apt-get update \
+# FIXME: Remove this exclusion once the mysql PGP key is no longer expired
+RUN rm /etc/apt/sources.list.d/mysql.list \
+    && apt-get update \
     && apt-get -yqq install \
       build-essential \
       libpq-dev \


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes a critical issue that's causing CI on `main` to fail when building the catalog (example run: https://github.com/WordPress/openverse/actions/runs/7213002475).

It seems the MySQL PGP key may be expired, and that's causing fresh builds of the catalog to fail. The build log failure we're seeing is:

```
 > [scheduler 2/7] RUN apt-get update     && apt-get -yqq install       build-essential       libpq-dev       libffi-dev     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*:
0.538 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
0.580 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
0.595 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
0.677 Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8062 kB]
0.696 Get:5 https://packages.microsoft.com/debian/11/prod bullseye InRelease [3649 B]
0.715 Get:6 http://repo.mysql.com/apt/debian bullseye InRelease [17.9 kB]
0.957 Get:7 https://packages.microsoft.com/debian/11/prod bullseye/main all Packages [1214 B]
1.002 Err:6 http://repo.mysql.com/apt/debian bullseye InRelease
1.002   The following signatures were invalid: EXPKEYSIG 467B942D3A79BD29 MySQL Release Engineering <mysql-build@oss.oracle.com>
1.049 Get:8 https://packages.microsoft.com/debian/11/prod bullseye/main amd64 Packages [131 kB]
1.113 Get:9 https://packages.microsoft.com/debian/11/prod bullseye/main arm64 Packages [27.5 kB]
1.137 Get:10 https://packages.microsoft.com/debian/11/prod bullseye/main armhf Packages [24.9 kB]
1.181 Get:11 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [260 kB]
1.191 Get:12 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [17.7 kB]
1.442 Get:13 https://apt.postgresql.org/pub/repos/apt bullseye-pgdg InRelease [123 kB]
2.014 Get:14 https://apt.postgresql.org/pub/repos/apt bullseye-pgdg/main amd64 Packages [305 kB]
2.293 Reading package lists...
2.801 W: GPG error: http://repo.mysql.com/apt/debian bullseye InRelease: The following signatures were invalid: EXPKEYSIG 467B942D3A79BD29 MySQL Release Engineering <mysql-build@oss.oracle.com>
2.801 E: The repository 'http://repo.mysql.com/apt/debian bullseye InRelease' is not signed.
```

Since we do not use MySQL in our Airflow setup, we should be safe to exclude this source from the list when running `apt` during image building. I've tested this locally and it appears to work fine!


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

CI/CD passing should be a positive indicator!

1. On the `main` branch, run `just dc pull` then `just build scheduler --no-cache`
2. Observe that the build error occurs
3. Check out this branch and run `just build scheduler --no-cache`, this should now succeed


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
