### PR TITLE
Remove Internet Archive Book Images sub provider

### DIFF
--- a/catalog/dags/common/loader/provider_details.py
+++ b/catalog/dags/common/loader/provider_details.py
@@ -62,7 +62,6 @@ FLICKR_SUB_PROVIDERS = {
     "east_riding": {"138361426@N08"},  # East Riding Archives
     "archief_alkmaar": {"98304311@N03"},  # Regionaal Archief Alkmaar Commons
     "bib_gulbenkian": {"26577438@N06"},  # Gulbenkian Art Library
-    "internet_archive_book_images": {"126377022@N07"},  # Internet Archive Book Images
 }
 
 FLICKR_PHOTO_URL_BASE = "https://www.flickr.com/photos/"

--- a/catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -56,6 +56,11 @@ class FlickrSubProviderAuditor:
         # TODO: Currently contains graphic medical imagery. Reconsider once
         # content safety progress is made.
         "61270229@N05",
+        # TODO: Internet Archive Book Images. Latest images were uploaded in
+        # 2015 and have not been previously ingested. Reconsider adding this
+        # subprovider when we have the ability to backfill these images.
+        # https://github.com/WordPress/openverse/issues/3490#issuecomment-1857072575  # noqa: E501
+        "126377022@N07",
     ]
 
     def __init__(self):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

See https://github.com/WordPress/openverse/issues/3490#issuecomment-1857072575 for additional context.

TL;DR: Internet Archive Book Images looks like a great candidate for a new sub-provider for Flickr, but the catalog does not currently have any images for this user because they were all uploaded prior to 2015. We also do not currently have an effective way to backfill these images, and it appears unlikely that many new ones will be added.

This PR:
* removes the sub-provider, which currently has 0 records
* adds the user id to the list of sub-provider candidates to ignore in the subprovider audit DAG, to prevent us from getting a notification each time it runs.

Since the sub-provider was not added to the API, there are no other changes necessary. To be totally safe we should verify after merging this that there are still 0 records ingested for this user.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the `flickr_audit_sub_provider_workflow` DAG and make sure it does not report the Internet Archive Book Images as a new subprovider.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
