### PR TITLE
Handle the possibility of an ES hit not being present in the database

### DIFF
--- a/api/test/unit/conftest.py
+++ b/api/test/unit/conftest.py
@@ -38,9 +38,6 @@ from api.serializers.media_serializers import (
     MediaSearchRequestSerializer,
     MediaSerializer,
 )
-from api.views.audio_views import AudioViewSet
-from api.views.image_views import ImageViewSet
-from api.views.media_views import MediaViewSet
 
 
 @pytest.fixture()
@@ -91,7 +88,6 @@ class MediaTypeConfig:
     report_serializer: MediaReportRequestSerializer
     report_factory: MediaReportFactory
     deleted_class: AbstractDeletedMedia
-    viewset_class: MediaViewSet
 
     @property
     def indexes(self):
@@ -113,7 +109,6 @@ MEDIA_TYPE_CONFIGS = {
         report_factory=model_factories.ImageReportFactory,
         mature_class=MatureImage,
         deleted_class=DeletedImage,
-        viewset_class=ImageViewSet,
     ),
     "audio": MediaTypeConfig(
         media_type="audio",
@@ -129,7 +124,6 @@ MEDIA_TYPE_CONFIGS = {
         report_factory=model_factories.AudioReportFactory,
         mature_class=MatureAudio,
         deleted_class=DeletedAudio,
-        viewset_class=AudioViewSet,
     ),
 }
 

--- a/api/test/unit/conftest.py
+++ b/api/test/unit/conftest.py
@@ -38,6 +38,9 @@ from api.serializers.media_serializers import (
     MediaSearchRequestSerializer,
     MediaSerializer,
 )
+from api.views.audio_views import AudioViewSet
+from api.views.image_views import ImageViewSet
+from api.views.media_views import MediaViewSet
 
 
 @pytest.fixture()
@@ -88,6 +91,7 @@ class MediaTypeConfig:
     report_serializer: MediaReportRequestSerializer
     report_factory: MediaReportFactory
     deleted_class: AbstractDeletedMedia
+    viewset_class: MediaViewSet
 
     @property
     def indexes(self):
@@ -109,6 +113,7 @@ MEDIA_TYPE_CONFIGS = {
         report_factory=model_factories.ImageReportFactory,
         mature_class=MatureImage,
         deleted_class=DeletedImage,
+        viewset_class=ImageViewSet,
     ),
     "audio": MediaTypeConfig(
         media_type="audio",
@@ -124,6 +129,7 @@ MEDIA_TYPE_CONFIGS = {
         report_factory=model_factories.AudioReportFactory,
         mature_class=MatureAudio,
         deleted_class=DeletedAudio,
+        viewset_class=AudioViewSet,
     ),
 }
 

--- a/api/test/unit/views/test_media_views.py
+++ b/api/test/unit/views/test_media_views.py
@@ -9,15 +9,24 @@ import pytest
 import pytest_django.asserts
 
 from api.models.models import ContentProvider
+from api.views.media_views import MediaViewSet
 
 
-def test_hits_to_db_handles_missing_entries(api_client, media_type_config):
+def test_hits_to_db_handles_missing_entries(api_client):
     """
     The ``get_db_results`` function should handle the case where a media entry
     is missing from the database.
     """
 
-    viewset = media_type_config.viewset_class()
+    # Can't use concrete subclasses of ``MediaViewSet`` as they inexplicably
+    # break other tests.
+    viewset = MediaViewSet(
+        model_class=Mock(),
+        media_type=Mock(),
+        query_serializer_class=Mock(),
+        collection_serializer_class=Mock(),
+        default_index=Mock(),
+    )
 
     hits = []
     for _ in range(10):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes the `get_db_results` function in `MediaViewSet` more robust by handling the case where an ES hit is not present in the database and in those situations, it just returns the `Hit` instead of the DB entry.

> [!NOTE]
> This situation is unlikely to occur as the ingestion server pushes the same data into the downstream API database as it indexes in Elasticsearch.

This change preserves the contract for the function to return as many entries as were passed to it, but in the case of inconsistencies, more fields will be `None` in the response as they are not present on the `Hit` during serialization. I don't know if that's an improvement over silently returning fewer results.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The included CI check verifies this behaviour. Additionally,

- Search for some term.
- Delete an item visible in the results from the DB.
- Search for the same term.
- You should still see the item, but with more fields set to `None` this time.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
