### PR TITLE
Use more flexible implementation for user mention link documentation extension

### DIFF
--- a/documentation/_ext/link_issues.py
+++ b/documentation/_ext/link_issues.py
@@ -102,8 +102,10 @@ class IssueReferences(SphinxTransform):
         tracker_config = TrackerConfig.from_sphinx_config(config)
         issue_pattern = config.issuetracker_issue_pattern
         title_template = None
+
         if isinstance(issue_pattern, str):
             issue_pattern = re.compile(issue_pattern)
+
         for node in self.document.traverse(nodes.Text):
             parent = node.parent
             if isinstance(parent, (nodes.literal, nodes.FixedTextElement)):
@@ -111,6 +113,7 @@ class IssueReferences(SphinxTransform):
                 continue
             if isinstance(parent, nodes.reference):
                 continue
+
             text = str(node)
             new_nodes = []
             last_issue_ref_end = 0
@@ -121,11 +124,13 @@ class IssueReferences(SphinxTransform):
                         "issuetracker_issue_pattern must have "
                         "exactly one group: {!r}".format(match.groups())
                     )
+
                 # extract the text between the last issue reference and the
                 # current issue reference and put it into a new text node
                 head = text[last_issue_ref_end : match.start()]
                 if head:
                     new_nodes.append(nodes.Text(head))
+
                 # adjust the position of the last issue reference in the
                 # text
                 last_issue_ref_end = match.end()
@@ -366,7 +371,6 @@ def connect_builtin_tracker(app: Sphinx) -> None:
 
 
 def setup(app: Sphinx) -> t.Dict[str, t.Any]:
-    app.add_config_value("mybase", "https://github.com/cihai/unihan-etl", "env")
     app.add_event("issuetracker-lookup-issue")
     app.connect("builder-inited", connect_builtin_tracker)
     app.add_config_value("issuetracker", None, "env")

--- a/documentation/_ext/link_usernames.py
+++ b/documentation/_ext/link_usernames.py
@@ -4,47 +4,115 @@ Based on: https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-source-r
 and: https://stackoverflow.com/a/31924901/3277713  CC BY-SA 3.0 by C_Z_
 
 This extension replaces username references of the form `@username` with a link
-to the user's GitHub profile. In order to prevent adding references to existing
-existing links (e.g. `[@username](...)`, whitespace is required in front of the `@`.
+to the user's GitHub profile.
 
-The GITHUB_IGNORE_USERNAMES set contains usernames that should not be linked but may
-appear to be usernames in the documentation.
+The plugin ignores code inside of fixed text blocks, including code blocks and backticks.
 """
 import re
 
+from docutils import nodes
 from sphinx.application import Sphinx
+from sphinx.transforms import SphinxTransform
 from sphinx.util import logging
 
 
 logger = logging.getLogger(__name__)
 
 # Format to use for the link to the GitHub profile
-GITHUB_USERNAME_TEMPLATE = "https://github.com/{}"
+GITHUB_USERNAME_TEMPLATE = "https://github.com/{username}"
+# Format to use for team mentions
+GITHUB_TEAM_TEMPLATE = "https://github.com/orgs/{org}/teams/{team}"
+
 # Regex to match username references
 GITHUB_USERNAME_REGEX = re.compile(
     r"""
-\ # Required initial whitespace
-@([A-Za-z0-9-]+)  # Match @ then any alphanumeric character or - for the username
+@(?P<username>[A-Za-z0-9-]+)  # Match @ then any alphanumeric character or - for the username
+(?P<team>/[A-Za-z0-9-]+)?  # If this is a team reference, match the team separately
 """,
     flags=re.VERBOSE,
 )
-GITHUB_IGNORE_USERNAMES = {"todo", "WordPress", "username", "defaultValue"}
 
 
-def _replace_username(match: re.Match) -> str:
-    username = match.group(1)
-    if username in GITHUB_IGNORE_USERNAMES:
-        logger.debug(f"Ignoring username reference: {username}")
-        return match.group(0)
-    logger.debug(f"Replacing username reference: {username}")
-    return f" [@{username}]({GITHUB_USERNAME_TEMPLATE.format(username)})"
+class GitHubUserMentions(SphinxTransform):
+    default_priority = 999
+
+    def apply(self) -> None:
+        for node in self.document.findall(nodes.Text):
+            parent = node.parent
+
+            # ignore existing links, back ticks, and code blocks
+            ignore_types = (nodes.reference, nodes.literal, nodes.FixedTextElement)
+            if isinstance(parent, ignore_types):
+                continue
+
+            text = str(node)
+            new_nodes = []
+            prev_mention_node_ref = 0
+            for match in GITHUB_USERNAME_REGEX.finditer(text):
+                # The full match including the leading @
+                mention = match.group(0)
+
+                username = match.group("username")
+
+                # `team` will be None if not a team mention
+                # If it is a team mention, then `username` will be the org
+                team = match.group("team")
+
+                # extract the text between the last user mention and the
+                # current user mention and put it into a new text node
+                head = text[prev_mention_node_ref : match.start()]
+                if head:
+                    new_nodes.append(nodes.Text(head))
+
+                # adjust the position of the last user mention in the
+                # text
+                prev_mention_node_ref = match.end()
+
+                textnode = nodes.Text(mention)
+                refnode = nodes.reference()
+
+                if team:
+                    url = GITHUB_TEAM_TEMPLATE.format(
+                        org=username,
+                        team=team.lstrip("/"),
+                    )
+                    title = f"Team {username}{team} on GitHub"
+                else:
+                    url = GITHUB_USERNAME_TEMPLATE.format(
+                        username=username,
+                    )
+                    title = f"{username} on GitHub"
+
+                refnode["refuri"] = url
+                refnode["reftitle"] = title
+                refnode.append(textnode)
+
+                new_nodes.append(refnode)
+
+            if not new_nodes:
+                # no user mentions were found, move on to the next node
+                continue
+
+            # extract the remaining text after the last user mention, and
+            # put it into a text node
+            tail = text[prev_mention_node_ref:]
+            if tail:
+                new_nodes.append(nodes.Text(tail))
+            # find and remove the original node, and insert all new nodes
+            # instead
+            parent.replace(node, new_nodes)
 
 
-def replace_username_references(app, docname, source):
-    logger.debug(f"In file: {docname}")
-    source[0] = GITHUB_USERNAME_REGEX.sub(_replace_username, source[0])
+def init_transformer(app: Sphinx) -> None:
+    if app.config.githubusermention:
+        app.add_transform(GitHubUserMentions)
 
 
 def setup(app: Sphinx):
-    # Hook for running the replace username references when the source file is read
-    app.connect("source-read", replace_username_references)
+    app.add_config_value("githubusermention", None, "env")
+    app.connect("builder-inited", init_transformer)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -78,6 +78,7 @@ html_show_copyright = False
 
 issuetracker = "github"
 issuetracker_project = "WordPress/openverse"
+githubusermention = True
 
 # The default for this is a sensible one for ReadTheDocs but
 # our site is served directly at the root docs.openverse.org URL


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3542 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the implementation of the `link_usernames` extension to be more flexible and resilient to the various text situations that can exist.

In doing so, it now trivially ignores the following contexts:
* Links
* Back `ticks`
* Code blocks (```` ``` ````)

The previous implementation could not ignore any of these without roundabout methods, like requiring leading whitespace. This led to the use of the flaky list of usernames to ignore. The new implementation doesn't need such a list, as it handles all the cases the ignore list targeted without issue, and removes the otherwise arbitrary requirement for leading whitespace. This means forms like `@person-a/@person-b` will work perfectly.

Additionally, the new implementation handles team mentions just as easily as username mentions.

The implementation is a significantly simplified version of the issue reference.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Review the code and confirm it makes sense. Check out the documentation preview on this PR and confirm that usernames are handled correctly and that the known edge cases are still handled, in addition to the new fix for code blocks (note, this is proven to be fixed by the removal of the `todo` and `defaultValue` ignored usernames. Those only appeared in code blocks!).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
