### PR TITLE
Fix issues in the sync workflow and narrow down its triggers

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -37,9 +37,5 @@ group:
         dest: .github/ISSUE_TEMPLATE/bug_report.md
       - source: .github/ISSUE_TEMPLATE/config.yml
         dest: .github/ISSUE_TEMPLATE/config.yml
-      - source: .github/ISSUE_TEMPLATE/discussion.md
-        dest: .github/ISSUE_TEMPLATE/discussion.md
       - source: .github/ISSUE_TEMPLATE/feature_request.md
         dest: .github/ISSUE_TEMPLATE/feature_request.md
-      - source: .github/ISSUE_TEMPLATE/sentry_bug.md
-        dest: .github/ISSUE_TEMPLATE/sentry_bug.md

--- a/.github/workflows/sync_meta.yml
+++ b/.github/workflows/sync_meta.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "automations/**"
+      - ".github/**"
 
 jobs:
   sync_meta:


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes the sync workflow run only when the files it syncs have been changed. While there was no negative effect to the workflow running, it wasted API calls and valuable minutes.

The PR also drops two files from the sync that are no longer present in this repo and raised warnings when syncing was attempted for them.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
