### PR TITLE
Fix/posix path separators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,3 +138,11 @@ repos:
       - id: renovate-config-validator
         args:
           - --strict
+
+  - repo: local
+    hooks:
+      - id: codeowners-validator
+        name: CODEOWNERS Validator
+        entry: ./codeowners-validator.sh
+        language: script
+        files: ^CODEOWNERS$

--- a/____BlaDockerfile
+++ b/____BlaDockerfile
@@ -1,0 +1,12 @@
+# Use a base image that has the necessary dependencies
+FROM alpine:latest
+
+# Install git, as it might be necessary for the codeowners-validator
+RUN apk add --no-cache git
+
+# Install the codeowners-validator
+ADD https://github.com/mszostok/codeowners-validator/releases/download/v0.6.0/codeowners-validator_0.6.0_Linux_x86_64.tar.gz /tmp
+RUN tar -xzf /tmp/codeowners-validator_0.6.0_Linux_x86_64.tar.gz -C /usr/local/bin
+
+# Set the entrypoint to the codeowners-validator
+ENTRYPOINT ["codeowners-validator"]

--- a/codeowners-validator.sh
+++ b/codeowners-validator.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm -v "$(pwd):/repo" -e REPOSITORY_PATH=/repo -e OWNERCHECKER_REPOSITORY=/repo gmottajr/codeowners-validator:latest

--- a/codeowners-validator.sh
+++ b/codeowners-validator.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -v "$(pwd):/repo" -e REPOSITORY_PATH=/repo -e OWNERCHECKER_REPOSITORY=/repo gmottajr/codeowners-validator:latest
+docker run --rm -v "$(pwd):/repo" -e REPOSITORY_PATH=/repo -e OWNERCHECKER_REPOSITORY=/repo mszostok/codeowners-validator


### PR DESCRIPTION
Integrating codeowners-validator into our openverse lint hooks (managed by pre-commit in the .pre-commit-config.yaml file). In order they can use the Docker approach codeowners-validator.