### PR TITLE
Additional service checks for ingestion server health endpoint

### DIFF
--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -15,6 +15,11 @@ from sentry_sdk.integrations.falcon import FalconIntegration
 
 from ingestion_server import slack
 from ingestion_server.constants.media_types import MEDIA_TYPES, MediaType
+from ingestion_server.db_helpers import (
+    DB_UPSTREAM_CONFIG,
+    DB_API_CONFIG,
+    database_connect,
+)
 from ingestion_server.es_helpers import elasticsearch_connect, get_stat
 from ingestion_server.indexer import TableIndexer
 from ingestion_server.state import clear_state, worker_finished
@@ -38,9 +43,40 @@ sentry_sdk.init(
 
 class HealthResource:
     @staticmethod
-    def on_get(_, resp):
+    def on_get(req, resp):
+        # Set the initial response, but change it if necessary
         resp.status = falcon.HTTP_200
         resp.media = {"status": "200 OK"}
+
+        if not req.get_param_as_bool("check_deps", blank_as_true=False):
+            return
+
+        messages = []
+        # Elasticsearch checks
+        es = elasticsearch_connect(timeout=3)
+        if not es:
+            messages.append("Elasticsearch could not be reached")
+        else:
+            es_health = es.cluster.health(timeout="3s")
+            if es_health["timed_out"]:
+                messages.append("Elasticsearch health check timed out")
+            if (es_status := es_health["status"]) != "green":
+                messages.append(f"Elasticsearch cluster health: {es_status}")
+
+        # Database checks
+        for name, dbconfig in zip(
+            ["upstream", "api"],
+            [DB_UPSTREAM_CONFIG, DB_API_CONFIG],
+        ):
+            db = database_connect(dbconfig=dbconfig, timeout=3, attempt_reconnect=False)
+            if not db:
+                messages.append(
+                    f"Database connection for '{name}' could not be established"
+                )
+
+        if messages:
+            resp.status = falcon.HTTP_503
+            resp.media = {"status": messages}
 
 
 class StatResource:

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -44,6 +44,10 @@ sentry_sdk.init(
 class HealthResource:
     @staticmethod
     def on_get(req, resp):
+        """
+        Health check for the service. Optionally check on resources with the
+        check_deps=true parameter.
+        """
         # Set the initial response, but change it if necessary
         resp.status = falcon.HTTP_200
         resp.media = {"status": "200 OK"}

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -14,8 +14,8 @@ import requests as re
 import tldextract
 from psycopg2.extras import DictCursor, Json
 
-from ingestion_server.indexer import DB_BUFFER_SIZE, database_connect
-
+from ingestion_server.indexer import DB_BUFFER_SIZE
+from ingestion_server.db_helpers import database_connect
 
 # Number of records to buffer in memory at once
 CLEANUP_BUFFER_SIZE = DB_BUFFER_SIZE

--- a/ingestion_server/ingestion_server/db_helpers.py
+++ b/ingestion_server/ingestion_server/db_helpers.py
@@ -1,0 +1,46 @@
+import logging as log
+import time
+
+import psycopg2
+from decouple import config
+
+DATABASE_HOST = config("DATABASE_HOST", default="localhost")
+DATABASE_PORT = config("DATABASE_PORT", default=5432, cast=int)
+DATABASE_USER = config("DATABASE_USER", default="deploy")
+DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="deploy")
+DATABASE_NAME = config("DATABASE_NAME", default="openledger")
+
+
+def database_connect(
+    autocommit: bool = False,
+    timeout: int = 5,
+    attempt_reconnect: bool = True,
+):
+    """
+    Repeatedly try to connect to the downstream (API) database until successful
+    (unless otherwise specified).
+
+    :return: A database connection object
+    """
+    while True:
+        try:
+            conn = psycopg2.connect(
+                dbname=DATABASE_NAME,
+                user=DATABASE_USER,
+                password=DATABASE_PASSWORD,
+                host=DATABASE_HOST,
+                port=DATABASE_PORT,
+                connect_timeout=timeout,
+            )
+            if autocommit:
+                conn.set_session(autocommit=True)
+        except psycopg2.OperationalError as e:
+            if not attempt_reconnect:
+                raise e
+            log.exception(e)
+            log.error("Reconnecting to database in 5 seconds. . .")
+            time.sleep(5)
+            continue
+        break
+
+    return conn

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -23,7 +23,6 @@ from collections import deque
 from typing import Any
 
 import elasticsearch
-import psycopg2
 import requests
 from decouple import config
 from elasticsearch import Elasticsearch, helpers
@@ -32,6 +31,7 @@ from psycopg2.sql import SQL, Identifier, Literal
 from requests import RequestException
 
 from ingestion_server import slack
+from ingestion_server.db_helpers import database_connect
 from ingestion_server.distributed_reindex_scheduler import schedule_distributed_index
 from ingestion_server.elasticsearch_models import media_type_to_elasticsearch_model
 from ingestion_server.es_helpers import get_stat
@@ -39,12 +39,6 @@ from ingestion_server.es_mapping import index_settings
 from ingestion_server.queries import get_existence_queries
 from ingestion_server.utils.sensitive_terms import get_sensitive_terms
 
-
-DATABASE_HOST = config("DATABASE_HOST", default="localhost")
-DATABASE_PORT = config("DATABASE_PORT", default=5432, cast=int)
-DATABASE_USER = config("DATABASE_USER", default="deploy")
-DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="deploy")
-DATABASE_NAME = config("DATABASE_NAME", default="openledger")
 
 # See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/docs-reindex.html#docs-reindex-throttle
 ES_FILTERED_INDEX_THROTTLING_RATE = config(
@@ -61,34 +55,6 @@ SYNCER_POLL_INTERVAL = config("SYNCER_POLL_INTERVAL", default=60, cast=int)
 REP_TABLES = config(
     "COPY_TABLES", default="image", cast=lambda var: [s.strip() for s in var.split(",")]
 )
-
-
-def database_connect(autocommit=False):
-    """
-    Repeatedly try to connect to the downstream (API) database until successful.
-
-    :return: A database connection object
-    """
-    while True:
-        try:
-            conn = psycopg2.connect(
-                dbname=DATABASE_NAME,
-                user=DATABASE_USER,
-                password=DATABASE_PASSWORD,
-                host=DATABASE_HOST,
-                port=DATABASE_PORT,
-                connect_timeout=5,
-            )
-            if autocommit:
-                conn.set_session(autocommit=True)
-        except psycopg2.OperationalError as e:
-            log.exception(e)
-            log.error("Reconnecting to database in 5 seconds. . .")
-            time.sleep(5)
-            continue
-        break
-
-    return conn
 
 
 def get_last_item_ids(table):

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -26,7 +26,7 @@ from psycopg2.sql import SQL, Identifier, Literal
 from ingestion_server import slack
 from ingestion_server.cleanup import clean_image_data
 from ingestion_server.constants.internal_types import ApproachType
-from ingestion_server.indexer import database_connect
+from ingestion_server.db_helpers import database_connect
 from ingestion_server.queries import (
     get_copy_data_query,
     get_create_ext_query,

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -26,7 +26,7 @@ from psycopg2.sql import SQL, Identifier, Literal
 from ingestion_server import slack
 from ingestion_server.cleanup import clean_image_data
 from ingestion_server.constants.internal_types import ApproachType
-from ingestion_server.db_helpers import database_connect
+from ingestion_server.db_helpers import database_connect, DB_UPSTREAM_CONFIG
 from ingestion_server.queries import (
     get_copy_data_query,
     get_create_ext_query,
@@ -36,21 +36,15 @@ from ingestion_server.queries import (
 from ingestion_server.utils.config import get_record_limit
 
 
-UPSTREAM_DB_HOST = config("UPSTREAM_DB_HOST", default="localhost")
-UPSTREAM_DB_PORT = config("UPSTREAM_DB_PORT", default=5433, cast=int)
-UPSTREAM_DB_USER = config("UPSTREAM_DB_USER", default="deploy")
-UPSTREAM_DB_PASSWORD = config("UPSTREAM_DB_PASSWORD", default="deploy")
-UPSTREAM_DB_NAME = config("UPSTREAM_DB_NAME", default="openledger")
-
 RELATIVE_UPSTREAM_DB_HOST = config(
     "RELATIVE_UPSTREAM_DB_HOST",
-    default=UPSTREAM_DB_HOST,
+    default=DB_UPSTREAM_CONFIG.host,
 )
 #: the hostname of the upstream DB from the POV of the downstream DB
 
 RELATIVE_UPSTREAM_DB_PORT = config(
     "RELATIVE_UPSTREAM_DB_PORT",
-    default=UPSTREAM_DB_PORT,
+    default=DB_UPSTREAM_CONFIG.port,
     cast=int,
 )
 #: the port of the upstream DB from the POV of the downstream DB
@@ -282,14 +276,7 @@ def refresh_api_table(
         "Starting ingestion server data refresh | _Next: copying data from upstream_",
     )
     downstream_db = database_connect()
-    upstream_db = psycopg2.connect(
-        dbname=UPSTREAM_DB_NAME,
-        user=UPSTREAM_DB_USER,
-        port=UPSTREAM_DB_PORT,
-        password=UPSTREAM_DB_PASSWORD,
-        host=UPSTREAM_DB_HOST,
-        connect_timeout=5,
-    )
+    upstream_db = database_connect(dbconfig=DB_UPSTREAM_CONFIG)
     shared_cols = _get_shared_cols(
         downstream_db, upstream_db, upstream_table, downstream_table
     )
@@ -309,9 +296,9 @@ def refresh_api_table(
         init_fdw = get_fdw_query(
             RELATIVE_UPSTREAM_DB_HOST,
             RELATIVE_UPSTREAM_DB_PORT,
-            UPSTREAM_DB_NAME,
-            UPSTREAM_DB_USER,
-            UPSTREAM_DB_PASSWORD,
+            DB_UPSTREAM_CONFIG.dbname,
+            DB_UPSTREAM_CONFIG.user,
+            DB_UPSTREAM_CONFIG.password,
             upstream_table,
         )
         downstream_cur.execute(init_fdw)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2019 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds checks for Elasticsearch and both databases to the ingestion server health check endpoint behind the `check_deps` query parameter. This also refactors the database connection into a `db_helpers` module similar to the `es_helpers` one that already exists. This helped simplify some of the code and centralize _where_ the database connection logic was being defined.

The failed response has a `status` field with a list of possible failures due to the number of upstream services to be checked. If there's a better way to structure that, let me know!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. `just i` to start the stack
1. Run `curl -L http://localhost:50281/` and verify the output is `{"status": "200 OK"}`
1. Run `curl -L http://localhost:50281/?check_deps=true` and verify the output is `{"status": "200 OK"}`
1. Run `docker stop openverse-db-1 openverse-es-1 openverse-upstream_db-1` to simulate the resources becoming unavailable
1. Run `curl -L http://localhost:50281/` and verify the output is `{"status": "200 OK"}` (unaffected)
1. Run `curl -L http://localhost:50281/?check_deps=true` and verify the output is `{"status": "503 Service Unavailable", "dependencies": {"es": ["Elasticsearch could not be reached"], "db": ["Database connection for 'upstream' could not be established", "Database connection for 'api' could not be established"]}}` (error messages shown)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
