### PR TITLE
HOTFIX: Convert encoded HTTP connection variables to http type not https

### DIFF
--- a/catalog/entrypoint.sh
+++ b/catalog/entrypoint.sh
@@ -52,8 +52,8 @@ while read -r var_string; do
   echo "    Old Value: $old_value"
   # call python to url encode the http clause
   url_encoded=$(python -c "from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" "$old_value")
-  # prepend https://
-  new_value='https://'$url_encoded
+  # prepend http://
+  new_value='http://'$url_encoded
   echo "    New Value: $new_value"
   # set the environment variable
   export "$var_name"="$new_value"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

With the merge of #3591 and #3572, we started to encounter errors with the data refresh's HTTP steps. When run locally, the `HttpOperator` steps would raise an exception about how they were unable to find a provider for the connection type `https`. After looking through the Airflow source code for deserializing providers, we realized that the [HTTP Operator is expecting an `http` prefix](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/connections/http.html) (whereas previously `https` was an allowed prefix when performing the lookup for which connection type to use).

We have code in our entrypoint which transforms connection URIs into URL-encoded `https` connection types (see: https://github.com/WordPress/openverse-catalog/pull/480), and this was ultimately where we identified a fix. Instead of prefixing those values with `https`, we prefix them with `http`, and Airflow behaves as expected with the connections. Since the Airflow documentation for the hook describes that you can use `http` and `https` prefixes, we'll still file an issue upstream even though we have this addressed locally.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Build the new containers with `j build`
2. Run `j api/init && j c`
3. Wait until the init is complete, then try to run an audio data refresh. It should succeed whereas on `main` it did not.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
