### PR TITLE
Add additional_query_params to provider DAG configuration

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -173,6 +173,9 @@ class ProviderDataIngester(ABC):
             # Create a generator to facilitate fetching the next set of query_params.
             self.override_query_params = (qp for qp in query_params_list)
 
+        # An optional set of query params to add to each query
+        self.additional_query_params = conf.get("additional_query_params", {})
+
         # A configuration option that is used to skip over ALL errors and continue
         # ingestion, reporting errors in aggregate when ingestion has completed. This
         # option should be used sparingly and can only be enabled at the level of an
@@ -349,9 +352,10 @@ class ProviderDataIngester(ABC):
             )
             return next_params
 
-        # Default behavior when no conf options are provided; build the next
-        # set of query params, given the previous.
-        return self.get_next_query_params(prev_query_params, **kwargs)
+        # Default behavior; build the next set of query params, given the previous,
+        # along with any extra params if additional_query_params were provided
+        next_query_params = self.get_next_query_params(prev_query_params, **kwargs)
+        return next_query_params | self.additional_query_params
 
     @abstractmethod
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:

--- a/catalog/dags/providers/provider_dag_factory.py
+++ b/catalog/dags/providers/provider_dag_factory.py
@@ -399,6 +399,15 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
                     " be run for just these sets of params."
                 ),
             ),
+            "additional_query_params": Param(
+                default={},
+                type=["object", "null"],
+                description=(
+                    "Supplement the `query_params` on each request. This option is used"
+                    " to run a DAG but restrict the search by specifying extra query"
+                    " params."
+                ),
+            ),
             "skip_ingestion_errors": Param(
                 default=False,
                 type="boolean",

--- a/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -394,6 +394,37 @@ def test_ingest_records_uses_query_params_list_from_dagrun_conf():
         )
 
 
+def test_ingest_records_uses_additional_query_params_from_dagrun_conf():
+    # Initialize the ingester with a conf
+    ingester = MockProviderDataIngester(
+        {"additional_query_params": {"extra_param": 310}}
+    )
+
+    with (
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=3),
+    ):
+        get_batch_mock.side_effect = [
+            (EXPECTED_BATCH_DATA, True),
+            (EXPECTED_BATCH_DATA, True),
+            (EXPECTED_BATCH_DATA, True),
+            (EXPECTED_BATCH_DATA, False),
+        ]
+
+        ingester.ingest_records()
+
+        # All calls should have the extra query param added
+        assert get_batch_mock.call_count == 4
+        get_batch_mock.assert_has_calls(
+            [
+                call({"has_image": 1, "page": 1, "extra_param": 310}),
+                call({"has_image": 1, "page": 1, "extra_param": 310}),
+                call({"has_image": 1, "page": 1, "extra_param": 310}),
+                call({"has_image": 1, "page": 1, "extra_param": 310}),
+            ]
+        )
+
+
 def test_ingest_records_raises_IngestionError():
     with patch.object(ingester, "get_batch") as get_batch_mock:
         get_batch_mock.side_effect = [


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3533 by @stacimc  

## Description
Adds a new configuration option, `additional_query_params`, to provider DAGs, such that on every request run, we add these params to the query.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
