### PR TITLE
Simplify load sample data

### DIFF
--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 WEB_SERVICE_NAME="${WEB_SERVICE_NAME:-web}"
 CACHE_SERVICE_NAME="${CACHE_SERVICE_NAME:-cache}"
@@ -21,20 +21,18 @@ done
 # Upstream DB #
 ###############
 
+function exec_sql {
+  echo "$2" | just dc exec -T "$1" psql -AXqt
+}
+
 # Load sample data
 function load_sample_data {
-  docker-compose exec -T "$UPSTREAM_DB_SERVICE_NAME" bash -c "psql <<-EOF
-		DELETE FROM $1;
-		\copy $1 \
-			from './sample_data/sample_$1.csv' \
-			with (FORMAT csv, HEADER true);
-		EOF"
+  exec_sql "$UPSTREAM_DB_SERVICE_NAME" "DELETE FROM $1"
+  exec_sql "$UPSTREAM_DB_SERVICE_NAME" "\copy $1 from './sample_data/sample_$1.csv' with (FORMAT csv, HEADER true);"
 }
 
 function verify_loaded_data {
-  COUNT=$(docker-compose exec -T "$UPSTREAM_DB_SERVICE_NAME" bash -c "psql -AXqt <<-EOF
-		SELECT COUNT(*) FROM $1;
-		EOF")
+  COUNT=$(exec_sql "$UPSTREAM_DB_SERVICE_NAME" "SELECT COUNT(*) FROM $1;")
   if [ "$COUNT" -ne 5000 ]; then
     echo "Error: table $1 count differs from expected."
     exit 1
@@ -56,35 +54,35 @@ fi
 #######
 
 # Set up API database and upstream
-docker-compose exec -T "$WEB_SERVICE_NAME" bash -c "python3 manage.py migrate --noinput"
+just dc exec -T "$WEB_SERVICE_NAME" python3 manage.py migrate --noinput
 # Create a superuser and a user for integration testing
 # Not that the Python code uses 4 spaces for indentation after the tab that is stripped by <<-
-docker-compose exec -T "$WEB_SERVICE_NAME" bash -c "python3 manage.py shell <<-EOF
-	from django.contrib.auth.models import User
-	usernames = ['continuous_integration', 'deploy']
-	for username in usernames:
-	    if User.objects.filter(username=username).exists():
-	        print(f'User {username} already exists')
-	        continue
-	    if username == 'deploy':
-	        user = User.objects.create_superuser(username, f'{username}@example.com', 'deploy')
-	    else:
-	        user = User.objects.create_user(username, f'{username}@example.com', 'deploy')
-	    user.save()
-	EOF"
+echo "
+from django.contrib.auth.models import User
+usernames = ['continuous_integration', 'deploy']
+for username in usernames:
+	if User.objects.filter(username=username).exists():
+		print(f'User {username} already exists')
+		continue
+	if username == 'deploy':
+		user = User.objects.create_superuser(username, f'{username}@example.com', 'deploy')
+	else:
+		user = User.objects.create_user(username, f'{username}@example.com', 'deploy')
+	user.save()
+" | just dc exec -T "$WEB_SERVICE_NAME" python3 manage.py shell
 
 # Load content providers
-docker-compose exec -T "$DB_SERVICE_NAME" bash -c "psql <<-EOF
-	DELETE FROM content_provider;
-	INSERT INTO content_provider
-		(created_on, provider_identifier, provider_name, domain_name, filter_content, media_type)
-	VALUES
-		(now(), 'flickr', 'Flickr', 'https://www.flickr.com', false, 'image'),
-		(now(), 'stocksnap', 'StockSnap', 'https://stocksnap.io', false, 'image'),
-		(now(), 'freesound', 'Freesound', 'https://freesound.org/', false, 'audio'),
-		(now(), 'jamendo', 'Jamendo', 'https://www.jamendo.com', false, 'audio'),
-		(now(), 'wikimedia_audio', 'Wikimedia', 'https://commons.wikimedia.org', false, 'audio');
-	EOF"
+exec_sql "$DB_SERVICE_NAME" "
+DELETE FROM content_provider;
+INSERT INTO content_provider
+	(created_on, provider_identifier, provider_name, domain_name, filter_content, media_type)
+VALUES
+	(now(), 'flickr', 'Flickr', 'https://www.flickr.com', false, 'image'),
+	(now(), 'stocksnap', 'StockSnap', 'https://stocksnap.io', false, 'image'),
+	(now(), 'freesound', 'Freesound', 'https://freesound.org/', false, 'audio'),
+	(now(), 'jamendo', 'Jamendo', 'https://www.jamendo.com', false, 'audio'),
+	(now(), 'wikimedia_audio', 'Wikimedia', 'https://commons.wikimedia.org', false, 'audio');
+"
 
 #############
 # Ingestion #


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

I set up Openverse from scratch today and ran into a very strange issue with `load_sample_data.sh` that I cannot track down the precise cause of. The version on `main` hangs completely, without any feedback, and apparently passes malformed SQL commands to `psql`.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The changes in this PR get the script running as expected for me again. They also, I believe, somewhat simplify things, through the introduction of two patterns:

1. The new `exec_sql` function which not only DRYs up the code a bit, but also uses what is apparently a more reliable approach for passing a set of SQL commands to `psql`. The same approach is used for interacting with Redis as well.
2. Taking advantage of bash's built-in multiline string support, rather than using docstring style. This is easier to read and keep track of (IMO) and has less potential variations. It's also easier to assign to variables or pass as arguments to bash functions.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should work, all API testing steps rely on this script. You should also be able to run it locally.

I really don't know _why_ the script as-is didn't work on this machine. The only thing I can think of is maybe the bash version is different?

```
$ bash --version
GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
