### PR TITLE
Allow CI + CD workflow to deploy from a different branch

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,8 +12,9 @@ on:
         type: string
         required: false
         default: ""
-      force_deploy:
-        description: "Whether to force GHCR publish and ECS deploy from a non-main branch."
+      # This is useful when dispatching on a branch other than `main`.
+      perform_deploy:
+        description: "Publish images and deploy staging?"
         type: boolean
         required: false
         default: false
@@ -909,7 +910,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
+        (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
       ) &&
       needs.determine-images.outputs.do_publish == 'true' &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
@@ -970,7 +971,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
+        (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
       ) &&
       needs.get-changes.outputs.frontend == 'true' &&
       needs.playwright.result == 'success' &&
@@ -1015,7 +1016,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
+        (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
       ) &&
       needs.get-changes.outputs.api == 'true' &&
       needs.publish-images.result == 'success'
@@ -1062,7 +1063,7 @@ jobs:
       !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
+        (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
       ) &&
       (
         (needs.get-changes.outputs.documentation == 'true' && needs.emit-docs.result != 'success') ||

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,7 +10,8 @@ on:
       image_tag:
         description: "The tag to assign to the images built in the workflow."
         type: string
-        required: true
+        required: false
+        default: ""
       force_deploy:
         description: "Whether to force GHCR publish and ECS deploy from a non-main branch."
         type: boolean
@@ -61,7 +62,7 @@ jobs:
       - name: Get image tag
         id: get-image-tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.image_tag }}" != "" ]]; then
               echo "image_tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           else
               echo "image_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -909,7 +909,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
       ) &&
       needs.determine-images.outputs.do_publish == 'true' &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
@@ -970,7 +970,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
       ) &&
       needs.get-changes.outputs.frontend == 'true' &&
       needs.playwright.result == 'success' &&
@@ -1015,7 +1015,7 @@ jobs:
       !failure() && !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
       ) &&
       needs.get-changes.outputs.api == 'true' &&
       needs.publish-images.result == 'success'
@@ -1062,7 +1062,7 @@ jobs:
       !cancelled() &&
       (
         (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy)
       ) &&
       (
         (needs.get-changes.outputs.documentation == 'true' && needs.emit-docs.result != 'success') ||

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -63,9 +63,9 @@ jobs:
         id: get-image-tag
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.image_tag }}" != "" ]]; then
-              echo "image_tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+              echo "image_tag=${{ inputs.image_tag }}" | tee "$GITHUB_OUTPUT"
           else
-              echo "image_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+              echo "image_tag=${{ github.sha }}" | tee "$GITHUB_OUTPUT"
           fi
 
   determine-images:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1066,7 +1066,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
       ) &&
       (
-        (needs.get-changes.outputs.documentation == 'true' && needs.emit-docs.result != 'success') ||
+        ((github.event_name == 'push' && needs.get-changes.outputs.documentation == 'true') && needs.emit-docs.result != 'success') ||
         (needs.determine-images.outputs.do_publish == 'true' && needs.publish-images.result != 'success') ||
         (needs.get-changes.outputs.frontend == 'true' && needs.deploy-frontend.result != 'success') ||
         (needs.get-changes.outputs.api == 'true' && needs.deploy-api.result != 'success')

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,6 +11,11 @@ on:
         description: "The tag to assign to the images built in the workflow."
         type: string
         required: true
+      force_deploy:
+        description: "Whether to force GHCR publish and ECS deploy from a non-main branch."
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -901,8 +906,10 @@ jobs:
     # prevent running on fork PRs
     if: |
       !failure() && !cancelled() &&
-      github.event_name == 'push' &&
-      github.repository == 'WordPress/openverse' &&
+      (
+        (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+      ) &&
       needs.determine-images.outputs.do_publish == 'true' &&
       (needs.test-ing.result == 'success' || needs.test-ing.result == 'skipped') &&
       (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
@@ -960,7 +967,10 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !failure() && !cancelled() &&
-      github.event_name == 'push' &&
+      (
+        (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+      ) &&
       needs.get-changes.outputs.frontend == 'true' &&
       needs.playwright.result == 'success' &&
       needs.publish-images.result == 'success'
@@ -1002,7 +1012,10 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !failure() && !cancelled() &&
-      github.event_name == 'push' &&
+      (
+        (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+      ) &&
       needs.get-changes.outputs.api == 'true' &&
       needs.publish-images.result == 'success'
     needs:
@@ -1046,8 +1059,10 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !cancelled() &&
-      github.event_name == 'push' &&
-      github.repository == 'WordPress/openverse' &&
+      (
+        (github.event_name == 'push' && github.repository == 'WordPress/openverse') ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy == 'true')
+      ) &&
       (
         (needs.get-changes.outputs.documentation == 'true' && needs.emit-docs.result != 'success') ||
         (needs.determine-images.outputs.do_publish == 'true' && needs.publish-images.result != 'success') ||


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the ability for the CI + CD workflow to deploy to staging from a non-`main` branch when dispatched from the UI. This boolean toggle will cause the workflow to tag the images, publish them on GHCR and deploy them to staging.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
