### PR TITLE
Use correct path when checking if DAGs.md needs to be regenerated

### DIFF
--- a/catalog/justfile
+++ b/catalog/justfile
@@ -134,7 +134,7 @@ generate-dag-docs fail_on_diff="false":
     echo "Done!"
     if {{ fail_on_diff }}; then
       set +e
-      git diff --exit-code -- documentation/catalog/reference/DAGs.md
+      git diff --exit-code -- ../documentation/catalog/reference/DAGs.md
       if [ $? -ne 0 ]; then
           printf "\n\n\e[31m!! Changes found in DAG documentation, please run 'just generate-dag-docs' locally and commit difference !!\n\n"
           exit 1

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -85,6 +85,7 @@ The following are DAGs grouped by their primary tag:
 
 | DAG ID                                                          | Schedule Interval | Dated   | Media Type(s) |
 | --------------------------------------------------------------- | ----------------- | ------- | ------------- |
+| [`auckland_museum_workflow`](#auckland_museum_workflow)         | `@daily`          | `True`  | image         |
 | `brooklyn_museum_workflow`                                      | `@monthly`        | `False` | image         |
 | [`cc_mixter_workflow`](#cc_mixter_workflow)                     | `@monthly`        | `False` | audio         |
 | `cleveland_museum_workflow`                                     | `@monthly`        | `False` | image         |
@@ -106,7 +107,7 @@ The following are DAGs grouped by their primary tag:
 | [`smk_workflow`](#smk_workflow)                                 | `@monthly`        | `False` | image         |
 | [`stocksnap_workflow`](#stocksnap_workflow)                     | `@monthly`        | `False` | image         |
 | [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)     | `@daily`          | `True`  | image, audio  |
-| [`wordpress_workflow`](#wordpress_workflow)                     | `@monthly`        | `False` | image         |
+| [`wordpress_workflow`](#wordpress_workflow)                     | `@weekly`         | `False` | image         |
 
 ### Provider Reingestion
 
@@ -123,6 +124,7 @@ The following is documentation associated with each DAG (where available):
 
 1.  [`add_license_url`](#add_license_url)
 1.  [`airflow_log_cleanup`](#airflow_log_cleanup)
+1.  [`auckland_museum_workflow`](#auckland_museum_workflow)
 1.  [`audio_data_refresh`](#audio_data_refresh)
 1.  [`audio_popularity_refresh`](#audio_popularity_refresh)
 1.  [`batched_update`](#batched_update)
@@ -202,6 +204,24 @@ airflow dags trigger --conf
 
 - maxLogAgeInDays:<INT> - Optional
 - enableDelete:<BOOLEAN> - Optional
+
+### `auckland_museum_workflow`
+
+Content Provider: Auckland War Memorial Museum Tāmaki Paenga Hira
+
+ETL Process: Use the API to identify all CC licensed media.
+
+Output: TSV file containing the media and the respective meta-data.
+
+Notes: https://api.aucklandmuseum.com/
+
+Resource: https://api.aucklandmuseum.com/
+https://github.com/AucklandMuseum/API/wiki/Tutorial
+
+| Resource     | Requests per second | Requests per day |
+| ------------ | ------------------- | ---------------- |
+| /search, /id | 10                  | 1000             |
+| /id/media    | 10                  | 1000             |
 
 ### `audio_data_refresh`
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Follow up from #3696, we identified that the DAG documentation generation CI check was no longer appropriately failing when it should have. This PR corrects the path used to reference the DAGs file and updates the DAG documentation appropriately. 


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Make a change to the DAGs.md file
1. Run `j catalog/generate-dag-docs true` and ensure that the task fails


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
