### PR TITLE
Do not use unsupported folded chomping multiline YAML block syntax

### DIFF
--- a/.github/workflows/pr_limit_reminders.yml
+++ b/.github/workflows/pr_limit_reminders.yml
@@ -42,19 +42,11 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          # The JSON below looks malformed, with an invalid multiline string, but YAML's `>`
-          # construct replaces linebreaks with a space, so the multiline string below will end
-          # up as a single-line string. The payload will be `{  "user": "...",  "message":   "..." }
-          payload: >
+          # Note: We cannot use the YAML folded chomping block syntax here (`>`) because
+          # GitHub Actions does not support it (they only support a subset of YAML):
+          # https://github.com/actions/runner/issues/418#issuecomment-612928525
+          payload: |
             {
               "user": "${{ env.slack_id }}",
-              "message":
-                "Hi, Opener! \n
-                You currently have ${{ env.pr_count }} Pull Request(s) open with requested
-                reviews (totalling ${{ env.required_review_count }} required reviews). \n
-                To help ease the review burden, increase review velocity for older PRs, and
-                improve the equitable distribution of project maintenance tasks across the team,
-                please consider reviewing this list of ways to contribute instead of working on
-                new code contributions: \n
-                https://docs.openverse.org/meta/maintainer_tasks.html"
+              "message": "Hi, Opener! \n You currently have ${{ env.pr_count }} Pull Request(s) open with requested reviews (totalling ${{ env.required_review_count }} required reviews). \n To help ease the review burden, increase review velocity for older PRs, and improve the equitable distribution of project maintenance tasks across the team, please consider reviewing this list of ways to contribute instead of working on new code contributions: \n https://docs.openverse.org/meta/maintainer_tasks.html"
             }


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This is a follow-up to #3657 - apparently the folded block syntax `>` [is not supported on GitHub Actions](https://github.com/actions/runner/issues/418#issuecomment-612928525). 

I observed this in #3699 due to this failed run: https://github.com/WordPress/openverse/actions/runs/7634210058/job/20797766111?pr=3699 (I don't think we had a run since merging #3657 that pinged someone yet).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

We can't test this, but since it's just concatenating into one big line, hopefully it should just work.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
