### PR TITLE
Remove sentry exception capture for thumbnail errors

### DIFF
--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 from dataclasses import dataclass
 from typing import Literal
@@ -23,8 +22,6 @@ from api.utils.tallies import get_monthly_timestamp
 
 
 parent_logger = logging.getLogger(__name__)
-
-exception_iterator = itertools.count()
 
 HEADERS = {
     "User-Agent": settings.OUTBOUND_USER_AGENT_TEMPLATE.format(

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -10,11 +10,9 @@ from rest_framework.exceptions import UnsupportedMediaType
 
 import aiohttp
 import django_redis
-import sentry_sdk
 from aiohttp.client_exceptions import ClientResponseError
 from asgiref.sync import sync_to_async
 from redis.exceptions import ConnectionError
-from sentry_sdk import push_scope, set_context
 
 from api.utils.aiohttp import get_aiohttp_session
 from api.utils.asyncio import do_not_wait_for
@@ -192,28 +190,10 @@ async def get(
         exception_name = f"{exc.__class__.__module__}.{exc.__class__.__name__}"
         key = f"thumbnail_error:{exception_name}:{domain}:{month}"
         try:
-            count = await tallies_incr(key)
+            await tallies_incr(key)
         except ConnectionError:
             logger.warning("Redis connect failed, thumbnail errors not tallied.")
-            # We will use a counter to space out Sentry logs.
-            count = next(exception_iterator)
 
-        if count <= settings.THUMBNAIL_ERROR_INITIAL_ALERT_THRESHOLD or (
-            count % settings.THUMBNAIL_ERROR_REPEATED_ALERT_FREQUENCY == 0
-        ):
-            with push_scope() as scope:
-                set_context(
-                    "upstream_url",
-                    {
-                        "url": upstream_url,
-                        "params": params,
-                        "headers": headers,
-                    },
-                )
-                scope.set_tag(
-                    "occurrences", settings.THUMBNAIL_ERROR_REPEATED_ALERT_FREQUENCY
-                )
-                sentry_sdk.capture_exception(exc)
         if isinstance(exc, ClientResponseError):
             status = exc.status
             do_not_wait_for(

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -15,11 +15,3 @@ PHOTON_ENDPOINT = config("PHOTON_ENDPOINT", default="https://i0.wp.com/")
 # to cast them in assertions to match the parsed param types)
 THUMBNAIL_WIDTH_PX = config("THUMBNAIL_WIDTH_PX", default="600")
 THUMBNAIL_QUALITY = config("THUMBNAIL_JPG_QUALITY", default="80")
-
-THUMBNAIL_ERROR_INITIAL_ALERT_THRESHOLD = config(
-    "THUMBNAIL_ERROR_INITIAL_ALERT_THRESHOLD", default=100, cast=int
-)
-
-THUMBNAIL_ERROR_REPEATED_ALERT_FREQUENCY = config(
-    "THUMBNAIL_ERROR_REPEATED_ALERT_FREQUENCY", default=1000, cast=int
-)

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -331,18 +331,8 @@ def test_get_successful_records_response_code(
 
 
 alert_count_params = pytest.mark.parametrize(
-    "count_start, should_alert",
-    [
-        (0, True),
-        (1, True),
-        (50, True),
-        (99, True),
-        (100, False),
-        (999, True),
-        (1000, False),
-        (1500, False),
-        (1999, True),
-    ],
+    "count_start",
+    [0, 1, 50, 99, 100, 999, 1000, 1500, 1999],
 )
 
 MOCK_CONNECTION_KEY = ConnectionKey(
@@ -385,7 +375,6 @@ def test_get_exception_handles_error(
     exc,
     exc_name,
     count_start,
-    should_alert,
     sentry_capture_exception,
     setup_request_exception,
     is_cache_reachable,
@@ -409,12 +398,7 @@ def test_get_exception_handles_error(
     ):
         photon_get(TEST_MEDIA_INFO)
 
-    assert_func = (
-        sentry_capture_exception.assert_called_once
-        if should_alert
-        else sentry_capture_exception.assert_not_called
-    )
-    assert_func()
+    sentry_capture_exception.assert_not_called()
 
     if is_cache_reachable:
         assert cache.get(key) == str(count_start + 1).encode()
@@ -438,7 +422,6 @@ def test_get_http_exception_handles_error(
     status_code,
     text,
     count_start,
-    should_alert,
     sentry_capture_exception,
     is_cache_reachable,
     cache_name,
@@ -459,12 +442,7 @@ def test_get_http_exception_handles_error(
             pook.get(PHOTON_URL_FOR_TEST_IMAGE).reply(status_code, text)
             photon_get(TEST_MEDIA_INFO)
 
-    assert_func = (
-        sentry_capture_exception.assert_called_once
-        if should_alert
-        else sentry_capture_exception.assert_not_called
-    )
-    assert_func()
+    sentry_capture_exception.assert_not_called()
 
     if is_cache_reachable:
         assert cache.get(key) == str(count_start + 1).encode()

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -1,7 +1,5 @@
 import asyncio
-import itertools
 from dataclasses import replace
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -332,7 +330,7 @@ def test_get_successful_records_response_code(
 
 alert_count_params = pytest.mark.parametrize(
     "count_start",
-    [0, 1, 50, 99, 100, 999, 1000, 1500, 1999],
+    [0, 1, 999],
 )
 
 MOCK_CONNECTION_KEY = ConnectionKey(
@@ -390,12 +388,7 @@ def test_get_exception_handles_error(
     if is_cache_reachable:
         cache.set(key, count_start)
 
-    with (
-        pytest.raises(UpstreamThumbnailException),
-        patch(
-            "api.utils.image_proxy.exception_iterator", itertools.count(count_start + 1)
-        ),
-    ):
+    with pytest.raises(UpstreamThumbnailException):
         photon_get(TEST_MEDIA_INFO)
 
     sentry_capture_exception.assert_not_called()
@@ -435,9 +428,7 @@ def test_get_http_exception_handles_error(
     if is_cache_reachable:
         cache.set(key, count_start)
 
-    with pytest.raises(UpstreamThumbnailException), patch(
-        "api.utils.image_proxy.exception_iterator", itertools.count(count_start + 1)
-    ):
+    with pytest.raises(UpstreamThumbnailException):
         with pook.use():
             pook.get(PHOTON_URL_FOR_TEST_IMAGE).reply(status_code, text)
             photon_get(TEST_MEDIA_INFO)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3708 by @aetherunbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR removes the Sentry-shipping of errors that occur in thumbnails on the API. It also removes settings related to that effect.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out this branch and add the following diff:

```diff
diff --git a/api/api/utils/image_proxy/__init__.py b/api/api/utils/image_proxy/__init__.py
index af8cd65c7..37c85a080 100644
--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -162,6 +162,7 @@ async def get(
 
     try:
         session = await get_aiohttp_session()
+        raise ValueError("Whoops!")
 
         upstream_response = await session.get(
             upstream_url,
```

2. Add the `SENTRY_DSN` environment variable to point to Sentry.
3. Run `just api/init` and then navigate to http://localhost:50270/v1/images/5c173952-6a45-4380-b9e4-c935263730ab/thumb/
4. Observe the error
5. Run `just docker/cache/cli -n 3`, then `KEYS thumbnail_error:builtins.ValueError*` and observe that a key is present in the tally database
6. Observe that no Sentry alert has been raised


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
