### PR TITLE
Prevent real network requests in TLS cleanup test

### DIFF
--- a/ingestion_server/justfile
+++ b/ingestion_server/justfile
@@ -99,6 +99,9 @@ create-and-populate-filtered-index model="image" destination_suffix="init":
 
 # Run ingestion-server tests locally
 test-local *args:
+    # populate the tldextract cache before running tests to prevent unnecessary network requests during tests
+    # and from needing to mock essentially unmockable responses
+    pipenv run tldextract --update
     pipenv run pytest {{ args }}
     {{ if IS_CI == "" { "just test-logs > test/ingestion_logs.txt && just test-clean-dc" } else { "" } }}
 

--- a/ingestion_server/test/unit_tests/test_cleanup.py
+++ b/ingestion_server/test/unit_tests/test_cleanup.py
@@ -1,8 +1,7 @@
-from unittest.mock import MagicMock
-
+import pook
 from psycopg2._json import Json
 
-from ingestion_server.cleanup import CleanupFunctions, TlsTest
+from ingestion_server.cleanup import CleanupFunctions
 from test.unit_tests.conftest import create_mock_image
 
 
@@ -42,14 +41,16 @@ class TestCleanup:
         assert result == expected
 
     @staticmethod
+    @pook.on
     def test_url_protocol_fix():
         bad_url = "flickr.com"
         tls_support_cache = {}
+        pook.get("https://flickr.com").reply(200)
         result = CleanupFunctions.cleanup_url(bad_url, tls_support_cache)
         expected = "'https://flickr.com'"
 
         bad_http = "neverssl.com"
-        TlsTest.test_tls_supported = MagicMock(return_value=False)
+        pook.get("https://neverssl.com").reply(500)
         result_http = CleanupFunctions.cleanup_url(bad_http, tls_support_cache)
         expected_http = "'http://neverssl.com'"
         assert result == expected


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes flaky failure present in https://github.com/WordPress/openverse/actions/runs/7699638405/job/20983733877

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The flakiness is caused by making real outbound network requests and relying on Flickr responding with a success status code. If Flickr is down, or anything else causes Flickr to not respond with a success (unrelated to our SSL testing method) the test fails in a flaky way.

This change prevents those outbound requests entirely.

Marked critical in line with the flaky test policy.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The updated test should pass CI.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
