### PR TITLE
Remove codeowners validator from pre-commit

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -125,6 +125,19 @@ jobs:
           just precommit
           just lint
 
+  validate-codeowners:
+    name: Validate CODEOWNERS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,duppatterns,syntax"
+          experimental_checks: "notowned,avoid-shadowing"
+
   add-stack-label:
     name: Add stack label
     if: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,14 +157,3 @@ repos:
       - id: renovate-config-validator
         args:
           - --strict
-
-  - repo: local
-    hooks:
-      - id: codeowners-validator
-        name: CODEOWNERS validator
-        language: docker_image
-        pass_filenames: false
-        entry: >
-          -e REPOSITORY_PATH="."
-          -e CHECKS="files,duppatterns,syntax"
-          ghcr.io/mszostok/codeowners-validator:v0.7.4

--- a/documentation/meta/ci_cd/jobs/preparation.md
+++ b/documentation/meta/ci_cd/jobs/preparation.md
@@ -45,6 +45,31 @@ Runs the linting steps defined in the repository's
 [pre-commit configuration](https://github.com/WordPress/openverse/blob/main/.pre-commit-config.yaml).
 This is executed via `just lint`.
 
+## `validate-codeowners`
+
+This job should be considered a complement to `lint` and would ideally be part
+of it, as a pre-commit hook. However, the docker image we relied on for the
+pre-commit hook causes issues with arm64 computers (which includes recent Apply
+devices). Therefore, we run the hook as a CI step instead.
+
+It is still possible to run this hook locally, assuming the docker image works
+on your computer's architecture, by invoking the `lint-codeowners` just recipe:
+
+```bash
+just lint-codeowners
+```
+
+````{tip}
+In CI we run the set of "experimental" checks as well, which are disabled
+in the just recipe because they fail if there are uncommitted changes.
+To run precisely the check that CI uses, enable experimental checks:
+
+```bash
+just lint-codeowners all
+```
+
+````
+
 ## `add-stack-label`
 
 ```{note}

--- a/justfile
+++ b/justfile
@@ -92,6 +92,17 @@ precommit:
 lint hook="" *files="": precommit
     python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files" } }}  {{ files }}
 
+# Run codeowners validator locally. Only enable experimental hooks if there are no uncommitted changes.
+lint-codeowners checks="stable":
+    docker run --rm \
+        -u 1000:1000 \
+        -v $PWD:/src:rw,Z \
+        --workdir=/src \
+        -e REPOSITORY_PATH="." \
+        -e CHECKS="files,duppaterns,syntax" \
+        {{ if checks != "stable" { "-e EXPERIMENTAL_CHECKS='notowned,avoid-shadowing'" } else { "" } }} \
+        ghcr.io/mszostok/codeowners-validator:v0.7.4
+
 ########
 # Init #
 ########


### PR DESCRIPTION

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes and issue reported by @dhruvkb and @stacimc they had running the pre-commit hook on their local machines.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The docker image has issues running on arm64, so we will instead run it in CI using the GitHub action, with an utility just recipe to run the same checks locally as needed.

I also updated the CI/CD documentation to explain the new job and document the `lint-codeowners` recipe.'

Marked high because it is affecting the ability for folks to work on the codebase without this tedious interruption.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass with the new job and the `just lint-codeowners` recipe should work, including `just lint-codeowners all` to enable the experimental checks.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
