### PR TITLE
Remove `edited` type from PR automation init review trigger, enable concurrency

### DIFF
--- a/.github/workflows/pr_automations_init.yml
+++ b/.github/workflows/pr_automations_init.yml
@@ -33,6 +33,9 @@ on:
       - submitted
       - dismissed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.node_id }}
+
 jobs:
   run:
     name: Save event info

--- a/.github/workflows/pr_automations_init.yml
+++ b/.github/workflows/pr_automations_init.yml
@@ -24,11 +24,13 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - converted_to_draft
       - ready_for_review
       - closed
   pull_request_review:
+    types:
+      - submitted
+      - dismissed
 
 jobs:
   run:

--- a/.github/workflows/pr_automations_init.yml
+++ b/.github/workflows/pr_automations_init.yml
@@ -24,6 +24,7 @@ on:
     types:
       - opened
       - reopened
+      - edited
       - converted_to_draft
       - ready_for_review
       - closed


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3770 by @AetherUnbound (hopefully, hard to know ahead of time)

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

**Update**: This PR now only removes `edited` from the `pull_request_review` trigger type. It also adds a concurrency limit, per @dhruvkb's suggestion: https://github.com/WordPress/openverse/pull/3771#issuecomment-1935349558

This PR removes the `edited` type from both the `pull_request` and `pull_request_review` workflow triggers for the PR automation init workflow. I suspect that this particular trigger is unnecessary for any of the actions we actually want to take when the workflow is triggered. It also makes debugging difficult. When looking at the init run history, it's hard to tell which events actually triggered the run in some cases:

![image](https://github.com/WordPress/openverse/assets/10214785/ddcf834f-4cf8-4d7f-991a-d165f9801b75)

I'm hoping that this somehow addresses the issue for why the PR automation was seemingly triggered in some cases and not others, as perhaps there was a race condition between `edited` and `closed`.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Merge and find out!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
