### PR TITLE
Fix newline at end of folded env variable string and prevent confusing skips of the changelog PRs

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -29,13 +29,9 @@ jobs:
       # Needed to open the changelog PR
       pull-requests: write
     env:
-      APP_NAME: >-
-        ${{
-          startsWith(github.ref_name, 'api-') && 'api'
-          || startsWith(github.ref_name, 'ingestion_server-') && 'ingestion_server'
-          || startsWith(github.ref_name, 'catalog-') && 'catalog'
-          || startsWith(github.ref_name, 'frontend-') && 'frontend'
-        }}
+      # Do not split this into multiple lines, it will not work:
+      # https://github.com/WordPress/openverse/pull/3789#pullrequestreview-1876525552
+      APP_NAME: ${{ startsWith(github.ref_name, 'api-') && 'api' || startsWith(github.ref_name, 'ingestion_server-') && 'ingestion_server' || startsWith(github.ref_name, 'catalog-') && 'catalog' || startsWith(github.ref_name, 'frontend-') && 'frontend' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed to open the changelog PR
       pull-requests: write
     env:
-      APP_NAME: >
+      APP_NAME: >-
         ${{
           startsWith(github.ref_name, 'api-') && 'api'
           || startsWith(github.ref_name, 'ingestion_server-') && 'ingestion_server'

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -122,14 +122,13 @@ jobs:
 
       - name: Open changelog PR
         uses: peter-evans/create-pull-request@v5
-        if: "!cancelled()"
         with:
           # Access token necessary for PRs to run with CI
           token: ${{ secrets.ACCESS_TOKEN }}
           base: main
-          branch: changelog/${{ steps.tag.outputs.git-tag }}
-          commit-message: Publish changelog for ${{ steps.tag.outputs.git-tag }}
-          title: Publish changelog for ${{ steps.tag.outputs.git-tag }}
+          branch: changelog/${{ github.ref_name }}
+          commit-message: Publish changelog for ${{ github.ref_name }}
+          title: Publish changelog for ${{ github.ref_name }}
           # Add labels to pass CI
           labels: |
             🧱 stack: ${{ env.APP_NAME == 'ingestion_server' && 'ingestion server' || env.APP_NAME }}


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/actions/runs/7879001320/job/21498432707

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Releases currently fail to complete due to the `env.APP_NAME` having a newline at the end of the string: https://github.com/WordPress/openverse/actions/runs/7879001320/job/21498432707

Converting it to a single line is necessary because, as Madison pointed out, you cannot use a chomped multiline string (`>-`) in GitHub actions.

This PR also fixes the changelog PR step to only run if the rest of the workflow completes and to use the correct variable in place of `git-tag`. I searched for other usages of `git-tag` to be sure and those were the last remaining ones.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Confirm the change will work as expected based on the information about yaml multiline strings in the linked documentation.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [N/A] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
