### PR TITLE
Prevent creation of `.md-e` files in the docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,15 @@ repos:
         entry: bash -c 'if [ ! -f "$(dirname "$dir")"/frontend/src/locales/ar.json ]; then just frontend/run i18n; fi'
         language: system
         pass_filenames: false
+
+      # Replace ```console code block with ```bash in our documentation
       - id: fix-console-code-block
         name: Ensure "bash" code block is used over "console"
         files: ^documentation/.*\.md$
-        # Check that we are not using the ```console block in our documentation
-        # -R recursively checks files
-        # -l suppresses normal input and only lists files with errors
-        # Print an error message if any files are found
-        entry: sed -i -e 's/```console/```bash/g'
+        # -i: edit in place (no argument means no backup)
+        # -p: loop over all files provided, print error message if file cannot be opened
+        # -e: use the code provided inline
+        entry: perl -i -pe 's/```console/```bash/g'
         language: system
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/ingestion_server/test/update_mocks.sh
+++ b/ingestion_server/test/update_mocks.sh
@@ -22,12 +22,12 @@ docker run \
 		EOF
 
 # Remove search path so we can refer to the public schema implicitly
-sed -i "" '/search_path/d' mock_schemas/image.sql
-sed -i "" '/search_path/d' mock_schemas/audio.sql
-sed -i "" '/search_path/d' mock_schemas/audioset.sql
-sed -i "" '/search_path/d' mock_schemas/image_view.sql
-sed -i "" '/search_path/d' mock_schemas/audio_view.sql
-sed -i "" '/search_path/d' mock_schemas/audioset_view.sql
+perl -i -pe '/search_path/d' mock_schemas/image.sql
+perl -i -pe '/search_path/d' mock_schemas/audio.sql
+perl -i -pe '/search_path/d' mock_schemas/audioset.sql
+perl -i -pe '/search_path/d' mock_schemas/image_view.sql
+perl -i -pe '/search_path/d' mock_schemas/audio_view.sql
+perl -i -pe '/search_path/d' mock_schemas/audioset_view.sql
 
 # Select some media samples and export them to CSV
 docker run \


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Currently the pre-commit lint step uses `sed` to ensure that we do not use ```` ```console ```` in the documentation and instead replace it with ```` ```bash ````.

The `sed` command works for Linux but is interpreted differently on macOS where `-i -e` is interpreted as `-i='-e'` and causes `.md-e` files to to be created for every documentation file when linting using `just lint`. Using `perl` can avoid this problem as that approach is cross-platform (provided `perl` is installed, which is usually is).

This also updates another script that used a similar construct in a different script (with the working and broken operating systems reversed) with `perl`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check that lint step in CI passes.
2. Intentionally change some occurrences of ```` ```bash ```` to ```` ```console ```` in the docs.
3. See that pre-commit does not allow you to commit these mistakes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
