### PR TITLE
Remove the repository specific code of conduct.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,6 @@ utilities/                  @WordPress/openverse-maintainers
 .gitattributes              @WordPress/openverse-maintainers
 .gitignore                  @WordPress/openverse-maintainers
 .pre-commit-config.yaml     @WordPress/openverse-maintainers
-CODE_OF_CONDUCT.md          @WordPress/openverse-maintainers
 CONTRIBUTING.md             @WordPress/openverse-maintainers
 LICENSE                     @WordPress/openverse-maintainers
 README.md                   @WordPress/openverse-maintainers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,0 @@
-Openverse is a WordPress project. As such, we follow the WordPress
-[Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/)
-and [Etiquette](https://wordpress.org/about/etiquette/).
-
-We invite, welcome and encourage everyone to contribute while upholding these
-codes of conduct.

--- a/documentation/general/contributing.md
+++ b/documentation/general/contributing.md
@@ -8,7 +8,7 @@ project.
 ## Code of Conduct
 
 You should read and agree to abide by the
-[code of conduct](https://github.com/WordPress/openverse/blob/main/CODE_OF_CONDUCT.md)
+[code of conduct](https://make.wordpress.org/handbook/community-code-of-conduct/)
 before contributing to WordPress projects. This applies to all Openverse
 repositories because Openverse is a WordPress Foundation project.
 


### PR DESCRIPTION
## Description
This removes the repository specific `CODE_OF_CONDUCT.md` file in favor of the newly added version maintained as the organization's default within the WordPress/.github repository.

While this file will not be included in `git clone`s, it will be displayed on the repository's main page and anywhere else GitHub includes a Code of Conduct link.

This change enables more consistent messaging for the community code of conduct, and allows the file to be updated in one location for all repositories under the WordPress organization.

See https://github.com/WordPress/.github/pull/1.