### PR TITLE
Use correct `BASE_URL` for the API by default

### DIFF
--- a/api/conf/settings/security.py
+++ b/api/conf/settings/security.py
@@ -32,7 +32,7 @@ if DEBUG:
         "0.0.0.0",
     ]
 
-BASE_URL = config("BASE_URL", default="https://openverse.org/")
+BASE_URL = config("BASE_URL", default="https://api.openverse.engineering/")
 
 # Trusted origins for CSRF
 # https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2689 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR updates the default value for `BASE_URL` on the API (which is the value that ends up being used in production) from `openverse.org` to `api.openverse.engineering`. The `BASE_URL` value is used in media reports to construct the item URL, and was constructing an incorrect URL which had the path components of the API but pointed to the frontend. Since this is a computed field, simply deploying this change should correct all the links provided on each of those tables.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Set `BASE_URL=https://openverse.org/` in your `api/.env` file
1. Run `just api/init` to start the API
1. Run `API_URL=http://localhost:50270 just frontend/run dev:only` to start the frontend
1. Navigate to an image result on the frontend, and submit a report
1. Visit http://localhost:50280/admin/api/imagereport/ and observe that the URL shows up as `https://openverse.org/<api-media-url>`, which is incorrect
1. Change the `api/.env` value to be `BASE_URL=http://localhost:50280/`, restart the API, and visit the above page to observe the difference


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
