### PR TITLE
Fix airflow connections

### DIFF
--- a/catalog/dags/common/slack.py
+++ b/catalog/dags/common/slack.py
@@ -307,7 +307,7 @@ def should_send_message(
         log.info(
             f"Skipping Slack notification for {dag_id}:{task_id} in"
             f" `{environment}` environment. To send the notification, enable"
-            " the`SLACK_MESSAGE_OVERRIDE` variable."
+            " the `SLACK_MESSAGE_OVERRIDE` variable."
         )
         return False
 

--- a/catalog/dags/elasticsearch_cluster/shared.py
+++ b/catalog/dags/elasticsearch_cluster/shared.py
@@ -8,4 +8,4 @@ from common.constants import Environment
 @task
 def get_es_host(environment: Environment) -> XComArg:
     conn = Connection.get_connection_from_secrets(f"elasticsearch_http_{environment}")
-    return conn.host
+    return conn.get_uri()

--- a/catalog/entrypoint.sh
+++ b/catalog/entrypoint.sh
@@ -36,7 +36,7 @@ function header() {
 if [ "$1" == help ] || [ "$1" == --help ]; then help_text && exit 0; fi
 sleep 0.1 # The $COLUMNS variable takes a moment to populate
 
-# Reformat Airflow connections that use https
+# Reformat Slack Airflow connections
 header "MODIFYING ENVIRONMENT"
 # Loop through environment variables, relying on naming conventions.
 # Bash loops with pipes occur in a subprocess, so we need to do some special
@@ -57,7 +57,8 @@ while read -r var_string; do
   echo "    New Value: $new_value"
   # set the environment variable
   export "$var_name"="$new_value"
-  # only include airflow connections with http somewhere in the string
-done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=http.*$")
+
+  # only include Slack airflow connections
+done < <(env | grep "^AIRFLOW_CONN_SLACK*")
 
 exec /entrypoint "$@"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Locally, most of our Airflow connections are set via environment variables in `catalog/.env`. In production they are generally set through the Airflow Admin UI. This caused the following issue to be missed in local testing:

We have a script in `entrypoint.sh` which reformats all airflow connection environment variables (containing the string `http`) by urlencoding them and prepending 'http://'. The purpose of this was for convenience with setting up the Slack connections locally (otherwise you have to urlencode part of the Slack uri).

It is not necessary for any of our other connection strings and in fact was causing issues with the Elasticsearch connections -- the reformatted string was not parsed correctly, parsing the entire uri as the `host`.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR:
* modifies the `entrypoint` script to only modify Slack connection strings, so that they will continue to work
* updates the `get_es_host` logic for connecting to Elasticsearch to correctly return the entire URI, rather than just the host (which was previously a workaround for the buggy local behavior, that is not compatible with the connections set in the Admin UI). This should now work for connections set in `.env` AND in the Airflow UI.
* adds some extra logs to slack notifications


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Check out this branch and first verify that the connections as currently set in your local environment still work:
* Run a data refresh. This will test the `data_refresh` and `elasticsearch_http_production` connections
* Run `staging_elasticsearch_cluster_healthcheck` to test the `elasticsearch_http_staging` connection
* Raise an error in a provider DAG somewhere and test that the Slack connections still work

Now re-test, setting the connection variables through the Admin UI. You can delete them from your `.env` and rebuild, or more simply just edit the code in `elasticsearch_cluster/shared.py` and `common/ingestion_server.py` to use new conn_ids (`elasticsearch_test` and `ingestion_server_test`. Then in the airflow UI, navigate to Admin > Connections and add two new connections:

* `ingestion_server_test` (or `data_refresh` if you deleted the local environment variable)
  * Connection Type = `HTTP`
  * Host = `ingestion_server`
  * Schema = `http`
  * Port = `8001`
* `elasticsearch_test`  (or `elasticsearch_http_staging` if you deleted the local environment variable)
  * Connection Type = `HTTP`
  * Host = `es`
  * Schema = **leave this blank**
  * Port = `9200`
* If you deleted the environment variables locally rather than updating the conn_ids to the test connections, you'll have to create an identical connection for `elasticsearch_http_production` as well

Then re-run the data refresh and the `staging_elasticsearch_cluster_healthcheck` and ensure they still work.

**Note that when we merge this we need to drop the 'schema' configuration for the two elasticsearch http connections in productiotn.**  


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
