### PR TITLE
Use infrequent access when uploading provider TSVs

### DIFF
--- a/catalog/dags/common/loader/s3.py
+++ b/catalog/dags/common/loader/s3.py
@@ -42,12 +42,15 @@ def copy_file_to_s3(
     s3_prefix,
     aws_conn_id,
     ti,
+    extra_args=None,
 ):
     """
     Copy a TSV file to S3 with the given prefix.
     The TSV's version is pushed to the `tsv_version` XCom, and the constructed
     S3 key is pushed to the `s3_key` XCom.
     The TSV is removed after the upload is complete.
+
+    ``extra_args`` refers to the S3Hook argument.
     """
     if tsv_file_path is None:
         raise FileNotFoundError("No TSV file path was provided")
@@ -57,7 +60,10 @@ def copy_file_to_s3(
     tsv_version = paths.get_tsv_version(tsv_file_path)
     s3_key = f"{s3_prefix}/{tsv_file.name}"
     logger.info(f"Uploading {tsv_file_path} to {s3_bucket}:{s3_key}")
-    s3 = S3Hook(aws_conn_id=aws_conn_id)
+    s3 = S3Hook(
+        aws_conn_id=aws_conn_id,
+        extra_args=extra_args or {},
+    )
     s3.load_file(tsv_file_path, s3_key, bucket_name=s3_bucket)
     ti.xcom_push(key="tsv_version", value=tsv_version)
     ti.xcom_push(key="s3_key", value=s3_key)

--- a/catalog/dags/providers/provider_dag_factory.py
+++ b/catalog/dags/providers/provider_dag_factory.py
@@ -230,6 +230,9 @@ def create_ingestion_workflow(
                             else None,
                         ),
                         "aws_conn_id": AWS_CONN_ID,
+                        "extra_args": {
+                            "StorageClass": conf.s3_tsv_storage_class,
+                        },
                     },
                     trigger_rule=TriggerRule.NONE_SKIPPED,
                 )

--- a/catalog/dags/providers/provider_workflows.py
+++ b/catalog/dags/providers/provider_workflows.py
@@ -166,6 +166,25 @@ class ProviderWorkflow:
     tags: list[str] = field(default_factory=list)
     overrides: list[TaskOverride] = field(default_factory=list)
 
+    # Set when the object is uploaded, even though we access the object later in
+    # the DAG. IA incurs additional retrieval fees per request, unlike plain
+    # standard storage. However, as of writing, that costs 0.001 USD (1/10th of
+    # a US cent) per 1k requests. In other words, a minuscule amount, considering
+    # we will access the object once later in the DAG, to upsert it to the DB,
+    # and then in all likelihood never access it again.
+    # Even if we did, and had to pay the retrieval fee, we would still come out
+    # ahead on storage costs, because IA is so much less expensive than regular
+    # storage. We could set the storage class in a later task in the DAG, to
+    # avoid the one time retrieval fee. However, that adds complexity to the DAG
+    # that we can avoid by eagerly setting the storage class early, and the actual
+    # savings would probably be nil, factoring in the time spent in standard storage
+    # incurring standard storage costs. If it absolutely needs to be rationalised,
+    # consider the amount of energy spent on the extra request to S3 to update the
+    # storage cost to try to get around a retrieval fee (which, again, will not
+    # actually cost more, all things considered). Saving that energy could melt
+    # the glaciers all that much more slowly.
+    s3_tsv_storage_class: str = "STANDARD_IA"
+
     def _get_module_info(self):
         # Get the module the ProviderDataIngester was defined in
         provider_script = inspect.getmodule(self.ingester_class)
@@ -186,11 +205,29 @@ class ProviderWorkflow:
         if not self.doc_md:
             self.doc_md = provider_script.__doc__
 
-        # Check for custom configuration overrides, which will be applied when
-        # the DAG is generated.
+        self._process_configuration_overrides()
+
+    def _process_configuration_overrides(self):
+        """
+        Check for and apply custom configuration overrides.
+
+        These are only applied when the DAG is generated.
+        """
+
+        # Provider-specific configuration overrides
         self.overrides = Variable.get(
             "CONFIGURATION_OVERRIDES", default_var={}, deserialize_json=True
         ).get(self.dag_id, [])
+
+        # Allow forcing the default to something other than `STANDARD_IA`
+        # Primarily meant for use in local development where minio is used
+        # which does not support all AWS storage classes
+        # https://github.com/minio/minio/issues/5469
+        # This intentionally applies to all providers, rather than the provider-specific
+        # overrides above
+        self.s3_tsv_storage_class = Variable.get(
+            "DEFAULT_S3_TSV_STORAGE_CLASS", default_var=self.s3_tsv_storage_class
+        )
 
 
 PROVIDER_WORKFLOWS = [

--- a/catalog/env.template
+++ b/catalog/env.template
@@ -68,7 +68,7 @@ S3_LOCAL_ENDPOINT=http://s3:5000
 # value so that the expected behaviour can be verified (specifically, that the storage
 # class is not the default "STANDARD")
 # https://github.com/minio/minio/issues/5469
-AIRFLOW_VAR_DEFAULT_S3_TSV_STORAGE_CLASS="REDUCED_REDUNDANCY"
+AIRFLOW_VAR_DEFAULT_S3_TSV_STORAGE_CLASS=REDUCED_REDUNDANCY
 
 # Connection to the Ingestion Server, used for managing data refreshes. Default is used to
 # connect to your locally running ingestion server.

--- a/catalog/env.template
+++ b/catalog/env.template
@@ -63,6 +63,12 @@ AIRFLOW_CONN_SLACK_NOTIFICATIONS=https://slack
 AIRFLOW_CONN_SLACK_ALERTS=https://slack
 
 S3_LOCAL_ENDPOINT=http://s3:5000
+# Set to a non-default value supported by minio in local development to workaround
+# Minio's lack of support for all AWS storage classes, while still using a non-default
+# value so that the expected behaviour can be verified (specifically, that the storage
+# class is not the default "STANDARD")
+# https://github.com/minio/minio/issues/5469
+AIRFLOW_VAR_DEFAULT_S3_TSV_STORAGE_CLASS="REDUCED_REDUNDANCY"
 
 # Connection to the Ingestion Server, used for managing data refreshes. Default is used to
 # connect to your locally running ingestion server.

--- a/catalog/tests/dags/providers/test_provider_workflows.py
+++ b/catalog/tests/dags/providers/test_provider_workflows.py
@@ -91,6 +91,7 @@ def test_overrides(configuration_overrides, expected_overrides):
     with mock.patch("providers.provider_workflows.Variable") as MockVariable:
         MockVariable.get.side_effect = [
             configuration_overrides,
+            MockVariable.get_original()[0],
         ]
         test_workflow = ProviderWorkflow(
             dag_id="my_dag_id",

--- a/justfile
+++ b/justfile
@@ -200,6 +200,10 @@ init:
 down *flags:
     just dc down {{ flags }}
 
+# Take all services down then call the specified app's up recipe. ex.: `just dup catalog` is useful for restarting the catalog with new environment variables
+dup app:
+    just down && just {{ app }}/up
+
 # Recreate all volumes and containers from scratch
 recreate:
     just down -v


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #1787 by @obulat 

This does not close the issue, as we still need to run the s3 command noted in the issue to backfill the storage class onto all existing objects.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Updates the provider ingestion workflow DAG to use the standard infrequent access storage class for provider TSVs.

I've documented the rationale behind setting the storage class eagerly, despite immediately accessing it, in the code. I really do not think it makes any sense at all to use a new task to set the storage class down to IA after the DAG is finished, and despite the 10th of a US penny spent on the retrieval fee, we will still save >99.99% of the money we. I really think the difference is incalculable and not worth the code complexity. The note about increased energy usage of an additional task (and all the requests it would need to send) helps further justify the fact, even though it doesn't save on our AWS bill.

The configuration is stored on the provider workflow, to allow for theoretical flexibility in setting different storage classes for different providers. We could use single-zone storage for non-dated DAGs, for example, as we always recreate the data 100% of the time on every DAG run, so it wouldn't present an issue if we needed to fully reload that provider's data if the AZ holding the data failed or went temporarily offline.

This does not close the issue, as we still need to run the s3 command noted in the issue to backfill the storage class onto all existing objects.

I also did not bother changing the storage class for staging objects because (a) the loader workflow DAG is retired and (b) those are immediately deleted when the DAG is successfully anyway.

As noted in `env.template` and the provider ingestion configuration data class, minio does not support the AWS storage classes aside from `STANDARD` (the default). Therefore, our local environments need to use a different non-default value. The testing instructions below describe how to verify the behaviour.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
There are two things to verify in this PR:
1. That the non-default storage class is used by the DAG
2. That the local environment is able to pass by using a non-standard storage class compatible with Minio.

For both of these, we'll run the wikimedia commons ingestion workflow, as it's the easiest to work with. For all these steps, we will follow this basic pattern:

1. Run the Wikimedia DAG
2. Allow the `load_mixed` task to pull data until it logs `x records retrieved` (usually 160)
3. Mark `load_mixed` as successful
4. Observe the behaviour of `copy_to_s3` (either success or failure, depending on the cases outlined below)
5. Observe the final result of the DAG (success or failure, as above)
6. In cases where we expect a success of the local run, confirm the value in Minio

Log in to your local minio at http://0.0.0.0:5011/ using `test_key` and `test_secret` as the username and password respectively.

First, test the behaviour on main, so that you understand what the existing behaviour here is. In short, because the storage class is not specified in our API call to s3, the default is used. For both minio and AWS, this is the "STANDARD" storage class. Run the Wikimedia DAG on `main` and confirm in minio that the uploaded TSV has the "STANDARD" storage class. Minio does not explicitly list the storage class of an object if it is the default. This is reliable behaviour, as you will see later. If you absolutely want to confirm the storage class of the object, download the "inspect" zip (disable encryption) and open the `xl.meta` file for the TSV inside the zip, and confirm that the string `x-amz-storage-classšSTANDARD` is present in the file.

![Screenshot showing standard storage class in the meta.xl file for the uploaded TSV](https://github.com/WordPress/openverse/assets/24264157/ca2b56bb-e863-49d2-ada7-2ab5a66803f3)

Now that you understand the behaviour on main, checkout the branch, and copy `env.template` to `.env` OR (if you don't want to override your `.env` entirely) copy the new `AIRFLOW_VAR_DEFAULT_S3_TSV_STORAGE_CLASS` variable into your .env. Run `just dup catalog` to get the new environment variable in.

Follow the steps above to run the Wikimedia DAG to completion, and expect a successful run. Navigate to the TSV in minio, click on it, and then scroll to the bottom of the sidebar to view the "Metadata" section, and confirm you see `REDUCED_REDUNDANCY` as the storage class:

![Minio dashboard showing non-default storage class](https://github.com/WordPress/openverse/assets/24264157/4c380676-465b-46cd-b0fc-0009e837b129)

This confirms that the DAG is sending the storage class with the load_file operation as expected. However, we must confirm that the `STANDARD_IA`, set as default in the code, is used when the Airflow variable isn't present. The variable is currently only meant for testing, though it could be used in the future to avoid a code change if we need to temporarily set the storage class to something else. However, we must ensure that the DAG uses `STANDARD_IA` by default.

To do this, comment out `AIRFLOW_VAR_DEFAULT_S3_TSV_STORAGE_CLASS` from your catalog .env file, and run `just dup catalog` to refresh the environment variable. At this point, if you ran the Wikimedia DAG you would see `copy_to_s3` fail on an error of invalid storage class. This is because Minio does not support `STANDARD_IA` and returns an error during upload. However, it does not specify which storage class is used. You may do so by adding the following code to the top of `copy_file_to_s3`:

```py
import json
logger.error(json.dumps(extra_args))
```

That way, when you run the DAG, the logs for `copy_to_s3` will show the storage class passed to the hook so you can confirm it is `STANDARD_IA` instead of some other value.

In this case, there will be nothing to confirm in Minio, as it will have rejected the upload due to the invalid storage class.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
