### PR TITLE
Turn analytics composable into a plugin

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -146,6 +146,7 @@ const config: NuxtConfig = {
     "~/plugins/api-token.server.ts",
     "~/plugins/polyfills.client.ts",
     "~/plugins/sentry.ts",
+    "~/plugins/analytics.ts",
   ],
   css: ["~/assets/fonts.css", "~/styles/tailwind.css", "~/styles/accent.css"],
   head,

--- a/frontend/src/composables/use-analytics.ts
+++ b/frontend/src/composables/use-analytics.ts
@@ -1,5 +1,11 @@
 import { useContext } from "@nuxtjs/composition-api"
 
+/**
+ * This wrapper around the plugin, retained to reduce code churn.
+ * @see Refer to frontend/src/plugins/analytics.ts for plugin implementation
+ *
+ * @deprecated For new code, use `$sendCustomEvent` from Nuxt context
+ */
 export const useAnalytics = () => {
   const { $sendCustomEvent } = useContext()
 

--- a/frontend/src/composables/use-analytics.ts
+++ b/frontend/src/composables/use-analytics.ts
@@ -1,68 +1,7 @@
-import { computed, onMounted } from "vue"
 import { useContext } from "@nuxtjs/composition-api"
 
-import type { Events, EventName } from "~/types/analytics"
-import { useUiStore } from "~/stores/ui"
-import { useFeatureFlagStore } from "~/stores/feature-flag"
-
-import { log } from "~/utils/console"
-
-/**
- * The `ctx` parameter must be supplied if using this composable outside the
- * bounds of the composition API.
- */
 export const useAnalytics = () => {
-  const { $plausible } = useContext()
-  const uiStore = useUiStore()
-  const featureFlagStore = useFeatureFlagStore()
+  const { $sendCustomEvent } = useContext()
 
-  onMounted(() => {
-    featureFlagStore.syncAnalyticsWithLocalStorage()
-  })
-
-  /**
-   * the Plausible props that work identically on the server-side and the
-   * client-side; This excludes props that need `window`.
-   */
-  const isomorphicProps = computed(() => ({
-    breakpoint: uiStore.breakpoint,
-  }))
-
-  /**
-   * the Plausible props that work only on the client-side; This only includes
-   * props that need `window`.
-   */
-  const windowProps = computed(() =>
-    window
-      ? {
-          width: window.innerWidth,
-          height: window.innerHeight,
-        }
-      : {}
-  )
-
-  /**
-   * Send a custom event to Plausible. Mandatory props are automatically merged
-   * with the event-specific props.
-   *
-   * @param name - the name of the event being recorded
-   * @param payload - the additional information to record about the event
-   */
-  const sendCustomEvent = <T extends EventName>(
-    name: T,
-    payload: Events[T]
-  ) => {
-    log(`Analytics event: ${name}`, payload)
-    $plausible.trackEvent(name, {
-      props: {
-        ...isomorphicProps.value,
-        ...windowProps.value,
-        ...payload,
-      },
-    })
-  }
-
-  return {
-    sendCustomEvent,
-  }
+  return { sendCustomEvent: $sendCustomEvent }
 }

--- a/frontend/src/plugins/analytics.ts
+++ b/frontend/src/plugins/analytics.ts
@@ -1,0 +1,45 @@
+import type { Events, EventName } from "~/types/analytics"
+import { useUiStore } from "~/stores/ui"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
+
+import { log } from "~/utils/console"
+
+import type { Plugin } from "@nuxt/types"
+
+type SendCustomEvent = <T extends EventName>(
+  name: T,
+  payload: Events[T]
+) => void
+
+declare module "@nuxt/types" {
+  interface Context {
+    $sendCustomEvent: SendCustomEvent
+  }
+}
+
+export default (function analyticsPlugin(context, inject) {
+  if (process.server) {
+    // Inject a noop on the server, as vue-plausible does not support SSR
+    inject("sendCustomEvent", (() => {}) as SendCustomEvent)
+    return
+  }
+
+  const uiStore = useUiStore(context.$pinia)
+  const featureFlagStore = useFeatureFlagStore(context.$pinia)
+
+  featureFlagStore.syncAnalyticsWithLocalStorage()
+
+  const sendCustomEvent: SendCustomEvent = (name, payload) => {
+    log(`Analytics event: ${name}`, payload)
+    context.$plausible.trackEvent(name, {
+      props: {
+        breakpoint: uiStore.breakpoint,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        ...payload,
+      },
+    })
+  }
+
+  inject("sendCustomEvent", sendCustomEvent)
+} satisfies Plugin)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

A pre-requisite for https://github.com/WordPress/openverse/pull/3721

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Convert the `useAnalytics` composable into a plugin. I've chosen to take an approach where the composable still exists, but just acts as a thin wrapper around `$sendCustomEvent` from the new plugin. This (a) reduces code churn and (b) allows us to confirm that the change behaves exactly as we expected the previous version to behave. All tests asserting against the analytics events continue to work without changes.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
All Playwright and unit tests should continue to pass without changes.

Furthermore, to confirm absolutely that the `breakpoint`, `height` and `width` variables still work as expected, run Plausible locally using `just frontend/up` followed by `just frontend/init` to get the custom events loaded. Then visit frontend through the Nginx container at http://0.0.0.0:50290

Perform a search and confirm that the three default props (listed above) match the expected values based on the viewport of your browser. Make multiple searches with different viewport sizes, especially making sure to trigger different breakpoints, and confirm that those events have the correct values.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
