### PR TITLE
Make User-Agent a default header

### DIFF
--- a/catalog/dags/common/loader/provider_details.py
+++ b/catalog/dags/common/loader/provider_details.py
@@ -124,7 +124,8 @@ SMITHSONIAN_SUB_PROVIDERS = {
 
 # User-Agent header for APIs that require it
 CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
-UA_STRING = f"Openverse/0.1 (https://wordpress.org/openverse; {CONTACT_EMAIL})"
+CANONICAL_ORIGIN = os.getenv("CANONICAL_ORIGIN", "https://openverse.org")
+UA_STRING = f"Openverse/0.1 ({CANONICAL_ORIGIN}; {CONTACT_EMAIL})"
 
 
 # Available Image Categories for API

--- a/catalog/dags/common/loader/provider_details.py
+++ b/catalog/dags/common/loader/provider_details.py
@@ -124,7 +124,12 @@ SMITHSONIAN_SUB_PROVIDERS = {
 
 # User-Agent header for APIs that require it
 CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
-CANONICAL_ORIGIN = os.getenv("CANONICAL_ORIGIN", "https://openverse.org")
+
+CANONICAL_DOMAIN: str = os.getenv("CANONICAL_DOMAIN", "openverse.org")
+
+_proto = "http" if "localhost" in CANONICAL_DOMAIN else "https"
+CANONICAL_ORIGIN: str = f"{_proto}://{CANONICAL_DOMAIN}"
+
 UA_STRING = f"Openverse/0.1 ({CANONICAL_ORIGIN}; {CONTACT_EMAIL})"
 
 

--- a/catalog/dags/common/requester.py
+++ b/catalog/dags/common/requester.py
@@ -7,6 +7,7 @@ from airflow.exceptions import AirflowException
 from requests.exceptions import JSONDecodeError
 
 import oauth2
+from common.loader import provider_details as prov
 
 
 # pytest_socket will not be available in production, so we must create a shim for
@@ -45,9 +46,10 @@ class DelayedRequester:
              by kwargs in specific calls to the get method
     """
 
-    def __init__(self, delay=0, headers=None):
+    def __init__(self, delay: int = 0, headers: dict | None = None):
+        headers = {} if headers is None else headers
         self._DELAY = delay
-        self.headers = headers or {}
+        self.headers = {"User-Agent": prov.UA_STRING} | headers
         self._last_request = 0
         self.session = requests.Session()
 

--- a/catalog/dags/common/requester.py
+++ b/catalog/dags/common/requester.py
@@ -43,7 +43,7 @@ class DelayedRequester:
     delay:   an integer giving the minimum number of seconds to wait
              between consecutive requests via the `get` method.
     headers: a dict that will be passed in all requests, unless overridden
-             by kwargs in specific calls to the get method
+             by kwargs in specific calls to the `get` method
     """
 
     def __init__(self, delay: int = 0, headers: dict | None = None):

--- a/catalog/dags/providers/provider_api_scripts/museum_victoria.py
+++ b/catalog/dags/providers/provider_api_scripts/museum_victoria.py
@@ -25,7 +25,7 @@ class ImageDetails(TypedDict, total=False):
 class VictoriaDataIngester(ProviderDataIngester):
     providers = {"image": prov.VICTORIA_DEFAULT_PROVIDER}
     endpoint = "https://collections.museumsvictoria.com.au/api/search"
-    headers = {"User-Agent": prov.UA_STRING, "Accept": "application/json"}
+    headers = {"Accept": "application/json"}
     batch_limit = 100
     delay = 5
     LANDING_PAGE = "https://collections.museumsvictoria.com.au/"

--- a/catalog/dags/providers/provider_api_scripts/nappy.py
+++ b/catalog/dags/providers/provider_api_scripts/nappy.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class NappyDataIngester(ProviderDataIngester):
     providers = {constants.IMAGE: prov.NAPPY_DEFAULT_PROVIDER}
     endpoint = "https://api.nappy.co/v1/openverse/images"
-    headers = {"User-Agent": prov.UA_STRING, "Accept": "application/json"}
+    headers = {"Accept": "application/json"}
 
     # Hardcoded to CC0, the only license Nappy.co uses
     license_info = get_license_info(

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -8,6 +8,7 @@ from typing import TypedDict
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
 
+from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.media import MediaStore
 from common.storage.util import get_media_store_class
@@ -144,6 +145,9 @@ class ProviderDataIngester(ABC):
 
         # Keep track of number of records ingested
         self.record_count = 0
+
+        # Set default headers
+        self.headers = {"User-Agent": prov.UA_STRING} | self.headers
 
         # Initialize the DelayedRequester and all necessary Media Stores.
         self.delayed_requester = DelayedRequester(

--- a/catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -89,7 +89,6 @@ class RawpixelDataIngester(ProviderDataIngester):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.api_key: str = Variable.get("API_KEY_RAWPIXEL")
-        self.headers = {"User-Agent": prov.UA_STRING}
 
     def get_media_type(self, record: dict) -> str:
         return constants.IMAGE

--- a/catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -31,10 +31,7 @@ class StockSnapDataIngester(ProviderDataIngester):
     providers = {"image": prov.STOCKSNAP_DEFAULT_PROVIDER}
     batch_limit = 1000
     delay = 1  # in seconds
-    headers = {
-        "Accept": "application/json",
-        "User-Agent": prov.UA_STRING,
-    }
+    headers = {"Accept": "application/json"}
     license_url = "https://creativecommons.org/publicdomain/zero/1.0/"
     license_info = get_license_info(license_url=license_url)
 

--- a/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -130,7 +130,6 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
     }
     host = "commons.wikimedia.org"
     endpoint = f"https://{host}/w/api.php"
-    headers = {"User-Agent": prov.UA_STRING}
 
     # The 10000 is a bit arbitrary, but needs to be larger than the mean
     # number of uses per file (globally) in the response_json, or we will

--- a/catalog/tests/dags/common/test_requester.py
+++ b/catalog/tests/dags/common/test_requester.py
@@ -8,6 +8,10 @@ from requests_oauthlib import OAuth2Session
 
 from catalog.tests.dags.conftest import FAKE_OAUTH_PROVIDER_NAME
 from common import requester
+from common.loader import provider_details as prov
+
+
+USER_AGENT = {"User-Agent": prov.UA_STRING}
 
 
 @patch("common.requester.time")
@@ -155,8 +159,12 @@ def test_oauth_requester_initializes_correctly(oauth_provider_var_mock):
 @pytest.mark.parametrize(
     "init_headers, request_kwargs, expected_request_kwargs",
     [
-        (None, None, {"headers": {}}),
-        ({"init_header": "test"}, None, {"headers": {"init_header": "test"}}),
+        (None, None, {"headers": USER_AGENT}),
+        (
+            {"init_header": "test"},
+            None,
+            {"headers": {"init_header": "test"} | USER_AGENT},
+        ),
         (
             None,
             {"headers": {"h1": "test1"}, "other_kwarg": "test"},

--- a/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -17,6 +17,7 @@ from catalog.tests.dags.providers.provider_api_scripts.resources.provider_data_i
     MockImageOnlyProviderDataIngester,
     MockProviderDataIngester,
 )
+from common.loader import provider_details as prov
 from common.requester import RetriesExceeded
 from common.storage.audio import AudioStore, MockAudioStore
 from common.storage.image import ImageStore, MockImageStore
@@ -90,6 +91,15 @@ def test_get_response_json(endpoint, expected):
         ingester.get_response_json({}, endpoint=endpoint)
         actual_endpoint = mock_get.call_args.args[0]
         assert actual_endpoint == expected
+
+
+def test_passes_user_agent_header():
+    ingester = MockProviderDataIngester()
+    with patch.object(ingester.delayed_requester, "get_response_json") as mock_get:
+        ingester.get_response_json({})
+        actual_headers = mock_get.call_args.kwargs["headers"]
+        assert "User-Agent" in actual_headers
+        assert actual_headers["User-Agent"] == prov.UA_STRING
 
 
 def test_batch_limit_is_capped_to_ingestion_limit():


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1362 by @krysal
Related to #2037 ([Airflow work](https://github.com/WordPress/openverse-infrastructure/milestone/6))

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Resuming the work done previous to the monorepo. This PR adds the User-Agent as the default header for all requests in the `DelayedRequester` and `ProviderDataIngester` classes, making it unnecessary to repeat code in providers DAGs, so it was removed from museum_victoria, nappy, rawpixel, stocksnap, and wikimedia_commons.

I added a new `CANONICAL_ORIGIN` reading it from the os environment to replace the old domain referenced in the UA string. Is it better to read it from an Airflow variable? CC @AetherUnbound.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run one of the above-mentioned DAGs, for example rawpixel, to confirm they continue to work. See the code and updated tests and confirm it all makes sense.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
