### PR TITLE
Preemptively fail unparsable/unusable Europeana URLs

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/catalog/dags/providers/provider_api_scripts/europeana.py
@@ -97,7 +97,15 @@ class EuropeanaRecordBuilder:
     @raise_if_empty
     def _get_image_url(self, data: dict) -> str | None:
         group = data.get("edmIsShownBy")
-        return group[0] if group else None
+        if not group:
+            return None
+        url = group[0]
+        # Some Europeana URLs may have prefixes, or reference Dropbox (which we can't
+        # include in our catalog because we cannot access them directly ourselves).
+        # E.g.: L-APC248-https://www.dropbox.com/s/i1pqizm1joof8y1/Belgium_Diptyque%20_MAR-SGP-CO1.jpg?raw=1
+        if "dropbox.com" in url:
+            return None
+        return url
 
     @raise_if_empty
     def _get_foreign_identifier(self, data: dict) -> str | None:

--- a/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
@@ -9,6 +9,7 @@ from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from common.storage.image import ImageStore
 from providers.provider_api_scripts.europeana import (
+    EmptyRequiredFieldException,
     EuropeanaDataIngester,
     EuropeanaRecordBuilder,
 )
@@ -252,6 +253,19 @@ def test_get_foreign_landing_url_without_edmIsShownAt(record_builder):
     assert (
         record_builder.get_record_data(image_data)["foreign_landing_url"] == expect_url
     )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"edmIsShownBy": None},
+        {"edmIsShownBy": ["dropbox.com/value"]},
+    ],
+)
+def test_get_image_url_empty(data, record_builder):
+    with pytest.raises(EmptyRequiredFieldException):
+        assert record_builder._get_image_url(data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2784 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the Europeana ingester to preemptively fail URLs that are invalid or unusable. See #2784 for what prompted this. Because we automatically add the scheme if it isn't present when attempting to validate the URL, I didn't want to add any machinery to check if the scheme was missing from the beginning of the URL (due to the diversity of sources Europeana includes, I can't check all possible URLs we might get returned back). Dropbox URLs, however, can't really be used by our API as they can't be accessed directly. It seems Europeana actually proxies them itself, here's an example result: https://www.europeana.eu/en/item/2063627/BEL_280_003

This adds a check to throw out any Dropbox URLs ahead of time, so the CSV writing can occur as intended and the error is raised upstream.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out this branch
2. Trigger the Europeana workflow with `additional_query_params` as `{"query": "timestamp_created:[2016-03-01T00:00:00Z TO 2016-03-02T00:00:00Z]"}`
3. Observe that the task completes successfully, although no records are ingested


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
