### PR TITLE
Various iNaturalist updates

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/inaturalist.py
+++ b/catalog/dags/providers/provider_api_scripts/inaturalist.py
@@ -49,6 +49,7 @@ LOADER_ARGS = {
     "media_type": IMAGE,
 }
 OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", "/tmp/"))
+COL_URL = "https://download.checklistbank.org/col/latest_coldp.zip"
 
 
 class INaturalistDataIngester(ProviderDataIngester):
@@ -217,7 +218,6 @@ class INaturalistDataIngester(ProviderDataIngester):
 
     @staticmethod
     def load_catalog_of_life_names(task: PythonOperator, remove_api_files: bool):
-        COL_URL = "https://api.checklistbank.org/dataset/9840/export.zip?format=ColDP"
         local_zip_file = "COL_archive.zip"
         name_usage_file = "NameUsage.tsv"
         vernacular_file = "VernacularName.tsv"

--- a/catalog/dags/providers/provider_api_scripts/inaturalist.py
+++ b/catalog/dags/providers/provider_api_scripts/inaturalist.py
@@ -233,6 +233,10 @@ class INaturalistDataIngester(ProviderDataIngester):
             # This is a static method so that it can be used to create preingestion
             # tasks for airflow. Unfortunately, that means it does not have access to
             # the delayed requester. So, we are just using requests for now.
+            logger.info(
+                f"Downloading Catalog of Life from "
+                f"{COL_URL} to {OUTPUT_DIR}/{local_zip_file}."
+            )
             with requests.get(COL_URL, stream=True) as response:
                 response.raise_for_status()
                 with open(OUTPUT_DIR / local_zip_file, "wb") as f:

--- a/catalog/dags/providers/provider_api_scripts/inaturalist.py
+++ b/catalog/dags/providers/provider_api_scripts/inaturalist.py
@@ -140,7 +140,10 @@ class INaturalistDataIngester(ProviderDataIngester):
         # TO DO: Would it be better to use loader.upsert_records here? Would need to
         # trace back the parameters that need to be passed in for different stats.
         upserted_records = sql.upsert_records_to_db_table(
-            postgres_conn_id=POSTGRES_CONN_ID, identifier=identifier, task=task
+            postgres_conn_id=POSTGRES_CONN_ID,
+            identifier=identifier,
+            task=task,
+            media_type=IMAGE,
         )
         logger.info(f"Upserted {upserted_records} records, from batch {batch_number}.")
         # Truncate the temp table

--- a/catalog/dags/providers/provider_csv_load_scripts/inaturalist/create_schema.sql
+++ b/catalog/dags/providers/provider_csv_load_scripts/inaturalist/create_schema.sql
@@ -54,58 +54,80 @@ https://www.itis.gov/dwca_format.html which also has vernacular names / synonyms
 DROP TABLE IF EXISTS inaturalist.col_vernacular;
 COMMIT;
 
+/* Table definition can be found here:
+   https://github.com/CatalogueOfLife/coldp/blob/master/README.md#vernacularname
+*/
 CREATE TABLE inaturalist.col_vernacular (
     taxonID varchar(5),
     sourceID decimal,
     taxon_name varchar(2000),
     transliteration text,
     name_language varchar(3),
+    preferred boolean,
     country varchar(3),
     area varchar(2000),
     sex decimal,
-    referenceID decimal
+    referenceID decimal,
+    remarks text
 );
 COMMIT;
 
 DROP TABLE IF EXISTS inaturalist.col_name_usage;
 COMMIT;
 
+/* Table definition can be found here:
+   https://github.com/CatalogueOfLife/coldp/blob/master/README.md#nameusage
+*/
 CREATE TABLE inaturalist.col_name_usage (
-    ID varchar(50),
+    ID text,
     alternativeID decimal,
     nameAlternativeID decimal,
     sourceID decimal,
-    parentID varchar(5),
-    basionymID varchar(5),
-    status varchar(22),
-    scientificName varchar(76),
-    authorship varchar(255),
-    rank varchar(21),
-    notho varchar(13),
-    uninomial varchar(50),
-    genericName varchar(50),
-    infragenericEpithet varchar(25),
-    specificEpithet varchar(50),
-    infraspecificEpithet varchar(50),
-    cultivarEpithet varchar(50),
-    namePhrase varchar(80),
-    nameReferenceID varchar(36),
+    parentID text,
+    basionymID text,
+    status text,
+    scientificName text,
+    authorship text,
+    rank text,
+    notho text,
+    originalSpelling boolean,
+    uninomial text,
+    genericName text,
+    infragenericEpithet text,
+    specificEpithet text,
+    infraspecificEpithet text,
+    cultivarEpithet text,
+    combinationAuthorship text,
+    combinationAuthorshipID text,
+    combinationExAuthorship text,
+    combinationExAuthorshipID text,
+    combinationAuthorshipYear text,
+    basionymAuthorship text,
+    basionymAuthorshipID text,
+    basionymExAuthorship text,
+    basionymExAuthorshipID text,
+    basionymAuthorshipYear text,
+    namePhrase text,
+    nameReferenceID text,
     publishedInYear decimal,
-    publishedInPage varchar(255),
-    publishedInPageLink varchar(255),
-    code varchar(10),
-    nameStatus varchar(15),
-    accordingToID varchar(36),
+    publishedInPage text,
+    publishedInPageLink text,
+    gender text,
+    genderAgreement boolean,
+    etymology text,
+    code text,
+    nameStatus text,
+    accordingToID text,
     accordingToPage decimal,
     accordingToPageLink decimal,
     referenceID text,
-    scrutinizer varchar(149),
+    scrutinizer text,
     scrutinizerID decimal,
-    scrutinizerDate varchar(10),
+    scrutinizerDate text,
     extinct boolean,
-    temporalRangeStart varchar(15),
-    temporalRangeEnd varchar(15),
-    environment varchar(38),
+    temporalRangeStart text,
+    temporalRangeEnd text,
+    environment text,
     species decimal,
     section decimal,
     subgenus decimal,
@@ -124,7 +146,7 @@ CREATE TABLE inaturalist.col_name_usage (
     kingdom decimal,
     sequenceIndex decimal,
     branchLength decimal,
-    link varchar(240),
+    link text,
     nameRemarks decimal,
     remarks text
 );

--- a/catalog/tests/dags/providers/provider_api_scripts/test_inaturalist.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_inaturalist.py
@@ -162,17 +162,18 @@ def test_consolidate_load_statistics(all_results, expected):
 
 
 @pytest.mark.parametrize(
-    "batch_length, max_id, expected",
+    "batch_length, min_and_max, expected",
     [
-        pytest.param(10, [(22,)], [[(0, 9)], [(10, 19)], [(20, 29)]], id="happy_path"),
-        pytest.param(10, [(2,)], [[(0, 9)]], id="bigger_batch_than_id"),
-        pytest.param(10, [(None,)], None, id="no_data"),
+        pytest.param(10, (0, 22), [[(0, 9)], [(10, 19)], [(20, 29)]], id="happy_path"),
+        pytest.param(10, (0, 2), [[(0, 9)]], id="bigger_batch_than_id"),
+        pytest.param(10, (None, None), None, id="no_data"),
+        pytest.param(10, (8, 22), [[(8, 17)], [(18, 27)]], id="min_not_zero"),
     ],
 )
-def test_get_batches(batch_length, max_id, expected):
+def test_get_batches(batch_length, min_and_max, expected):
     task = mock.Mock()
     with mock.patch.object(PostgresHook, "get_execution_timeout", return_value=60):
-        with mock.patch.object(PostgresHook, "get_records", return_value=max_id):
+        with mock.patch.object(PostgresHook, "get_records", return_value=[min_and_max]):
             actual = INAT.get_batches(batch_length, task)
             assert actual == expected
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3631 by @rwidom

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes a number of aspects of the iNaturalist ingestion, with the hope that we should be able to turn it back on in production after this!

- Addresses the issue in #3631 by pointing to a "latest" version of the COL data. This link doesn't include a build/date/version number, and so shouldn't need updating down the line.
- Fixed an issue where the media type was not provided when running various `common.sql` methods directly.
- Updated the iNaturalist schemas, which had changed since the last time this was successfully run.
- Use the minimum photo ID when creating the initial ranges, rather than starting from 0

It seems it had been a minute since we've gotten iNaturalist running :sweat_smile: There were quite a few changes, but I think I've covered them all and added references to documentation for where to look if they change again.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Due to our use of parameters over variables for defining when to skip the removal of the source data, this is a little tricky

1. Enable the iNaturalist DAG, then disable it. A DAG run should start, immediately mark the entire DAG as failed.
2. Trigger a new run of the DAG, and uncheck `sql_rm_source_data_after_ingesting` in the parameter settings before running
3. Let the DAG execute and ingest data! It won't be a whole lot of images (and the initial download of the COL data is about **600MB** so be advised it will take time!)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
