### PR TITLE
Remove references to api-dev

### DIFF
--- a/utilities/load_testing/README.md
+++ b/utilities/load_testing/README.md
@@ -37,5 +37,5 @@ All load tests are accessible through `just` scripts in this directory's
 
 To run API load tests against a local API instance, use `just api`. You can
 optionally specify a host (the default is to point to local). For example
-`just api https://api-dev.openverse.engineering` will run the load tests against
-the staging API.
+`just api https://api-staging.openverse.engineering` will run the load tests
+against the staging API.

--- a/utilities/load_testing/k6/utils.js
+++ b/utilities/load_testing/k6/utils.js
@@ -3,7 +3,7 @@ import http from "k6/http"
 import { randomItem } from "https://jslib.k6.io/k6-utils/1.2.0/index.js"
 
 export const API_URL =
-  __ENV.API_URL || "https://api-dev.openverse.engineering/v1/"
+  __ENV.API_URL || "https://api-staging.openverse.engineering/v1/"
 export const SLEEP_DURATION = 0.1
 // Use the random words list available locally, but filter any words that end with apostrophe-s
 const WORDS = open("/usr/share/dict/words")


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse-infrastructure/pull/804 which removed `api-dev` as a staging domain.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The subdomain no longer exists, and so it should not be referenced in current documentation.

I considered similarly removing references to `search.openverse.engineering` (and `search-staging`) but the only reference to that are in planning documents, which reference in-time things on those pages, so I feel it doesn't make sense to update them.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check that I haven't missed any references to the removed domains.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
