### PR TITLE
Revert "Update Node.js to v18.19.1"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,7 +112,7 @@
     "@testing-library/vue": "^5.8.2",
     "@types/express-useragent": "^1.0.2",
     "@types/jest": "^29.5.4",
-    "@types/node": "18.19.21",
+    "@types/node": "18.19.14",
     "@types/throttle-debounce": "^5.0.0",
     "@types/uuid": "^9.0.6",
     "@vue/test-utils": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pnpm": ">= 8.12.1"
   },
   "volta": {
-    "node": "18.19.1"
+    "node": "18.19.0"
   },
   "devDependencies": {
     "@openverse/eslint-plugin": "workspace:0.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^29.5.4
         version: 29.5.4
       '@types/node':
-        specifier: 18.19.21
-        version: 18.19.21
+        specifier: 18.19.14
+        version: 18.19.14
       '@types/throttle-debounce':
         specifier: ^5.0.0
         version: 5.0.0
@@ -282,7 +282,7 @@ importers:
         version: 3.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.19.21)(typescript@5.2.2)
+        version: 10.9.1(@types/node@18.19.14)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4118,7 +4118,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       jest-message-util: 26.6.2
       jest-util: 26.6.2
@@ -4130,7 +4130,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       jest-message-util: 29.6.3
       jest-util: 29.6.3
@@ -4145,7 +4145,7 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       exit: 0.1.2
@@ -4190,14 +4190,14 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.6.3
-      jest-config: 29.6.4(@types/node@18.19.21)
+      jest-config: 29.6.4(@types/node@18.19.14)
       jest-haste-map: 29.6.4
       jest-message-util: 29.6.3
       jest-regex-util: 29.6.3
@@ -4231,7 +4231,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-mock: 26.6.2
     dev: true
 
@@ -4241,7 +4241,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-mock: 29.6.3
 
   /@jest/expect-utils@29.6.4:
@@ -4265,7 +4265,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -4277,7 +4277,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-message-util: 29.6.3
       jest-mock: 29.6.3
       jest-util: 29.6.3
@@ -4351,7 +4351,7 @@ packages:
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -4491,7 +4491,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: true
@@ -4502,7 +4502,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
@@ -4513,7 +4513,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
@@ -4525,7 +4525,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -7333,7 +7333,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -7341,14 +7341,14 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/responselike': 1.0.0
     dev: true
 
   /@types/clean-css@4.2.5:
     resolution: {integrity: sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       source-map: 0.6.1
     dev: true
 
@@ -7361,7 +7361,7 @@ packages:
   /@types/connect@3.4.37:
     resolution: {integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/cookie@0.3.3:
@@ -7371,13 +7371,13 @@ packages:
   /@types/etag@1.8.2:
     resolution: {integrity: sha512-z8Pbo2e+EZWMpuRPYSjhSivp2OEkqrMZBUfEAWlJC31WUCKveZ8ioWXHAC5BXRZfwxCBfYRhPij1YJHK1W6oDA==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/express-serve-static-core@4.17.26:
     resolution: {integrity: sha512-zeu3tpouA043RHxW0gzRxwCHchMgftE8GArRsvYT0ByDMbn19olQHx5jLue0LxWY6iYtXb7rXmuVtSkhy9YZvQ==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -7407,13 +7407,13 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
 
   /@types/hast@2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
@@ -7443,7 +7443,7 @@ packages:
   /@types/http-proxy@1.17.10:
     resolution: {integrity: sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: false
 
   /@types/is-function@1.0.1:
@@ -7486,7 +7486,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/less@3.0.5:
@@ -7514,7 +7514,7 @@ packages:
   /@types/node-fetch@2.6.1:
     resolution: {integrity: sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       form-data: 3.0.1
     dev: true
 
@@ -7526,8 +7526,8 @@ packages:
     resolution: {integrity: sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==}
     dev: true
 
-  /@types/node@18.19.21:
-    resolution: {integrity: sha512-2Q2NeB6BmiTFQi4DHBzncSoq/cJMLDdhPaAoJFnFCyD9a8VPZRf7a1GAwp1Edb7ROaZc5Jz/tnZyL6EsWMRaqw==}
+  /@types/node@18.19.14:
+    resolution: {integrity: sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==}
     dependencies:
       undici-types: 5.26.5
 
@@ -7582,13 +7582,13 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/sax@1.2.3:
     resolution: {integrity: sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: false
 
   /@types/semver@7.5.0:
@@ -7598,7 +7598,7 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/serve-static@1.15.4:
@@ -7606,7 +7606,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 1.3.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /@types/source-list-map@0.1.2:
@@ -7680,14 +7680,14 @@ packages:
   /@types/webpack-sources@3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/source-list-map': 0.1.2
       source-map: 0.7.3
 
   /@types/webpack@4.41.35:
     resolution: {integrity: sha512-XRC6HLGHtNfN8/xWeu1YUQV1GSE+28q8lSqvcJ+0xt/zW9Wmn4j9pCSvaXPyRlCKrl5OuqECQNEJUy2vo8oWqg==}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.13.1
       '@types/webpack-sources': 3.2.0
@@ -14304,7 +14304,7 @@ packages:
       '@jest/expect': 29.6.4
       '@jest/test-result': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -14367,7 +14367,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.0.3
-      jest-config: 29.6.4(@types/node@18.19.21)
+      jest-config: 29.6.4(@types/node@18.19.14)
       jest-util: 29.6.3
       jest-validate: 29.6.3
       prompts: 2.4.2
@@ -14405,7 +14405,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.5
       pretty-format: 26.6.2
-      ts-node: 10.9.1(@types/node@18.19.21)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.19.14)(typescript@5.2.2)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -14413,7 +14413,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config@29.6.4(@types/node@18.19.21):
+  /jest-config@29.6.4(@types/node@18.19.14):
     resolution: {integrity: sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -14428,7 +14428,7 @@ packages:
       '@babel/core': 7.22.5
       '@jest/test-sequencer': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       babel-jest: 29.6.4(@babel/core@7.22.5)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -14512,7 +14512,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-mock: 26.6.2
       jest-util: 26.6.2
       jsdom: 16.7.0
@@ -14530,7 +14530,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: true
@@ -14542,7 +14542,7 @@ packages:
       '@jest/environment': 29.6.4
       '@jest/fake-timers': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-mock: 29.6.3
       jest-util: 29.6.3
 
@@ -14567,7 +14567,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       anymatch: 3.1.3
       fb-watchman: 2.0.1
       graceful-fs: 4.2.11
@@ -14590,7 +14590,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       anymatch: 3.1.3
       fb-watchman: 2.0.1
       graceful-fs: 4.2.11
@@ -14611,7 +14611,7 @@ packages:
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       co: 4.6.0
       expect: 26.6.2
@@ -14700,7 +14700,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
     dev: true
 
   /jest-mock@29.6.3:
@@ -14708,7 +14708,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-util: 29.6.3
 
   /jest-pnp-resolver@1.2.2(jest-resolve@26.6.2):
@@ -14799,7 +14799,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
@@ -14832,7 +14832,7 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -14902,7 +14902,7 @@ packages:
       '@jest/test-result': 29.6.4
       '@jest/transform': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.1
@@ -14924,7 +14924,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       graceful-fs: 4.2.11
     dev: true
 
@@ -14988,7 +14988,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -15000,7 +15000,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -15035,7 +15035,7 @@ packages:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 26.6.2
@@ -15048,7 +15048,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.6.4
       '@jest/types': 29.6.3
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -15059,7 +15059,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -15067,7 +15067,7 @@ packages:
     resolution: {integrity: sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       jest-util: 29.6.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -17621,7 +17621,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.9.1(@types/node@18.19.21)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.19.14)(typescript@5.2.2)
       yaml: 2.3.1
     dev: true
 
@@ -20840,7 +20840,7 @@ packages:
     resolution: {integrity: sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==}
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.19.21)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@18.19.14)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -20859,7 +20859,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.21
+      '@types/node': 18.19.14
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
Reverts WordPress/openverse#3854

The deployment failed and I'm not able to fix forward right now. cc @AetherUnbound as MSR, @WordPress/openverse-frontend for looking into this failure. I'm at WordCamp next week and then AFK the week after, so won't be able to look into this myself, as just wrapping up for the week to get ready to travel.