### PR TITLE
Recover from updated build_param in Phylopic DAG

### DIFF
--- a/catalog/dags/common/requester.py
+++ b/catalog/dags/common/requester.py
@@ -143,7 +143,7 @@ class DelayedRequester:
         endpoint,
         retries=0,
         query_params=None,
-        requestMethod="get",
+        request_method="get",
         **kwargs,
     ):
         """
@@ -151,7 +151,7 @@ class DelayedRequester:
         there are no remaining retries, it will instead raise the error.
         """
         if retries <= 0:
-            logger.error("No retries remaining.  Failure.")
+            logger.error("No retries remaining. Failure.")
             raise error
 
         logger.warning(error)
@@ -166,20 +166,20 @@ class DelayedRequester:
             endpoint,
             retries=retries - 1,
             query_params=query_params,
-            requestMethod=requestMethod,
+            request_method=request_method,
             **kwargs,
         )
 
     def get_response_json(
-        self, endpoint, retries=0, query_params=None, requestMethod="get", **kwargs
+        self, endpoint, retries=0, query_params=None, request_method="get", **kwargs
     ):
         response_json = None
         response = None
 
         try:
-            if requestMethod == "get":
+            if request_method == "get":
                 response = self.get(endpoint, params=query_params, **kwargs)
-            elif requestMethod == "post":
+            elif request_method == "post":
                 response = self.post(endpoint, params=query_params, **kwargs)
 
             if response is not None and response.status_code == 200:
@@ -195,12 +195,12 @@ class DelayedRequester:
                     endpoint,
                     retries,
                     query_params,
-                    requestMethod,
+                    request_method,
                     **kwargs,
                 )
         except HTTPError as e:
             response_json = self._attempt_retry_get_response_json(
-                e, endpoint, retries, query_params, requestMethod, **kwargs
+                e, endpoint, retries, query_params, request_method, **kwargs
             )
 
         return response_json

--- a/catalog/dags/common/requester.py
+++ b/catalog/dags/common/requester.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import requests
 from airflow.exceptions import AirflowException
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import HTTPError, JSONDecodeError
 
 import oauth2
 from common.loader import provider_details as prov
@@ -21,12 +21,6 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
-
-
-class RetriesExceeded(Exception):
-    """Custom exception for when the number of allowed retries has been exceeded."""
-
-    pass
 
 
 class DelayedRequester:
@@ -73,15 +67,8 @@ class DelayedRequester:
             request_kwargs["headers"] = self.headers
         try:
             response = method(url, **request_kwargs)
-            if response.status_code == requests.codes.ok:
-                logger.debug(f"Received response from url {response.url}")
-            elif response.status_code == requests.codes.unauthorized:
-                logger.error(f"Authorization failed for URL: {response.url}")
-            else:
-                logger.warning(
-                    f"Unable to request URL: {response.url}  "
-                    f"Status code: {response.status_code}"
-                )
+            response.raise_for_status()
+
             return response
         except SocketConnectBlockedError:
             # This exception will only be raised during testing, and it *must*
@@ -94,12 +81,14 @@ class DelayedRequester:
             # sent a SIGTERM, which means that the task should be stopped.
             raise
         except Exception as e:
+            # All other exceptions are logged and re-raised
             logger.error(f"Error with the request for URL: {url}")
             logger.info(f"{type(e).__name__}: {e}")
             if params := request_kwargs.get("params"):
                 logger.info(f"Using query parameters {params}")
             logger.info(f'Using headers {request_kwargs.get("headers")}')
-            return None
+
+            raise
 
     def get(self, url, params=None, **kwargs):
         """
@@ -148,36 +137,70 @@ class DelayedRequester:
         except JSONDecodeError as e:
             logger.warning(f"Could not get response_json.\n{e}")
 
+    def _attempt_retry_get_response_json(
+        self,
+        error,
+        endpoint,
+        retries=0,
+        query_params=None,
+        requestMethod="get",
+        **kwargs,
+    ):
+        """
+        Attempt to retry `get_response_json` after a failure, with the given arguments. If
+        there are no remaining retries, it will instead raise the error.
+        """
+        if retries <= 0:
+            logger.error("No retries remaining.  Failure.")
+            raise error
+
+        logger.warning(error)
+        logger.warning(
+            "Retrying:\n_get_response_json(\n"
+            f"    {endpoint},\n"
+            f"    {query_params},\n"
+            f"    retries={retries - 1}"
+            ")"
+        )
+        return self.get_response_json(
+            endpoint,
+            retries=retries - 1,
+            query_params=query_params,
+            requestMethod=requestMethod,
+            **kwargs,
+        )
+
     def get_response_json(
         self, endpoint, retries=0, query_params=None, requestMethod="get", **kwargs
     ):
         response_json = None
         response = None
-        if retries < 0:
-            logger.error("No retries remaining.  Failure.")
-            raise RetriesExceeded("Retries exceeded")
 
-        if requestMethod == "get":
-            response = self.get(endpoint, params=query_params, **kwargs)
-        elif requestMethod == "post":
-            response = self.post(endpoint, params=query_params, **kwargs)
+        try:
+            if requestMethod == "get":
+                response = self.get(endpoint, params=query_params, **kwargs)
+            elif requestMethod == "post":
+                response = self.post(endpoint, params=query_params, **kwargs)
 
-        if response is not None and response.status_code == 200:
-            response_json = self._get_json(response)
+            if response is not None and response.status_code == 200:
+                response_json = self._get_json(response)
 
-        if response_json is None or (
-            isinstance(response_json, dict) and response_json.get("error") is not None
-        ):
-            logger.warning(f"Bad response_json:  {response_json}")
-            logger.warning(
-                "Retrying:\n_get_response_json(\n"
-                f"    {endpoint},\n"
-                f"    {query_params},\n"
-                f"    retries={retries - 1}"
-                ")"
-            )
-            response_json = self.get_response_json(
-                endpoint, retries=retries - 1, query_params=query_params, **kwargs
+            if response_json is None or (
+                isinstance(response_json, dict)
+                and response_json.get("error") is not None
+            ):
+                # Status code was 200 but there was an error parsing response_json
+                response_json = self._attempt_retry_get_response_json(
+                    ValueError(f"Bad response_json: {response_json}"),
+                    endpoint,
+                    retries,
+                    query_params,
+                    requestMethod,
+                    **kwargs,
+                )
+        except HTTPError as e:
+            response_json = self._attempt_retry_get_response_json(
+                e, endpoint, retries, query_params, requestMethod, **kwargs
             )
 
         return response_json

--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -17,13 +17,12 @@ import logging
 from datetime import datetime
 
 from airflow.models import Variable
-from requests.exceptions import ConnectionError, SSLError
+from requests.exceptions import ConnectionError, HTTPError, SSLError
 from retry import retry
 
 from common import constants
 from common.licenses.licenses import get_license_info
 from common.loader import provider_details as prov
-from common.requester import RetriesExceeded
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
@@ -142,12 +141,15 @@ class FreesoundDataIngester(ProviderDataIngester):
             set_id = response_json.get("id")
             set_name = response_json.get("name")
             return set_id, set_name
-        except RetriesExceeded:
+        except HTTPError as error:
             # https://github.com/WordPress/openverse-catalog/issues/659
             # This should be temporary for the full run of Freesound, as
             # some historical audio sets 404.
-            logger.warning("Unable to fetch audio_set information")
-            return None, None
+            if error.response.status_code == 404:
+                logger.warning("Unable to fetch audio_set information")
+                return None, None
+            else:
+                raise
 
     def _get_audio_set_info(self, media_data):
         # set id, set name, set url

--- a/catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -17,9 +17,7 @@ from requests.exceptions import HTTPError
 from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-from providers.provider_api_scripts.provider_data_ingester import (
-    ProviderDataIngester,
-)
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
 logger = logging.getLogger(__name__)
@@ -42,8 +40,8 @@ class PhylopicDataIngester(ProviderDataIngester):
         try:
             super().ingest_records()
 
-        # Catch 410 error caused by the build_param changing while ingestion is ongoing
         except HTTPError as error:
+            # Catch 410 error caused by the build_param changing while ingestion is ongoing
             if error.response.status_code == 410:
                 # Refetch initial query params; this will update the build_param to the
                 # most recent value and reset the `current_page` to 1.

--- a/catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -12,10 +12,14 @@ Notes:                  http://api-docs.phylopic.org/v2/
 
 import logging
 
+from requests.exceptions import HTTPError
+
 from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
+from providers.provider_api_scripts.provider_data_ingester import (
+    ProviderDataIngester,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -35,15 +39,43 @@ class PhylopicDataIngester(ProviderDataIngester):
 
     def ingest_records(self):
         self._get_initial_query_params()
-        super().ingest_records()
+        try:
+            super().ingest_records()
+
+        # Catch 410 error caused by the build_param changing while ingestion is ongoing
+        except HTTPError as error:
+            if error.response.status_code == 410:
+                # Refetch initial query params; this will update the build_param to the
+                # most recent value and reset the `current_page` to 1.
+                old_build_param = self.build_param
+                self._get_initial_query_params()
+
+                if old_build_param == self.build_param:
+                    # If the build_param could not be updated, there must be another
+                    # issue. Raise the original error.
+                    raise
+
+                # Otherwise, the build_param did in fact change. Attempt ingestion
+                # again with the new param.
+                logger.info(
+                    f"Build_param changed from {old_build_param} to {self.build_param}"
+                    " during ingestion. Restarting ingestion from the beginning."
+                )
+                super().ingest_records()
+
+            else:
+                # Raise all other errors
+                raise
 
     def _get_initial_query_params(self) -> None:
         """Get the required `build` param from the API and set the total pages."""
         resp = self.get_response_json(query_params={})
         if not resp:
             raise Exception("No response from Phylopic API.")
-        self.build_param = resp.get("build")
+        self.current_page = 1
         self.total_pages = resp.get("totalPages")
+        self.build_param = resp.get("build")
+
         logger.info(
             f"Total items to fetch: {resp.get('totalItems')}. "
             f"Total pages: {self.total_pages}."

--- a/catalog/tests/dags/common/test_requester.py
+++ b/catalog/tests/dags/common/test_requester.py
@@ -43,10 +43,10 @@ def test_get_delays_processing(monkeypatch):
         r.status_code = 200
         return r
 
-    monkeypatch.setattr(requester.requests.Session, "get", mock_requests_get)
-
     delay = 1
     dq = requester.DelayedRequester(delay=delay)
+    monkeypatch.setattr(dq.session, "get", mock_requests_get)
+
     start = time.time()
     dq.get("http://fake_url")
     dq.get("http://fake_url")
@@ -62,34 +62,26 @@ def test_get_handles_exception(monkeypatch, caplog):
     monkeypatch.setattr(dq.session, "get", mock_requests_get)
 
     with caplog.at_level(logging.WARNING):
-        dq.get("https://google.com/")
-        assert "Error with the request for URL: https://google.com/" in caplog.text
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            dq.get("https://google.com/")
+            assert "Error with the request for URL: https://google.com/" in caplog.text
 
 
-@pytest.mark.parametrize(
-    "code, log_level, expected_message",
-    [
-        (500, logging.WARNING, "Unable to request URL"),
-        (401, logging.ERROR, "Authorization failed for URL"),
-    ],
-)
-def test_get_handles_failure_status_codes(
-    code, log_level, expected_message, monkeypatch, caplog
-):
+@pytest.mark.parametrize("code", (500, 401))
+def test_get_handles_failure_status_codes(code, monkeypatch, caplog):
     url = "https://google.com/"
-    mock_response = MagicMock()
-    mock_response.status_code = code
-    mock_response.url = url
 
     def mock_requests_get(url, params, **kwargs):
-        return mock_response
+        r = requests.Response()
+        r.status_code = code
+        r.url = url
+        return r
 
     dq = requester.DelayedRequester(1)
     monkeypatch.setattr(dq.session, "get", mock_requests_get)
 
-    with caplog.at_level(log_level):
+    with pytest.raises(requests.exceptions.HTTPError, match=str(code)):
         dq.get(url)
-        assert f"{expected_message}: {url}" in caplog.text
 
 
 def test_get_response_json_retries_with_none_response():
@@ -117,6 +109,31 @@ def test_get_response_json_retries_with_non_ok():
             )
 
     assert mock_get.call_count == 3
+
+
+def test_get_response_json_gets_response_on_retry():
+    # Test that the response is returned when it fails initially but
+    # succeeds on a retry
+    dq = requester.DelayedRequester(1)
+    failure_response = requests.Response()
+    failure_response.status_code = 410
+    success_response = requests.Response()
+    success_response.status_code = 200
+    success_response.json = MagicMock(return_value={"foo": "bar"})
+
+    with patch.object(dq, "get") as mock_get:
+        mock_get.side_effect = [
+            # First try fails
+            failure_response,
+            # Second try succeeds
+            success_response,
+        ]
+        assert dq.get_response_json(
+            "https://google.com/",
+            retries=2,
+        ) == {"foo": "bar"}
+
+    assert mock_get.call_count == 2
 
 
 def test_get_response_json_retries_with_error_json():
@@ -193,7 +210,7 @@ def test_handles_optional_headers(
     init_headers, request_kwargs, expected_request_kwargs
 ):
     dq = requester.DelayedRequester(0, headers=init_headers)
-    dq.session.get = MagicMock(return_value=None)
+    dq.session.get = MagicMock(return_value=MagicMock())
     url = "http://test"
     params = {"testy": "test"}
     dq.get(url, params, **(request_kwargs or {}))

--- a/catalog/tests/dags/providers/provider_api_scripts/test_freesound.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_freesound.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests.exceptions import HTTPError
 
 from catalog.tests.dags.providers.provider_api_scripts.resources.json_load import (
     make_resource_json_func,
@@ -100,7 +101,7 @@ def test_handles_failure_to_get_set_info():
     with patch.object(fsd.delayed_requester, "get") as get_mock, patch("time.sleep"):
         error_response = MagicMock()
         error_response.status_code = 404
-        get_mock.return_value = error_response
+        get_mock.side_effect = HTTPError(response=error_response)
 
         actual_id, actual_name, actual_url = fsd._get_audio_set_info(
             {"pack": "https://freesound.org/apiv2/packs/35596/"}

--- a/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import requests
 from airflow.exceptions import AirflowException
+from requests.exceptions import HTTPError
 
 from catalog.tests.dags.providers.provider_api_scripts.resources.json_load import (
     make_resource_json_func,
@@ -18,7 +19,6 @@ from catalog.tests.dags.providers.provider_api_scripts.resources.provider_data_i
     MockProviderDataIngester,
 )
 from common.loader import provider_details as prov
-from common.requester import RetriesExceeded
 from common.storage.audio import AudioStore, MockAudioStore
 from common.storage.image import ImageStore, MockImageStore
 from providers.provider_api_scripts.provider_data_ingester import (
@@ -152,8 +152,8 @@ def test_get_batch_raises_error():
     r.status_code = 500
     r.json = MagicMock(return_value={"error": ""})
     with (
-        patch.object(ingester.delayed_requester, "get", return_value=r),
-        pytest.raises(RetriesExceeded),
+        patch.object(ingester.delayed_requester.session, "get", return_value=r),
+        pytest.raises(HTTPError),
     ):
         ingester.get_batch({})
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3820 by @AetherUnbound, fixes #1369

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

#3820 gives an excellent explanation of the problem, but the tldr is that the Phylopic DAG works by first fetching a `build_param` that is used in all subsequent requests for data, and sometimes this `build_param` changes _while ingestion is underway_, causing errors. When that happens we want to identify the issue, fetch the new `build_param`, and start ingestion over from the top.

To accomplish that, this PR ended up making additional changes to the `DelayedRequester`. Currently the requester will, after all configured retries have been exhausted, raise a `RetriesExceeded` error with no other context about what the actual error was from the provider API. This PR updates the requester to instead raise the actual error from the API, which I think is more useful information. For example we already have one other provider (Freesound) which was trying to detect and handle specific API errors, and now we can do that.

Consequently tests were added and updated, but reviewers should weigh in on whether they think there's reason to keep the previous implementation.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The easiest way to test this manually is to add a few lines of code to the Phylopic DAG to make it return an incorrect `build_param` on the first try. I did this by updating the `__init__` method to initialize a test variable:

```
     def __init__(self, *args, **kwargs):
+        self.test = 0
```

And then further updating the `_get_initial_query_params` to reset `build_param` to a bad value on the first iteration, using the var:

```
@@ -76,6 +77,10 @@ class PhylopicDataIngester(ProviderDataIngester):
         self.total_pages = resp.get("totalPages")
         self.build_param = resp.get("build")

+        if self.test == 0:
+            self.build_param = 307
+            self.test += 1
```

Now try running the Phylopic DAG locally and inspect the logs. You should see a log like this when it tries to fetch a batch with the bad build param:

```
[2024-03-04, 20:19:25 UTC] {requester.py:85} ERROR - Error with the request for URL: https://api.phylopic.org/images
[2024-03-04, 20:19:25 UTC] {requester.py:86} INFO - HTTPError: 410 Client Error: Gone for url: https://api.phylopic.org/images?build=307&page=0&embed_items=true
```

You should see the same request retry 3 times (and fail each time).

However the DAG should not fail; you should instead see the `build_param` is refetched and ingestion starts over, this time successfully. The logs will look like:

```

[2024-03-04, 20:19:45 UTC] {phylopic.py:61} INFO - Build_param changed from 307 to 321 during ingestion. Restarting ingestion from the beginning.
[2024-03-04, 20:19:45 UTC] {provider_data_ingester.py:228} INFO - Begin ingestion for PhylopicDataIngester
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
