### PR TITLE
ES healthcheck: skip message composition task when cluster is green

### DIFF
--- a/catalog/tests/dags/elasticsearch_cluster/test_healthcheck_dag.py
+++ b/catalog/tests/dags/elasticsearch_cluster/test_healthcheck_dag.py
@@ -87,6 +87,13 @@ def _missing_node_keys(master_nodes: int, data_nodes: int):
             ),
             id="yellow-status-all-nodes-present",
         ),
+        pytest.param(
+            None,
+            None,
+            _make_response_body(status="green"),
+            id="green-status",
+            marks=pytest.mark.raises(exception=AirflowSkipException),
+        ),
     ),
 )
 def test_compose_notification(


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3902 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes an issue for the Elasticsearch healthcheck DAG wherein the message composition would return `None` because the cluster was green, but the downstream `notify` step was expecting a particular message type. I've corrected this first by adding explicit typing so the expectations are a bit more obvious, and then by raising an `AirflowSkipException` when the cluster health is green (since no alerting is necessary). This likely didn't come up locally because our local ES cluster health is always yellow!


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass, this is hard to assess locally because our ES cluster health won't be green.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
