### PR TITLE
Handle bad octals with decimal point in ccMixter DAG

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/cc_mixter.py
+++ b/catalog/dags/providers/provider_api_scripts/cc_mixter.py
@@ -25,7 +25,7 @@ from providers.provider_api_scripts.provider_data_ingester import ProviderDataIn
 
 logger = logging.getLogger(__name__)
 
-JSON_OCTALS = re.compile(r":\s*0+(?P<num>\d+)\s*(?P<sep>[,}])")
+JSON_OCTALS = re.compile(r":\s*0+(?P<num>[\d.]+)\s*(?P<sep>[,}])")
 
 
 class CcMixterDelayedRequester(DelayedRequester):

--- a/catalog/tests/dags/providers/provider_api_scripts/test_cc_mixter.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_cc_mixter.py
@@ -16,7 +16,7 @@ RESOURCES = Path(__file__).parent / "resources/cc_mixter"
 ingester = CcMixterDataIngester()
 
 
-@pytest.mark.parametrize("bad_number", ["0123", "00123"])
+@pytest.mark.parametrize("bad_number", ["0123", "00123", "012.3"])
 def test_custom_requester_parses_bad_json(bad_number):
     response = Mock(text=f'{{"value": {bad_number}}}')
 


### PR DESCRIPTION
## Fixes

Addresses #3901

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

ccMixter's API can send malformed JSON so this PR adds addtional handling for the same. This particular case appears at offset 27100:

```json
"file_name" : "salvatore_j_-_128_bpm_matched_Drum_loops_15.mp3", "file_nicname" : 012.2,
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Run the ccMixter DAG locally at offset 27100.
1. The DAG should fail without this patch, and succeed with it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
