### PR TITLE
Freesound: handle space in creator name when making URL

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -110,7 +110,7 @@ class FreesoundDataIngester(ProviderDataIngester):
     def _get_creator_data(item):
         if creator := item.get("username"):
             creator = creator.strip()
-            creator_url = f"https://freesound.org/people/{creator}/"
+            creator_url = f"https://freesound.org/people/{creator}/".replace(" ", "%20")
         else:
             creator_url = None
         return creator, creator_url

--- a/catalog/tests/dags/providers/provider_api_scripts/test_freesound.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_freesound.py
@@ -196,21 +196,26 @@ def test_get_audio_set_info(audio_data):
     assert (set_foreign_id, audio_set, set_url) == expected_audio_set_info
 
 
-def test_get_creator_data(audio_data):
-    actual_creator, actual_creator_url = fsd._get_creator_data(audio_data)
-    expected_creator = "owly-bee"
-    expected_creator_url = "https://freesound.org/people/owly-bee/"
-
+@pytest.mark.parametrize(
+    "creator_data, expected_creator, expected_creator_url",
+    [
+        (
+            {"username": "owly-bee"},
+            "owly-bee",
+            "https://freesound.org/people/owly-bee/",
+        ),
+        (
+            {"username": "Dingle Brumbus"},
+            "Dingle Brumbus",
+            "https://freesound.org/people/Dingle%20Brumbus/",
+        ),
+        ({}, None, None),
+    ],
+)
+def test_get_creator_data(creator_data, expected_creator, expected_creator_url):
+    actual_creator, actual_creator_url = fsd._get_creator_data(creator_data)
     assert actual_creator == expected_creator
     assert actual_creator_url == expected_creator_url
-
-
-def test_get_creator_data_returns_none_when_no_artist(audio_data):
-    audio_data.pop("username", None)
-    actual_creator, actual_creator_url = fsd._get_creator_data(audio_data)
-
-    assert actual_creator is None
-    assert actual_creator_url is None
 
 
 def test_extract_audio_data_handles_example_dict(audio_data, file_size_patch):


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3908 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Similar to #3907, this PR adds handling for cases where Freesound creator names have spaces in them.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Tests should pass
2. Running the DAG locally with `initial_query_params` set to `{"format": "json", "query": "", "page_size": 150, "fields": "id,url,name,tags,description,created,license,type,download,filesize,bitrate,bitdepth,duration,samplerate,pack,username,num_downloads,avg_rating,num_ratings,geotag,previews", "filter": "created:[* TO NOW]", "page": 15}` should pass


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
