### PR TITLE
Add elasticsearch concurrency tags for Airflow

### DIFF
--- a/catalog/dags/common/sensors/constants.py
+++ b/catalog/dags/common/sensors/constants.py
@@ -1,0 +1,11 @@
+from common.constants import PRODUCTION, STAGING
+
+
+# DagTags used to establish a concurrency group for each environment
+PRODUCTION_ES_CONCURRENCY_TAG = "production_concurrency"
+STAGING_ES_CONCURRENCY_TAG = "staging_concurrency"
+
+ES_CONCURRENCY_TAGS = {
+    PRODUCTION: PRODUCTION_ES_CONCURRENCY_TAG,
+    STAGING: STAGING_ES_CONCURRENCY_TAG,
+}

--- a/catalog/dags/common/sensors/constants.py
+++ b/catalog/dags/common/sensors/constants.py
@@ -2,8 +2,8 @@ from common.constants import PRODUCTION, STAGING
 
 
 # DagTags used to establish a concurrency group for each environment
-PRODUCTION_ES_CONCURRENCY_TAG = "production_concurrency"
-STAGING_ES_CONCURRENCY_TAG = "staging_concurrency"
+PRODUCTION_ES_CONCURRENCY_TAG = "production_es_concurrency"
+STAGING_ES_CONCURRENCY_TAG = "staging_es_concurrency"
 
 ES_CONCURRENCY_TAGS = {
     PRODUCTION: PRODUCTION_ES_CONCURRENCY_TAG,

--- a/catalog/dags/common/sensors/constants.py
+++ b/catalog/dags/common/sensors/constants.py
@@ -1,9 +1,17 @@
 from common.constants import PRODUCTION, STAGING
 
 
-# DagTags used to establish a concurrency group for each environment
-PRODUCTION_ES_CONCURRENCY_TAG = "production_es_concurrency"
-STAGING_ES_CONCURRENCY_TAG = "staging_es_concurrency"
+# These DagTags are used to identify DAGs which should not be run concurrently
+# with one another.
+
+# Used to identify DAGs for each environment which affect the Elasticsearch cluster
+# and should not be run simultaneously
+PRODUCTION_ES_CONCURRENCY_TAG = "production_elasticsearch_concurrency"
+STAGING_ES_CONCURRENCY_TAG = "staging_elasticsearch_concurrency"
+
+# Used to identify DAGs which affect the staging API database in such a
+# way that they should not be run simultaneously
+STAGING_DB_CONCURRENCY_TAG = "staging_api_database_concurrency"
 
 ES_CONCURRENCY_TAGS = {
     PRODUCTION: PRODUCTION_ES_CONCURRENCY_TAG,

--- a/catalog/dags/common/sensors/utils.py
+++ b/catalog/dags/common/sensors/utils.py
@@ -10,6 +10,9 @@ from airflow.utils.state import State
 from common.constants import REFRESH_POKE_INTERVAL
 
 
+THREE_DAYS = 60 * 60 * 24 * 3
+
+
 def _get_most_recent_dag_run(dag_id) -> list[datetime] | datetime:
     """
     Retrieve the most recent DAG run's execution date.
@@ -36,21 +39,40 @@ def _get_most_recent_dag_run(dag_id) -> list[datetime] | datetime:
     return []
 
 
-def _get_dags_with_tag(tag: str, excluded_dag_ids: list[str], session=None):
-    """Get a list of DAG ids with the given tag, optionally excluding certain ids."""
-    if not excluded_dag_ids:
-        excluded_dag_ids = []
-
-    dags = session.query(DagModel).filter(DagModel.tags.any(DagTag.name == tag)).all()
-
-    # Return just the ids, excluding excluded_dag_ids
-    ids = [dag.dag_id for dag in dags if dag.dag_id not in excluded_dag_ids]
-    return ids
-
-
-def wait_for_external_dag(external_dag_id: str, task_id: str | None = None):
+@task
+def get_dags_with_concurrency_tag(
+    tag: str, excluded_dag_ids: list[str], session=None, **context
+):
     """
-    Return a Sensor task which will wait if the given external DAG is
+    Get a list of DAG ids with the given tag. The id of the running DAG is excluded,
+    as well as any ids in the `excluded_dag_ids` list.
+    """
+    dags = session.query(DagModel).filter(DagModel.tags.any(DagTag.name == tag)).all()
+    dag_ids = [dag.dag_id for dag in dags]
+
+    running_dag_id = context["dag"].dag_id
+    if running_dag_id not in dag_ids:
+        raise ValueError(
+            f"The `{running_dag_id}` DAG tried preventing concurrency with the `{tag}`,"
+            " tag, but does not have the tag itself. To ensure that other DAGs with this"
+            f" tag will also avoid running concurrently with `{running_dag_id}`, it must"
+            f"have the `{tag}` tag applied."
+        )
+
+    # Return just the ids of DAGs to prevent concurrency with. This excludes the running dag id,
+    # and any supplied `excluded_dag_ids`
+    return [id for id in dag_ids if id not in [*excluded_dag_ids, running_dag_id]]
+
+
+@task
+def wait_for_external_dag(
+    external_dag_id: str,
+    task_id: str | None = None,
+    timeout: int | None = THREE_DAYS,
+    **context,
+):
+    """
+    Execute a Sensor task which will wait if the given external DAG is
     running.
 
     To fully ensure that the waiting DAG and the external DAG do not run
@@ -64,7 +86,7 @@ def wait_for_external_dag(external_dag_id: str, task_id: str | None = None):
     if not task_id:
         task_id = f"wait_for_{external_dag_id}"
 
-    return ExternalTaskSensor(
+    sensor = ExternalTaskSensor(
         task_id=task_id,
         poke_interval=REFRESH_POKE_INTERVAL,
         external_dag_id=external_dag_id,
@@ -75,24 +97,28 @@ def wait_for_external_dag(external_dag_id: str, task_id: str | None = None):
         mode="reschedule",
         # Any "finished" state is sufficient for us to continue
         allowed_states=[State.SUCCESS, State.FAILED],
+        # execution_timeout for the task does not include time that the sensor
+        # was up for reschedule but not actually running. `timeout` does
+        timeout=timeout,
     )
+
+    sensor.execute(context)
 
 
 @task_group(group_id="wait_for_external_dags")
 @provide_session
 def wait_for_external_dags_with_tag(
-    tag: str, excluded_dag_ids: list[str], session=None, **context
+    tag: str, excluded_dag_ids: list[str] = None, session=None
 ):
     """
     Wait until all DAGs with the given `tag`, excluding those identified by the
     `excluded_dag_ids`, are no longer in the running state before continuing.
     """
-    external_dag_ids = _get_dags_with_tag(
-        tag=tag, excluded_dag_ids=excluded_dag_ids, session=session
-    )
+    external_dag_ids = get_dags_with_concurrency_tag.override(
+        task_id=f"get_dags_in_{tag}_group"
+    )(tag=tag, excluded_dag_ids=excluded_dag_ids or [], session=session)
 
-    for dag_id in external_dag_ids:
-        wait_for_external_dag(dag_id)
+    wait_for_external_dag.expand(external_dag_id=external_dag_ids)
 
 
 @task(retries=0)
@@ -101,13 +127,13 @@ def prevent_concurrency_with_dag(external_dag_id: str, **context):
     Prevent concurrency with the given external DAG, by failing
     immediately if that DAG is running.
     """
-    wait_for_dag = wait_for_external_dag(
-        external_dag_id=external_dag_id,
-        task_id=f"check_for_running_{external_dag_id}",
-    )
-    wait_for_dag.timeout = 0
     try:
-        wait_for_dag.execute(context)
+        wait_for_external_dag.function(
+            external_dag_id=external_dag_id,
+            task_id=f"check_for_running_{external_dag_id}",
+            timeout=0,
+            **context,
+        )
     except AirflowSensorTimeout:
         raise ValueError(f"Concurrency check with {external_dag_id} failed.")
 
@@ -115,7 +141,7 @@ def prevent_concurrency_with_dag(external_dag_id: str, **context):
 @task_group(group_id="prevent_concurrency_with_dags")
 @provide_session
 def prevent_concurrency_with_dags_with_tag(
-    tag: str, excluded_dag_ids: list[str], session=None, **context
+    tag: str, excluded_dag_ids: list[str] = None, session=None
 ):
     """
     Prevent concurrency with any DAGs that have the given `tag`, excluding
@@ -123,14 +149,11 @@ def prevent_concurrency_with_dags_with_tag(
     failing the task immediately if any of the tagged DAGs are in the running
     state.
     """
-    external_dag_ids = _get_dags_with_tag(
-        tag=tag, excluded_dag_ids=excluded_dag_ids, session=session
-    )
+    external_dag_ids = get_dags_with_concurrency_tag.override(
+        task_id=f"get_dags_in_{tag}_group"
+    )(tag=tag, excluded_dag_ids=excluded_dag_ids or [], session=session)
 
-    for external_dag_id in external_dag_ids:
-        prevent_concurrency_with_dag.override(
-            task_id=f"prevent_concurrency_with_{external_dag_id}"
-        )(external_dag_id)
+    prevent_concurrency_with_dag.expand(external_dag_id=external_dag_ids)
 
 
 @task(retries=0)

--- a/catalog/dags/common/sensors/utils.py
+++ b/catalog/dags/common/sensors/utils.py
@@ -41,7 +41,7 @@ def _get_most_recent_dag_run(dag_id) -> list[datetime] | datetime:
 
 @task
 def get_dags_with_concurrency_tag(
-    tag: str, excluded_dag_ids: list[str], session=None, **context
+    tag: str, excluded_dag_ids: list[str], session=None, dag=None
 ):
     """
     Get a list of DAG ids with the given tag. The id of the running DAG is excluded,
@@ -50,7 +50,7 @@ def get_dags_with_concurrency_tag(
     dags = session.query(DagModel).filter(DagModel.tags.any(DagTag.name == tag)).all()
     dag_ids = [dag.dag_id for dag in dags]
 
-    running_dag_id = context["dag"].dag_id
+    running_dag_id = dag.dag_id
     if running_dag_id not in dag_ids:
         raise ValueError(
             f"The `{running_dag_id}` DAG tried preventing concurrency with the `{tag}`,"
@@ -61,7 +61,7 @@ def get_dags_with_concurrency_tag(
 
     # Return just the ids of DAGs to prevent concurrency with. This excludes the running dag id,
     # and any supplied `excluded_dag_ids`
-    return [id for id in dag_ids if id not in [*excluded_dag_ids, running_dag_id]]
+    return [id for id in dag_ids if id not in {*excluded_dag_ids, running_dag_id}]
 
 
 @task

--- a/catalog/dags/data_refresh/create_filtered_index_dag.py
+++ b/catalog/dags/data_refresh/create_filtered_index_dag.py
@@ -56,15 +56,13 @@ from datetime import datetime
 from airflow import DAG
 from airflow.models.param import Param
 
-from common.constants import DAG_DEFAULT_ARGS, PRODUCTION
-from common.sensors.utils import prevent_concurrency_with_dags
+from common.constants import DAG_DEFAULT_ARGS
+from common.sensors.constants import PRODUCTION_ES_CONCURRENCY_TAG
+from common.sensors.utils import prevent_concurrency_with_dags_with_tag
 from data_refresh.create_filtered_index import (
     create_filtered_index_creation_task_groups,
 )
 from data_refresh.data_refresh_types import DATA_REFRESH_CONFIGS, DataRefresh
-from elasticsearch_cluster.create_new_es_index.create_new_es_index_types import (
-    CREATE_NEW_INDEX_CONFIGS,
-)
 
 
 # Note: We can't use the TaskFlow `@dag` DAG factory decorator
@@ -88,7 +86,7 @@ def create_filtered_index_creation_dag(data_refresh: DataRefresh):
         default_args=DAG_DEFAULT_ARGS,
         schedule=None,
         start_date=datetime(2023, 4, 1),
-        tags=["data_refresh"],
+        tags=["data_refresh", PRODUCTION_ES_CONCURRENCY_TAG],
         max_active_runs=1,
         catchup=False,
         doc_md=__doc__,
@@ -117,14 +115,12 @@ def create_filtered_index_creation_dag(data_refresh: DataRefresh):
         },
         render_template_as_native_obj=True,
     ) as dag:
-        # Immediately fail if the associated data refresh is running, or the
-        # create_new_production_es_index DAG is running. This prevents multiple
-        # DAGs from reindexing from a single production index simultaneously.
-        prevent_concurrency = prevent_concurrency_with_dags(
-            external_dag_ids=[
-                data_refresh.dag_id,
-                CREATE_NEW_INDEX_CONFIGS[PRODUCTION].dag_id,
-            ]
+        # Immediately fail if any DAG that operates on the production elasticsearch
+        # cluster is running. This prevents multiple DAGs from reindexing from a
+        # single production index simultaneously.
+        prevent_concurrency = prevent_concurrency_with_dags_with_tag(
+            tag=PRODUCTION_ES_CONCURRENCY_TAG,
+            excluded_dag_ids=[data_refresh.filtered_index_dag_id],
         )
 
         # Once the concurrency check has passed, actually create the filtered

--- a/catalog/dags/data_refresh/create_filtered_index_dag.py
+++ b/catalog/dags/data_refresh/create_filtered_index_dag.py
@@ -121,7 +121,6 @@ def create_filtered_index_creation_dag(data_refresh: DataRefresh):
         # single production index simultaneously.
         prevent_concurrency = prevent_concurrency_with_dags_with_tag(
             tag=PRODUCTION_ES_CONCURRENCY_TAG,
-            excluded_dag_ids=[data_refresh.filtered_index_dag_id],
         )
 
         # Once the concurrency check has passed, actually create the filtered

--- a/catalog/dags/data_refresh/create_filtered_index_dag.py
+++ b/catalog/dags/data_refresh/create_filtered_index_dag.py
@@ -43,7 +43,7 @@ no data source from which to pull documents.
 There are two mechanisms that prevent this from happening:
 
 1. The filtered index creation DAGs fail immediately if any of the DAGs that are
-tagged as prt of the `production-es-concurrency` group (including the data
+tagged as part of the `production-es-concurrency` group (including the data
 refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
 DAG runs for the media type to finish before continuing.

--- a/catalog/dags/data_refresh/create_filtered_index_dag.py
+++ b/catalog/dags/data_refresh/create_filtered_index_dag.py
@@ -42,8 +42,9 @@ no data source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh
-for the media type is already running.
+1. The filtered index creation DAGs fail immediately if any of the DAGs that are
+tagged as prt of the `production-es-concurrency` group (including the data
+refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
 DAG runs for the media type to finish before continuing.
 

--- a/catalog/dags/data_refresh/dag_factory.py
+++ b/catalog/dags/data_refresh/dag_factory.py
@@ -34,6 +34,7 @@ from common.constants import (
     OPENLEDGER_API_CONN_ID,
     XCOM_PULL_TEMPLATE,
 )
+from common.sensors.constants import PRODUCTION_ES_CONCURRENCY_TAG
 from common.sql import PGExecuteQueryOperator, single_value
 from data_refresh.data_refresh_task_factory import create_data_refresh_task_group
 from data_refresh.data_refresh_types import DATA_REFRESH_CONFIGS, DataRefresh
@@ -70,7 +71,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
         max_active_runs=1,
         catchup=False,
         doc_md=__doc__,
-        tags=["data_refresh"],
+        tags=["data_refresh", PRODUCTION_ES_CONCURRENCY_TAG],
     )
 
     with dag:

--- a/catalog/dags/data_refresh/data_refresh_task_factory.py
+++ b/catalog/dags/data_refresh/data_refresh_task_factory.py
@@ -125,9 +125,9 @@ def create_data_refresh_task_group(
             group_id="wait_for_es_dags"
         )(
             tag=PRODUCTION_ES_CONCURRENCY_TAG,
-            # Exclude the current DAG id, as well as all other data refresh DAG ids (these
-            # are waited on in the previous task)
-            excluded_dag_ids=[*external_dag_ids, data_refresh.dag_id],
+            # Exclude the other data refresh DAG ids, as waiting on these was handled in
+            # the previous task.
+            excluded_dag_ids=external_dag_ids,
         )
         tasks.append([wait_for_data_refresh, wait_for_es_dags])
 

--- a/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
@@ -80,7 +80,6 @@ def restore_staging_database():
     # Wait for any DAGs that operate on the staging elasticsearch cluster
     wait_for_recreate_full_staging_index = wait_for_external_dags_with_tag(
         tag=STAGING_ES_CONCURRENCY_TAG,
-        excluded_dag_ids=[constants.DAG_ID],
     )
     should_skip = skip_restore()
     latest_snapshot = get_latest_prod_snapshot()

--- a/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
@@ -1,5 +1,5 @@
 """
-# Update the staging database
+# Staging Database Restore DAG
 
 This DAG is responsible for updating the staging database using the most recent
 snapshot of the production database.
@@ -19,6 +19,11 @@ run using a different hook:
   (e.g. `aws_rds`)
 - `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the above
   example, it might be `AIRFLOW_CONN_AWS_RDS`)
+
+## Race conditions
+
+Because this DAG completely replaces the staging database, it first waits on any
+running DAGs that are tagged as part of the `staging_es_concurrency` group.
 """
 
 import logging

--- a/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
+++ b/catalog/dags/database/staging_database_restore/staging_database_restore_dag.py
@@ -35,7 +35,8 @@ from common.constants import (
     DAG_DEFAULT_ARGS,
     POSTGRES_API_STAGING_CONN_ID,
 )
-from common.sensors.utils import wait_for_external_dag
+from common.sensors.constants import STAGING_ES_CONCURRENCY_TAG
+from common.sensors.utils import wait_for_external_dags_with_tag
 from common.sql import PGExecuteQueryOperator
 from database.staging_database_restore import constants
 from database.staging_database_restore.staging_database_restore import (
@@ -48,9 +49,6 @@ from database.staging_database_restore.staging_database_restore import (
     restore_staging_from_snapshot,
     skip_restore,
 )
-from elasticsearch_cluster.recreate_staging_index.recreate_full_staging_index import (
-    DAG_ID as RECREATE_STAGING_INDEX_DAG_ID,
-)
 
 
 log = logging.getLogger(__name__)
@@ -60,7 +58,7 @@ log = logging.getLogger(__name__)
     dag_id=constants.DAG_ID,
     schedule="@monthly",
     start_date=datetime(2023, 5, 1),
-    tags=["database"],
+    tags=["database", STAGING_ES_CONCURRENCY_TAG],
     max_active_runs=1,
     dagrun_timeout=timedelta(days=1),
     catchup=False,
@@ -74,11 +72,10 @@ log = logging.getLogger(__name__)
     render_template_as_native_obj=True,
 )
 def restore_staging_database():
-    # If the `recreate_full_staging_index` DAG was manually triggered prior
-    # to the database restoration starting, we should wait for it to
-    # finish.
-    wait_for_recreate_full_staging_index = wait_for_external_dag(
-        external_dag_id=RECREATE_STAGING_INDEX_DAG_ID,
+    # Wait for any DAGs that operate on the staging elasticsearch cluster
+    wait_for_recreate_full_staging_index = wait_for_external_dags_with_tag(
+        tag=STAGING_ES_CONCURRENCY_TAG,
+        excluded_dag_ids=[constants.DAG_ID],
     )
     should_skip = skip_restore()
     latest_snapshot = get_latest_prod_snapshot()

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
@@ -136,15 +136,15 @@ from elasticsearch_cluster.create_new_es_index.create_new_es_index_types import 
 logger = logging.getLogger(__name__)
 
 
-def create_new_es_index_dag(config: CreateNewIndex):
+def create_new_es_index_dag(dag_config: CreateNewIndex):
     dag = DAG(
-        dag_id=config.dag_id,
+        dag_id=dag_config.dag_id,
         default_args=DAG_DEFAULT_ARGS,
         schedule=None,
         max_active_runs=1,
         catchup=False,
         doc_md=__doc__,
-        tags=["elasticsearch", config.concurrency_tag],
+        tags=["elasticsearch", dag_config.concurrency_tag],
         render_template_as_native_obj=True,
         params={
             "media_type": Param(
@@ -228,10 +228,10 @@ def create_new_es_index_dag(config: CreateNewIndex):
         # Fail early if any other DAG that operates on the relevant elasticsearch cluster
         # is running
         prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-            tag=config.concurrency_tag,
+            tag=dag_config.concurrency_tag,
         )
 
-        es_host = es.get_es_host(environment=config.environment)
+        es_host = es.get_es_host(environment=dag_config.environment)
 
         index_name = get_index_name(
             media_type="{{ params.media_type }}",
@@ -271,8 +271,8 @@ def create_new_es_index_dag(config: CreateNewIndex):
             destination_index=index_name,
             source_index="{{ params.source_index or params.media_type }}",
             query="{{ params.query }}",
-            timeout=config.reindex_timeout,
-            requests_per_second=config.requests_per_second,
+            timeout=dag_config.reindex_timeout,
+            requests_per_second=dag_config.requests_per_second,
             es_host=es_host,
         )
 
@@ -305,6 +305,6 @@ def create_new_es_index_dag(config: CreateNewIndex):
     return dag
 
 
-for config in CREATE_NEW_INDEX_CONFIGS.values():
+for dag_config in CREATE_NEW_INDEX_CONFIGS.values():
     # Generate the DAG for this environment
-    globals()[config.dag_id] = create_new_es_index_dag(config)
+    globals()[dag_config.dag_id] = create_new_es_index_dag(dag_config)

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
@@ -144,7 +144,7 @@ def create_new_es_index_dag(dag_config: CreateNewIndex):
         max_active_runs=1,
         catchup=False,
         doc_md=__doc__,
-        tags=["elasticsearch", dag_config.concurrency_tag],
+        tags=["elasticsearch", dag_config.prevent_concurrency_tag],
         render_template_as_native_obj=True,
         params={
             "media_type": Param(
@@ -228,7 +228,7 @@ def create_new_es_index_dag(dag_config: CreateNewIndex):
         # Fail early if any other DAG that operates on the relevant elasticsearch cluster
         # is running
         prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-            tag=dag_config.concurrency_tag,
+            tag=dag_config.prevent_concurrency_tag,
         )
 
         es_host = es.get_es_host(environment=dag_config.environment)

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
@@ -100,6 +100,13 @@ The resulting, merged configuration will be:
     }
 }
 ```
+
+## Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`create_new_staging_es_index` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
 """
 
 import logging

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_dag.py
@@ -228,7 +228,7 @@ def create_new_es_index_dag(config: CreateNewIndex):
         # Fail early if any other DAG that operates on the relevant elasticsearch cluster
         # is running
         prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-            tag=config.concurrency_tag, excluded_dag_ids=[config.dag_id]
+            tag=config.concurrency_tag,
         )
 
         es_host = es.get_es_host(environment=config.environment)

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_types.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_types.py
@@ -14,27 +14,27 @@ class CreateNewIndex:
 
     Required Constructor Arguments:
 
-    environment:         str representation of the environment in which to
-                         create the new index
-    concurrency_tag:     tag used to identify dags with which to prevent
-                         concurrency
-                         immediately if any of these dags are running.
-    reindex_timeout:     timedelta expressing maximum amount of time the
-                         reindexing step may take
-    requests_per_second: number of requests to send per second during ES
-                         reindexing, used to throttle the reindex step
+    environment:                 str representation of the environment in which to
+                                 create the new index
+    prevent_concurrency_tag:     tag used to identify dags with which to prevent
+                                 concurrency immediately if any of these dags are
+                                 running.
+    reindex_timeout:             timedelta expressing maximum amount of time the
+                                 reindexing step may take
+    requests_per_second:         number of requests to send per second during ES
+                                 reindexing, used to throttle the reindex step
     """
 
     dag_id: str = field(init=False)
     es_host: str = field(init=False)
-    concurrency_tag: str = field(init=False)
+    prevent_concurrency_tag: str = field(init=False)
     environment: str
     requests_per_second: int | None = None
     reindex_timeout: timedelta = timedelta(hours=12)
 
     def __post_init__(self):
         self.dag_id = f"create_new_{self.environment}_es_index"
-        self.concurrency_tag = ES_CONCURRENCY_TAGS[self.environment]
+        self.prevent_concurrency_tag = ES_CONCURRENCY_TAGS[self.environment]
 
         if not self.requests_per_second:
             self.requests_per_second = Variable.get(

--- a/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_types.py
+++ b/catalog/dags/elasticsearch_cluster/create_new_es_index/create_new_es_index_types.py
@@ -4,13 +4,7 @@ from datetime import timedelta
 from airflow.models import Variable
 
 from common.constants import PRODUCTION, STAGING
-from data_refresh.data_refresh_types import DATA_REFRESH_CONFIGS
-from database.staging_database_restore.constants import (
-    DAG_ID as STAGING_DB_RESTORE_DAG_ID,
-)
-from elasticsearch_cluster.recreate_staging_index.recreate_full_staging_index import (
-    DAG_ID as RECREATE_STAGING_INDEX_DAG_ID,
-)
+from common.sensors.constants import ES_CONCURRENCY_TAGS
 
 
 @dataclass
@@ -22,8 +16,8 @@ class CreateNewIndex:
 
     environment:         str representation of the environment in which to
                          create the new index
-    blocking_dags:       list of dags with which to prevent concurrency; the
-                         generated create_new_es_index dag will fail
+    concurrency_tag:     tag used to identify dags with which to prevent
+                         concurrency
                          immediately if any of these dags are running.
     reindex_timeout:     timedelta expressing maximum amount of time the
                          reindexing step may take
@@ -33,13 +27,14 @@ class CreateNewIndex:
 
     dag_id: str = field(init=False)
     es_host: str = field(init=False)
+    concurrency_tag: str = field(init=False)
     environment: str
-    blocking_dags: list
     requests_per_second: int | None = None
     reindex_timeout: timedelta = timedelta(hours=12)
 
     def __post_init__(self):
         self.dag_id = f"create_new_{self.environment}_es_index"
+        self.concurrency_tag = ES_CONCURRENCY_TAGS[self.environment]
 
         if not self.requests_per_second:
             self.requests_per_second = Variable.get(
@@ -50,17 +45,8 @@ class CreateNewIndex:
 CREATE_NEW_INDEX_CONFIGS = {
     STAGING: CreateNewIndex(
         environment=STAGING,
-        blocking_dags=[RECREATE_STAGING_INDEX_DAG_ID, STAGING_DB_RESTORE_DAG_ID],
     ),
     PRODUCTION: CreateNewIndex(
         environment=PRODUCTION,
-        blocking_dags=(
-            # Block on all the data refreshes
-            [data_refresh.dag_id for data_refresh in DATA_REFRESH_CONFIGS.values()]
-            + [  # Block on the filtered index creation DAGs
-                data_refresh.filtered_index_dag_id
-                for data_refresh in DATA_REFRESH_CONFIGS.values()
-            ]
-        ),
     ),
 }

--- a/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
@@ -28,9 +28,8 @@ This DAG is on a `None` schedule and is run manually.
 
 ## Race conditions
 
-Because this DAG runs on the staging ingestion server and staging elasticsearch
-cluster, it does _not_ interfere with the `data_refresh` or
-`create_filtered_index` DAGs.
+Because this DAG runs on the staging elasticsearch cluster, it does _not_ interfere
+ with the `data_refresh` or `create_filtered_index` DAGs.
 
 However, as the DAG operates on the staging API database it will exit
 immediately if any of the following DAGs are running:
@@ -53,18 +52,10 @@ from common.constants import (
     MEDIA_TYPES,
     STAGING,
 )
-from common.sensors.utils import prevent_concurrency_with_dags
-from database.staging_database_restore.constants import (
-    DAG_ID as STAGING_DB_RESTORE_DAG_ID,
-)
-from elasticsearch_cluster.create_new_es_index.create_new_es_index_types import (
-    CREATE_NEW_INDEX_CONFIGS,
-)
+from common.sensors.constants import STAGING_ES_CONCURRENCY_TAG
+from common.sensors.utils import prevent_concurrency_with_dags_with_tag
 from elasticsearch_cluster.create_proportional_by_source_staging_index import (
     create_proportional_by_source_staging_index as create_index,
-)
-from elasticsearch_cluster.recreate_staging_index.recreate_full_staging_index import (
-    DAG_ID as RECREATE_STAGING_INDEX_DAG_ID,
 )
 
 
@@ -76,7 +67,7 @@ DAG_ID = "create_proportional_by_source_staging_index"
     default_args=DAG_DEFAULT_ARGS,
     schedule=None,
     start_date=datetime(2024, 1, 31),
-    tags=["database", "elasticsearch"],
+    tags=["elasticsearch", STAGING_ES_CONCURRENCY_TAG],
     max_active_runs=1,
     catchup=False,
     doc_md=__doc__,
@@ -118,12 +109,8 @@ DAG_ID = "create_proportional_by_source_staging_index"
 )
 def create_proportional_by_source_staging_index():
     # Fail early if any conflicting DAGs are running
-    prevent_concurrency = prevent_concurrency_with_dags(
-        external_dag_ids=[
-            STAGING_DB_RESTORE_DAG_ID,
-            RECREATE_STAGING_INDEX_DAG_ID,
-            CREATE_NEW_INDEX_CONFIGS[STAGING].dag_id,
-        ]
+    prevent_concurrency = prevent_concurrency_with_dags_with_tag(
+        tag=STAGING_ES_CONCURRENCY_TAG, excluded_dag_ids=[DAG_ID]
     )
 
     es_host = es.get_es_host(environment=STAGING)

--- a/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
@@ -106,7 +106,7 @@ DAG_ID = "create_proportional_by_source_staging_index"
 def create_proportional_by_source_staging_index():
     # Fail early if any conflicting DAGs are running
     prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-        tag=STAGING_ES_CONCURRENCY_TAG, excluded_dag_ids=[DAG_ID]
+        tag=STAGING_ES_CONCURRENCY_TAG,
     )
 
     es_host = es.get_es_host(environment=STAGING)

--- a/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/create_proportional_by_source_staging_index/create_proportional_by_source_staging_index_dag.py
@@ -29,13 +29,9 @@ This DAG is on a `None` schedule and is run manually.
 ## Race conditions
 
 Because this DAG runs on the staging elasticsearch cluster, it does _not_ interfere
- with the `data_refresh` or `create_filtered_index` DAGs.
-
-However, as the DAG operates on the staging API database it will exit
-immediately if any of the following DAGs are running:
-* `staging_database_restore`
-* `recreate_full_staging_index`
-* `create_new_staging_es_index`
+ with the production `data_refresh` or `create_filtered_index` DAGs. However, it will
+ fail immediately if any of the DAGs tagged as part of the `staging-es-concurrency`
+ group are running.
 """
 
 from datetime import datetime, timedelta

--- a/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
+++ b/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
@@ -38,7 +38,7 @@ from common.sensors.utils import prevent_concurrency_with_dags_with_tag
 
 
 def point_es_alias_dag(environment: str):
-        dag = DAG(
+    dag = DAG(
         dag_id=f"point_{environment}_alias",
         default_args=DAG_DEFAULT_ARGS,
         schedule=None,

--- a/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
+++ b/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
@@ -39,7 +39,7 @@ from common.sensors.utils import prevent_concurrency_with_dags_with_tag
 
 def point_es_alias_dag(environment: str):
     dag = DAG(
-        dag_id=f"point_{environment}_alias",
+        dag_id=f"point_{environment}_es_alias",
         default_args=DAG_DEFAULT_ARGS,
         schedule=None,
         start_date=datetime(2024, 1, 31),

--- a/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
+++ b/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
@@ -37,9 +37,9 @@ from common.sensors.constants import ES_CONCURRENCY_TAGS
 from common.sensors.utils import prevent_concurrency_with_dags_with_tag
 
 
-def point_es_alias_dag(environment: str, dag_id: str):
-    dag = DAG(
-        dag_id=dag_id,
+def point_es_alias_dag(environment: str):
+        dag = DAG(
+        dag_id=f"point_{environment}_alias",
         default_args=DAG_DEFAULT_ARGS,
         schedule=None,
         start_date=datetime(2024, 1, 31),
@@ -79,7 +79,7 @@ def point_es_alias_dag(environment: str, dag_id: str):
         # Fail early if any other DAG that operates on the elasticsearch cluster for
         # this environment is running
         prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-            tag=ES_CONCURRENCY_TAGS[environment], excluded_dag_ids=[dag_id]
+            tag=ES_CONCURRENCY_TAGS[environment],
         )
 
         es_host = es.get_es_host(environment=environment)
@@ -104,4 +104,4 @@ def point_es_alias_dag(environment: str, dag_id: str):
 
 
 for environment in ENVIRONMENTS:
-    point_es_alias_dag(environment, f"point_{environment}_alias")
+    point_es_alias_dag(environment)

--- a/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
+++ b/catalog/dags/elasticsearch_cluster/point_es_alias/point_es_alias_dag.py
@@ -12,6 +12,13 @@ optionally, it can also delete that index afterward.
 ## When this DAG runs
 
 This DAG is on a `None` schedule and is run manually.
+
+## Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`point_staging_alias` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
 """
 
 from datetime import datetime

--- a/catalog/dags/elasticsearch_cluster/recreate_staging_index/recreate_full_staging_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/recreate_staging_index/recreate_full_staging_index_dag.py
@@ -103,7 +103,7 @@ def recreate_full_staging_index():
     # Fail early if any other DAG that operates on the staging elasticsearch cluster
     # is running
     prevent_concurrency = prevent_concurrency_with_dags_with_tag(
-        tag=STAGING_ES_CONCURRENCY_TAG, excluded_dag_ids=[DAG_ID]
+        tag=STAGING_ES_CONCURRENCY_TAG,
     )
 
     target_alias = get_target_alias(

--- a/catalog/dags/elasticsearch_cluster/recreate_staging_index/recreate_full_staging_index_dag.py
+++ b/catalog/dags/elasticsearch_cluster/recreate_staging_index/recreate_full_staging_index_dag.py
@@ -34,11 +34,9 @@ Because this DAG runs on the staging ingestion server and staging elasticsearch
 cluster, it does _not_ interfere with the `data_refresh` or
 `create_filtered_index` DAGs.
 
-However, as the DAG operates on the staging API database it will exit
-immediately if any of the following DAGs are running:
-* `staging_database_restore`
-* `create_proportional_by_provider_staging_index`
-* `create_new_staging_es_index`
+However, as the DAG operates on the staging API database and ES cluster it will exit
+immediately if any of the DAGs tagged as part of the `staging_es_concurrency` group
+are already running.
 """
 
 from datetime import datetime

--- a/catalog/tests/dags/common/sensors/test_utils.py
+++ b/catalog/tests/dags/common/sensors/test_utils.py
@@ -5,7 +5,7 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
-from common.sensors.utils import get_most_recent_dag_run
+from common.sensors.utils import _get_most_recent_dag_run
 
 
 TEST_DAG_ID = "data_refresh_dag_factory_test_dag"
@@ -29,11 +29,11 @@ def test_get_most_recent_dag_run_returns_most_recent_execution_date(
     most_recent = datetime(2023, 5, 10)
     for i in range(3):
         _create_dagrun(most_recent - timedelta(days=i), sample_dag_id_fixture)
-    assert get_most_recent_dag_run(sample_dag_id_fixture) == most_recent
+    assert _get_most_recent_dag_run(sample_dag_id_fixture) == most_recent
 
 
 def test_get_most_recent_dag_run_returns_empty_list_when_no_runs(
     sample_dag_id_fixture, clean_db
 ):
     # Relies on ``clean_db`` cleaning up DagRuns from other tests
-    assert get_most_recent_dag_run(sample_dag_id_fixture) == []
+    assert _get_most_recent_dag_run(sample_dag_id_fixture) == []

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -434,7 +434,7 @@ source from which to pull documents.
 There are two mechanisms that prevent this from happening:
 
 1. The filtered index creation DAGs fail immediately if any of the DAGs that are
-   tagged as prt of the `production-es-concurrency` group (including the data
+   tagged as part of the `production-es-concurrency` group (including the data
    refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
    DAG runs for the media type to finish before continuing.
@@ -490,7 +490,7 @@ source from which to pull documents.
 There are two mechanisms that prevent this from happening:
 
 1. The filtered index creation DAGs fail immediately if any of the DAGs that are
-   tagged as prt of the `production-es-concurrency` group (including the data
+   tagged as part of the `production-es-concurrency` group (including the data
    refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
    DAG runs for the media type to finish before continuing.

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -58,8 +58,8 @@ The following are DAGs grouped by their primary tag:
 | [`create_new_production_es_index`](#create_new_production_es_index)                             | `None`            |
 | [`create_new_staging_es_index`](#create_new_staging_es_index)                                   | `None`            |
 | [`create_proportional_by_source_staging_index`](#create_proportional_by_source_staging_index)   | `None`            |
-| [`point_production_alias`](#point_production_alias)                                             | `None`            |
-| [`point_staging_alias`](#point_staging_alias)                                                   | `None`            |
+| [`point_production_es_alias`](#point_production_es_alias)                                       | `None`            |
+| [`point_staging_es_alias`](#point_staging_es_alias)                                             | `None`            |
 | [`production_elasticsearch_cluster_healthcheck`](#production_elasticsearch_cluster_healthcheck) | `*/15 * * * *`    |
 | [`staging_elasticsearch_cluster_healthcheck`](#staging_elasticsearch_cluster_healthcheck)       | `*/15 * * * *`    |
 
@@ -160,8 +160,8 @@ The following is documentation associated with each DAG (where available):
 1.  [`oauth2_token_refresh`](#oauth2_token_refresh)
 1.  [`phylopic_reingestion_workflow`](#phylopic_reingestion_workflow)
 1.  [`phylopic_workflow`](#phylopic_workflow)
-1.  [`point_production_alias`](#point_production_alias)
-1.  [`point_staging_alias`](#point_staging_alias)
+1.  [`point_production_es_alias`](#point_production_es_alias)
+1.  [`point_staging_es_alias`](#point_staging_es_alias)
 1.  [`pr_review_reminders`](#pr_review_reminders)
 1.  [`production_elasticsearch_cluster_healthcheck`](#production_elasticsearch_cluster_healthcheck)
 1.  [`rawpixel_workflow`](#rawpixel_workflow)
@@ -1065,7 +1065,7 @@ Output: TSV file containing the image, their respective meta-data.
 
 Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
 
-### `point_production_alias`
+### `point_production_es_alias`
 
 #### Point ES Alias DAG
 
@@ -1088,7 +1088,7 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `point_staging_alias` DAG fails immediately if any DAGs tagged with
 `staging-es-concurrency` are running.)
 
-### `point_staging_alias`
+### `point_staging_es_alias`
 
 #### Point ES Alias DAG
 
@@ -1319,11 +1319,6 @@ the RDS operations run using a different hook:
   `aws_rds`)
 - `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
   above example, it might be `AIRFLOW_CONN_AWS_RDS`)
-
-##### Race conditions
-
-Because this DAG completely replaces the staging database, it first waits on any
-running DAGs that are tagged as part of the `staging_es_concurrency` group.
 
 ### `staging_elasticsearch_cluster_healthcheck`
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -41,18 +41,15 @@ The following are DAGs grouped by their primary tag:
 
 ### Database
 
-| DAG ID                                                                                        | Schedule Interval |
-| --------------------------------------------------------------------------------------------- | ----------------- |
-| [`batched_update`](#batched_update)                                                           | `None`            |
-| [`create_proportional_by_source_staging_index`](#create_proportional_by_source_staging_index) | `None`            |
-| [`delete_records`](#delete_records)                                                           | `None`            |
-| [`point_production_es_alias`](#point_production_es_alias)                                     | `None`            |
-| [`point_staging_es_alias`](#point_staging_es_alias)                                           | `None`            |
-| [`recreate_audio_popularity_calculation`](#recreate_audio_popularity_calculation)             | `None`            |
-| [`recreate_full_staging_index`](#recreate_full_staging_index)                                 | `None`            |
-| [`recreate_image_popularity_calculation`](#recreate_image_popularity_calculation)             | `None`            |
-| [`report_pending_reported_media`](#report_pending_reported_media)                             | `@weekly`         |
-| [`staging_database_restore`](#staging_database_restore)                                       | `@monthly`        |
+| DAG ID                                                                            | Schedule Interval |
+| --------------------------------------------------------------------------------- | ----------------- |
+| [`batched_update`](#batched_update)                                               | `None`            |
+| [`delete_records`](#delete_records)                                               | `None`            |
+| [`recreate_audio_popularity_calculation`](#recreate_audio_popularity_calculation) | `None`            |
+| [`recreate_full_staging_index`](#recreate_full_staging_index)                     | `None`            |
+| [`recreate_image_popularity_calculation`](#recreate_image_popularity_calculation) | `None`            |
+| [`report_pending_reported_media`](#report_pending_reported_media)                 | `@weekly`         |
+| [`staging_database_restore`](#staging_database_restore)                           | `@monthly`        |
 
 ### Elasticsearch
 
@@ -60,6 +57,9 @@ The following are DAGs grouped by their primary tag:
 | ----------------------------------------------------------------------------------------------- | ----------------- |
 | [`create_new_production_es_index`](#create_new_production_es_index)                             | `None`            |
 | [`create_new_staging_es_index`](#create_new_staging_es_index)                                   | `None`            |
+| [`create_proportional_by_source_staging_index`](#create_proportional_by_source_staging_index)   | `None`            |
+| [`point_production_es_alias`](#point_production_es_alias)                                       | `None`            |
+| [`point_staging_es_alias`](#point_staging_es_alias)                                             | `None`            |
 | [`production_elasticsearch_cluster_healthcheck`](#production_elasticsearch_cluster_healthcheck) | `*/15 * * * *`    |
 | [`staging_elasticsearch_cluster_healthcheck`](#staging_elasticsearch_cluster_healthcheck)       | `*/15 * * * *`    |
 
@@ -433,8 +433,9 @@ source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh for
-   the media type is already running.
+1. The filtered index creation DAGs fail immediately if any of the DAGs that are
+   tagged as prt of the `production-es-concurrency` group (including the data
+   refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
    DAG runs for the media type to finish before continuing.
 
@@ -488,8 +489,9 @@ source from which to pull documents.
 
 There are two mechanisms that prevent this from happening:
 
-1. The filtered index creation DAGs are not allowed to run if a data refresh for
-   the media type is already running.
+1. The filtered index creation DAGs fail immediately if any of the DAGs that are
+   tagged as prt of the `production-es-concurrency` group (including the data
+   refreshes) are currently running.
 2. The data refresh DAGs will wait for any pre-existing filtered index creation
    DAG runs for the media type to finish before continuing.
 
@@ -600,6 +602,13 @@ The resulting, merged configuration will be:
 }
 ```
 
+##### Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`create_new_staging_es_index` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
+
 ### `create_new_staging_es_index`
 
 #### Create New ES Index DAG
@@ -704,6 +713,13 @@ The resulting, merged configuration will be:
 }
 ```
 
+##### Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`create_new_staging_es_index` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
+
 ### `create_proportional_by_source_staging_index`
 
 #### Create Proportional By Source Staging Index DAG
@@ -732,16 +748,10 @@ This DAG is on a `None` schedule and is run manually.
 
 ##### Race conditions
 
-Because this DAG runs on the staging ingestion server and staging elasticsearch
-cluster, it does _not_ interfere with the `data_refresh` or
-`create_filtered_index` DAGs.
-
-However, as the DAG operates on the staging API database it will exit
-immediately if any of the following DAGs are running:
-
-- `staging_database_restore`
-- `recreate_full_staging_index`
-- `create_new_staging_es_index`
+Because this DAG runs on the staging elasticsearch cluster, it does _not_
+interfere with the production `data_refresh` or `create_filtered_index` DAGs.
+However, it will fail immediately if any of the DAGs tagged as part of the
+`staging-es-concurrency` group are running.
 
 ### `delete_records`
 
@@ -1071,7 +1081,18 @@ also delete that index afterward.
 
 This DAG is on a `None` schedule and is run manually.
 
+<<<<<<< HEAD
 ### `point_staging_es_alias`
+=======
+##### Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`point_staging_alias` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
+
+### `point_staging_alias`
+>>>>>>> be549cdee (Update dag docs)
 
 #### Point ES Alias DAG
 
@@ -1086,6 +1107,13 @@ also delete that index afterward.
 ##### When this DAG runs
 
 This DAG is on a `None` schedule and is run manually.
+
+##### Race conditions
+
+Each DAG will fail immediately if any of the DAGs tagged as part of the
+es-concurrency group for the DAG's environment is running. (E.g., the
+`point_staging_alias` DAG fails immediately if any DAGs tagged with
+`staging-es-concurrency` are running.)
 
 ### `pr_review_reminders`
 
@@ -1192,12 +1220,9 @@ Because this DAG runs on the staging ingestion server and staging elasticsearch
 cluster, it does _not_ interfere with the `data_refresh` or
 `create_filtered_index` DAGs.
 
-However, as the DAG operates on the staging API database it will exit
-immediately if any of the following DAGs are running:
-
-- `staging_database_restore`
-- `create_proportional_by_provider_staging_index`
-- `create_new_staging_es_index`
+However, as the DAG operates on the staging API database and ES cluster it will
+exit immediately if any of the DAGs tagged as part of the
+`staging_es_concurrency` group are already running.
 
 ### `recreate_image_popularity_calculation`
 
@@ -1277,7 +1302,7 @@ Notes: https://www.smk.dk/en/article/smk-api/
 
 ### `staging_database_restore`
 
-#### Update the staging database
+#### Staging Database Restore DAG
 
 This DAG is responsible for updating the staging database using the most recent
 snapshot of the production database.
@@ -1298,6 +1323,11 @@ the RDS operations run using a different hook:
   `aws_rds`)
 - `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
   above example, it might be `AIRFLOW_CONN_AWS_RDS`)
+
+##### Race conditions
+
+Because this DAG completely replaces the staging database, it first waits on any
+running DAGs that are tagged as part of the `staging_es_concurrency` group.
 
 ### `staging_elasticsearch_cluster_healthcheck`
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -58,8 +58,8 @@ The following are DAGs grouped by their primary tag:
 | [`create_new_production_es_index`](#create_new_production_es_index)                             | `None`            |
 | [`create_new_staging_es_index`](#create_new_staging_es_index)                                   | `None`            |
 | [`create_proportional_by_source_staging_index`](#create_proportional_by_source_staging_index)   | `None`            |
-| [`point_production_es_alias`](#point_production_es_alias)                                       | `None`            |
-| [`point_staging_es_alias`](#point_staging_es_alias)                                             | `None`            |
+| [`point_production_alias`](#point_production_alias)                                             | `None`            |
+| [`point_staging_alias`](#point_staging_alias)                                                   | `None`            |
 | [`production_elasticsearch_cluster_healthcheck`](#production_elasticsearch_cluster_healthcheck) | `*/15 * * * *`    |
 | [`staging_elasticsearch_cluster_healthcheck`](#staging_elasticsearch_cluster_healthcheck)       | `*/15 * * * *`    |
 
@@ -160,8 +160,8 @@ The following is documentation associated with each DAG (where available):
 1.  [`oauth2_token_refresh`](#oauth2_token_refresh)
 1.  [`phylopic_reingestion_workflow`](#phylopic_reingestion_workflow)
 1.  [`phylopic_workflow`](#phylopic_workflow)
-1.  [`point_production_es_alias`](#point_production_es_alias)
-1.  [`point_staging_es_alias`](#point_staging_es_alias)
+1.  [`point_production_alias`](#point_production_alias)
+1.  [`point_staging_alias`](#point_staging_alias)
 1.  [`pr_review_reminders`](#pr_review_reminders)
 1.  [`production_elasticsearch_cluster_healthcheck`](#production_elasticsearch_cluster_healthcheck)
 1.  [`rawpixel_workflow`](#rawpixel_workflow)
@@ -1065,7 +1065,7 @@ Output: TSV file containing the image, their respective meta-data.
 
 Notes: http://api-docs.phylopic.org/v2/ No rate limit specified.
 
-### `point_production_es_alias`
+### `point_production_alias`
 
 #### Point ES Alias DAG
 
@@ -1081,9 +1081,6 @@ also delete that index afterward.
 
 This DAG is on a `None` schedule and is run manually.
 
-<<<<<<< HEAD
-### `point_staging_es_alias`
-=======
 ##### Race conditions
 
 Each DAG will fail immediately if any of the DAGs tagged as part of the
@@ -1092,7 +1089,6 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `staging-es-concurrency` are running.)
 
 ### `point_staging_alias`
->>>>>>> be549cdee (Update dag docs)
 
 #### Point ES Alias DAG
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3891 by @stacimc 


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

We now have quite a few DAGs that all operate on Elasticsearch or the underlying databases, and therefore must not run concurrently. We've been using the `prevent_concurrency_with_dags` and `wait_for_external_dags` utils to accomplish this in each DAG, by passing in a hard-coded list of the external DAGs we want to either wait on or otherwise prevent concurrency with. Since this list is hard-coded for each DAG, it is extremely easy to miss dependencies especially as DAGs are added and changed. A few were missed in the implementation of the Search Relevancy project so far.

This PR introduces ~two~ **three** new Tags that are used to identify DAGs as being part of a "concurrency group": `production_elasticsearch_concurrency`,  and `staging_elasticsearch_concurrency` for DAGs which affect the elasticsearch cluster, and `staging_api_db_concurrency` for DAGs which affect the API DB. Each DAG in these groups have been given the appropriate tag (the groups are listed below). The concurrency tasks have been updated to accept the name of the tag you want to select on, rather than a hard coded list, ie:

```
prevent_concurrency = prevent_concurrency_with_dags_with_tag(
    tag=STAGING_ES_CONCURRENCY_TAG,
)
```

^ This will select all the DAGs that have the given `tag`, *except for the running DAG/the DAG that called the task*, and fail immediately if any of them are running.

<img width="160" alt="Screenshot 2024-03-13 at 10 35 10 AM" src="https://github.com/WordPress/openverse/assets/63313398/c8cb6866-55bb-4dc0-82b5-8bac019e3c4d">

So now if you add a new ES dag, rather than having to manually update a bunch of lists of DAG dependencies on every single other ES dag, you just have to remember to add the appropriate `tag`(s) to your new DAG. The concurrency util will raise an error if you forget, as well.

### Additional thoughts/alternatives 

[This comment](https://github.com/WordPress/openverse/issues/3891#issuecomment-1988961899) on the issue explains why it wasn't possible to use the existing feature of Airflow pools to do this. Tags also have the benefit of being very visible in the UI and easy to filter by.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

These are the intended concurrency groups:

  * `staging_api_db_concurrency`
    * recreate_full_staging_index
    * staging_database_restore 
  * `staging_elasticsearch_concurrency`
    * recreate_full_staging_index
    * point_staging_es_alias
    * create_new_staging_es_index
    * create_proportional_by_source_staging_index
  * `production_elasticsearch_concurrency`
    * both data refreshes
    * both filtered index creation dags
    * create_new_production_es_index
    * point_production_es_index 

Note that `staging_database_restore` is **not** part of the `staging_elasticsearch_concurrency` group, because it only affects the API _database_ and therefore DAGs that only operate on the staging ES cluster (like `create_new_staging_es_index` don't need to block on it. Also note that `recreate_full_staging_index` is part of **both** the `staging_elasticsearch_concurrency` and `staging_api_db_concurrency` group, as it pulls records from the api db for reindexing.

For each DAG, run the DAG and check that the appropriate DAGs were waited on/prevented_concurrency_with. You can do this by looking at the logs for the `get_dags_in_<tag>_group` task, and then checking that the correct number of mapped tasks were made. (Example: `create_proportional_by_source_staging_index` is in the staging group which has 4 dags total. It has a `prevent_concurrency_with_dag` task generated for each of the 3 DAGs in the group excluding itself). Check the code to see special cases where some dependencies have been excluded for the data refresh.


Airflow 2.9 is supposed to include the ability to prove meaningful names for dynamically mapped tasks (instead of just a numerical index), which will make this much easier to read at-a-glance once we upgrade!

<img width="554" alt="Screenshot 2024-03-13 at 10 37 03 AM" src="https://github.com/WordPress/openverse/assets/63313398/94161d9e-9975-4045-8783-6fe27164ae66">


### Test the actual concurrency utils still works

We should also test the actual concurrency for at least a few options. The easiest way to do this is to trigger them in sequence through the Airflow CLI. Make sure the relevant DAGs are turned on in Airflow, then run `just catalog/shell` and:

```sh
# For example, this would trigger the recreate full staging index DAG and then immediately trigger staging db restore
# We would expect staging_database_restore to poke a few times while awaiting the `recreate_full_staging_index`
# DAG to complete, then resume once that DAG completes
> airflow dags trigger recreate_full_staging_index && airflow dags trigger staging_database_restore
```

A general tip for remembering how the concurrency checks should work: scheduled DAGs (data refreshes, staging database restore) will wait if a conflicting DAG is running, and resume once it completes. DAGs that are only run manually (create_new_es_index, create_filtered_index, recreate_full_staging_index) fail immediately if a conflicting DAG is running.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
