### PR TITLE
Use DAG_DEFAULT_ARGS for all DAGs

### DIFF
--- a/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
+++ b/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
@@ -25,7 +25,7 @@ from airflow.exceptions import AirflowSkipException
 from airflow.providers.elasticsearch.hooks.elasticsearch import ElasticsearchPythonHook
 from elasticsearch import Elasticsearch
 
-from common.constants import ENVIRONMENTS, PRODUCTION, Environment
+from common.constants import DAG_DEFAULT_ARGS, ENVIRONMENTS, PRODUCTION, Environment
 from common.elasticsearch import get_es_host
 from common.sensors.utils import is_concurrent_with_any
 from common.slack import send_alert, send_message
@@ -161,6 +161,7 @@ _SHARED_DAG_ARGS = {
     "max_active_runs": 1,
     "doc_md": __doc__,
     "tags": ["elasticsearch", "monitoring"],
+    "default_args": DAG_DEFAULT_ARGS,
 }
 
 

--- a/catalog/dags/maintenance/rotate_db_snapshots.py
+++ b/catalog/dags/maintenance/rotate_db_snapshots.py
@@ -23,7 +23,7 @@ from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.operators.rds import RdsCreateDbSnapshotOperator
 from airflow.providers.amazon.aws.sensors.rds import RdsSnapshotExistenceSensor
 
-from common.constants import AWS_RDS_CONN_ID
+from common.constants import AWS_RDS_CONN_ID, DAG_DEFAULT_ARGS
 
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ def delete_previous_snapshots(db_identifier: str, snapshots_to_retain: int):
     catchup=False,
     # Use the docstring at the top of the file as md docs in the UI
     doc_md=__doc__,
+    default_args=DAG_DEFAULT_ARGS,
     render_template_as_native_obj=True,
 )
 def rotate_db_snapshots():

--- a/catalog/tests/dags/test_dag_parsing.py
+++ b/catalog/tests/dags/test_dag_parsing.py
@@ -71,3 +71,20 @@ def test_dags_loads_correct_number_with_no_errors(relative_path, tmpdir):
     dag_bag.process_file(str(DAG_FOLDER / relative_path))
     assert len(dag_bag.import_errors) == 0, "Errors found during DAG import"
     assert len(dag_bag.dags) == expected_count, "An unexpected # of DAGs was found"
+
+
+def test_dag_uses_default_args():
+    # Attempt to load all DAGs in the DAG_FOLDER and check if they use the
+    # DAG_DEFAULT_ARGS settings
+    dagbag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+
+    failures = []
+    for dag_id, dag in dagbag.dags.items():
+        # An easy proxy for this is checking if DAGs have an on_failure_callback
+        on_failure_callback = dag.default_args.get("on_failure_callback")
+        if on_failure_callback is None:
+            failures.append(dag_id)
+
+    assert (
+        not failures
+    ), f"The following DAGs do not have DAG_DEFAULT_ARGS defined: {failures}"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3803 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the `DAG_DEFAULT_ARGS` (which includes automatic failure callbacks) to the DAGs which were missing them. It also adds a test to ensure all parseable DAGs contain the default args, and enumerates those which do not. This will be helpful going forward to ensure we add those defaults to all new DAGs.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Tests should pass
2. The affected DAGs should now longer show up with `airflow` as the owner, unlike how they currently do:


![image](https://github.com/WordPress/openverse/assets/10214785/ee74f841-5d2c-482e-81bc-90a080f686d2)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
