### PR TITLE
Fix audio alt files missing bit rate

### DIFF
--- a/api/api/examples/audio_responses.py
+++ b/api/api/examples/audio_responses.py
@@ -82,7 +82,7 @@ audio_stats_200_example = {
             "display_name": "Freesound",
             "source_url": "https://freesound.org/",
             "logo_url": None,
-            "media_count": 828,
+            "media_count": 827,
         },
         {
             "source_name": "jamendo",

--- a/api/api/serializers/audio_serializers.py
+++ b/api/api/serializers/audio_serializers.py
@@ -133,18 +133,19 @@ class AudioAltFileSerializer(serializers.Serializer):
         help_text="URL of the alternative file.",
     )
     bit_rate = serializers.IntegerField(
-        help_text="Bit rate of the alternative file.",
-        min_value=0,
+        help_text="Bit rate of the alternative file.", min_value=0, required=False
     )
     filesize = serializers.IntegerField(
         help_text="Size of the alternative file in bytes.",
         min_value=0,
+        required=False,
     )
     filetype = serializers.CharField(
         help_text="File type of the alternative file.",
     )
     sample_rate = serializers.IntegerField(
         help_text="Sample rate of the alternative file.",
+        required=False,
         min_value=0,
     )
 

--- a/api/api/serializers/audio_serializers.py
+++ b/api/api/serializers/audio_serializers.py
@@ -133,7 +133,9 @@ class AudioAltFileSerializer(serializers.Serializer):
         help_text="URL of the alternative file.",
     )
     bit_rate = serializers.IntegerField(
-        help_text="Bit rate of the alternative file.", min_value=0, required=False
+        help_text="Bit rate of the alternative file.",
+        min_value=0,
+        required=False,
     )
     filesize = serializers.IntegerField(
         help_text="Size of the alternative file in bytes.",

--- a/api/test/integration/test_media_integration.py
+++ b/api/test/integration/test_media_integration.py
@@ -49,7 +49,7 @@ def media_type(request):
         "audio": MediaType(
             name="audio",
             path="audio",
-            providers=["freesound", "jamendo", "wikimedia_audio"],
+            providers=["freesound", "jamendo", "wikimedia_audio", "ccmixter"],
             categories=["music", "pronunciation"],
             tags=["cat"],
             q="love",

--- a/api/test/unit/serializers/test_audio_serializers.py
+++ b/api/test/unit/serializers/test_audio_serializers.py
@@ -40,3 +40,25 @@ def test_audio_serializer_with_peaks_param(audio_fixture, include_peaks):
 
     audio_serializer = AudioSerializer(instance=audio_fixture, context=mock_ctx)
     assert ("peaks" in audio_serializer.data) is include_peaks
+
+
+# https://github.com/WordPress/openverse/issues/3930
+@pytest.mark.django_db
+def test_audio_serializer_with_non_required_alt_audio_fields_missing():
+    alt_files = [
+        {"bit_rate": 128, "filetype": "mp3", "url": "https://example.com/audio.mp3"}
+    ]
+    audio = Audio(
+        identifier=uuid.uuid4(),
+        alt_files=alt_files,
+    )
+    audio.save()
+    factory = APIRequestFactory()
+    request = factory.get(f"audio/{audio.identifier}/?peaks=false")
+    request = Request(request)
+    mock_ctx = {"request": request}
+
+    audio_serializer = AudioSerializer(instance=audio, context=mock_ctx)
+
+    assert len(audio_serializer.data.get("alt_files")) == 1
+    assert audio_serializer.data.get("alt_files")[0] == alt_files[0]

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -86,6 +86,7 @@ VALUES
 	(now(), 'freesound', 'Freesound', 'https://freesound.org/', false, 'audio'),
 	(now(), 'jamendo', 'Jamendo', 'https://www.jamendo.com', false, 'audio'),
 	(now(), 'wikimedia_audio', 'Wikimedia', 'https://commons.wikimedia.org', false, 'audio');
+	(now(), 'ccmixter', 'CCMixter', 'https://ccmixter.org', false, 'audio');
 "
 
 #############


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3930 by @sentry-bot

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR marks some audio alt file properties as not required. This fixes the 500 error when serializing CC Mixter items that don't set `bit_rate` on the alt files.

To allow for local tests, this PR adds 10 audio items from CC Mixter to the `sample_audio.csv`

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the API. Delete the current audio index (I use Elasticvue for this, there is probably a better way to recreate the index) and run `just api/init` to index audio again.
Check that 10 CC Mixter items are rendered correctly: http://localhost:50280/v1/audio/?source=ccmixter
See that this causes 500 without the code changes in this PR, or in prod. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
