### PR TITLE
Group "week in Openverse" items by stack label

### DIFF
--- a/automations/js/src/last_week_tonight.mjs
+++ b/automations/js/src/last_week_tonight.mjs
@@ -80,22 +80,16 @@ const getItemsHtml = (title, items) => {
   const stacks = [
     ...new Set(
       items
-        .map((item) =>
-          item.labels
-            .map((label) => label.name)
-            .filter((name) => name.startsWith('🧱 stack'))
-        )
-        .flat()
+        .flatMap((item) => item.labels) // Flatten all labels into a single array
+        .map((label) => label.name) // Extract the name of each label
+        .filter((name) => name.startsWith('🧱 stack'))
     ),
   ].sort()
-  console.log(stacks)
 
   // Aggregate items by stack
   let itemsByStack = {}
 
   for (const stack of stacks) {
-    console.log(stack)
-    console.log(stack.split(':'))
     const stackName = stack.split(':')[1].trim()
     itemsByStack[stackName] = items
       .filter((item) => item.labels.map((label) => label.name).includes(stack))

--- a/automations/js/src/last_week_tonight.mjs
+++ b/automations/js/src/last_week_tonight.mjs
@@ -57,6 +57,13 @@ const mergedPrsQ = (repo) =>
 const closedIssuesQ = (repo) =>
   `repo:${org}/${repo} is:issue is:closed closed:>=${startDate}`
 
+/* Other constants */
+
+const stackNameMap = {
+  api: 'API',
+  mgmt: 'Management',
+}
+
 /* Format issues, PRs and repos as HTML */
 
 /**
@@ -69,16 +76,48 @@ const closedIssuesQ = (repo) =>
 const getItemsHtml = (title, items) => {
   if (!items.length) return []
 
+  // Get a unique list of stack labels
+  const stacks = [
+    ...new Set(
+      items
+        .map((item) =>
+          item.labels
+            .map((label) => label.name)
+            .filter((name) => name.startsWith('🧱 stack'))
+        )
+        .flat()
+    ),
+  ].sort()
+  console.log(stacks)
+
+  // Aggregate items by stack
+  let itemsByStack = {}
+
+  for (const stack of stacks) {
+    console.log(stack)
+    console.log(stack.split(':'))
+    const stackName = stack.split(':')[1].trim()
+    itemsByStack[stackName] = items
+      .filter((item) => item.labels.map((label) => label.name).includes(stack))
+      .sort((a, b) => a.number - b.number)
+  }
+
   return [
     `<h3>${title}</h3>`,
-    '<ul>',
-    ...items.map((item) => {
-      const href = item.html_url
-      const number = `#${item.number}`
-      const title = escapeHtml(item.title)
-      return `<li><a href="${href}">${number}</a>: ${title}`
-    }),
-    '</ul>',
+    // Produce a list of elements for each stack, then combine them all
+    ...Object.entries(itemsByStack)
+      .map(([stackName, items]) => [
+        `<h4>${stackNameMap[stackName] || stackName.replace(/\b[a-z]/g, (match) => match.toUpperCase())}</h4>`,
+        '<ul>',
+        ...items.map((item) => {
+          const href = item.html_url
+          const number = `#${item.number}`
+          const title = escapeHtml(item.title)
+          return `<li><a href="${href}">${number}</a>: ${title}`
+        }),
+        '</ul>',
+      ])
+      .flat(),
   ]
 }
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3445 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes some alterations to the "Week in Openverse" blog post generation script to group the closed issues/merged PRs for a given repository by the stack label. Since an issue/PR can have more than one stack label, this approach will produce an output where said issue/PR shows up in _each_ of the stacks for which it has a label.

I am no Javascript expert - if there are more sensible ways to do the operations I'm performing in this script, _please_ feel free to share! I'm happy to try and make this more idiomatic :smile:

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This can be run locally with node in the `automations/js` directory with the following: `ACCESS_TOKEN=<value> MAKE_USERNAME=<value> MAKE_PASSWORD=<value> node src/last_week_tonight.mjs`. However, example output is below (along with a screenshot):

<details> <summary>HTML output example</summary>

```html
<h2><a href="https://github.com/WordPress/openverse">openverse</a></h2>
<h3>Merged PRs</h3>
<h4>API</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3760">#3760</a>: Implementation Plan: Content moderation metrics
<li><a href="https://github.com/WordPress/openverse/pull/3836">#3836</a>: Add accesstoken and ThrottledApplication to admin panel
<li><a href="https://github.com/WordPress/openverse/pull/3929">#3929</a>: Remove unused API variables from environment template
<li><a href="https://github.com/WordPress/openverse/pull/3931">#3931</a>: Fix audio alt files missing bit rate
<li><a href="https://github.com/WordPress/openverse/pull/3932">#3932</a>: Publish changelog for api-2024.03.18.15.51.25
<li><a href="https://github.com/WordPress/openverse/pull/3953">#3953</a>: Bump jwcrypto from 1.5.4 to 1.5.6 in /api
</ul>
<h4>Catalog</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3909">#3909</a>: Freesound: handle space in creator name when making URL
<li><a href="https://github.com/WordPress/openverse/pull/3928">#3928</a>: Use DAG_DEFAULT_ARGS for all DAGs
</ul>
<h4>Documentation</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3760">#3760</a>: Implementation Plan: Content moderation metrics
<li><a href="https://github.com/WordPress/openverse/pull/3950">#3950</a>: Link to Openverse in Documentation site root
</ul>
<h4>Frontend</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3808">#3808</a>: Cleanup tag display for long lists of tags
<li><a href="https://github.com/WordPress/openverse/pull/3835">#3835</a>: Use the `VMediaCollection` for search and collection results
<li><a href="https://github.com/WordPress/openverse/pull/3850">#3850</a>: Centralise frontend error reporting (and suppress unactionable Sentry errors)
<li><a href="https://github.com/WordPress/openverse/pull/3933">#3933</a>: Publish changelog for frontend-2024.03.18.15.51.41
<li><a href="https://github.com/WordPress/openverse/pull/3942">#3942</a>: Fix the skip-to-content link reloading the results
<li><a href="https://github.com/WordPress/openverse/pull/3952">#3952</a>: Update pinia and vue-demi
</ul>
<h4>Ingestion Server</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3931">#3931</a>: Fix audio alt files missing bit rate
</ul>
<h4>Management</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/pull/3954">#3954</a>: Add debug logs to renovate
</ul>
<h3>Closed issues</h3>
<h4>API</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/issues/3711">#3711</a>: Add access token and throttled application models to Django admin
<li><a href="https://github.com/WordPress/openverse/issues/3821">#3821</a>: Clean up API URL environment variables
<li><a href="https://github.com/WordPress/openverse/issues/3930">#3930</a>: KeyError: &quot;Got KeyError when attempting to get a value for field `bit_rate` on serializer `AudioAltFileSeri...
</ul>
<h4>Catalog</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/issues/1459">#1459</a>: Surface materialized views in view names
<li><a href="https://github.com/WordPress/openverse/issues/1473">#1473</a>: Investigate Data Refreshes blocking during popularity steps
<li><a href="https://github.com/WordPress/openverse/issues/1662">#1662</a>: Catalog database/ingestion overhaul
<li><a href="https://github.com/WordPress/openverse/issues/1667">#1667</a>: No descriptions for audio files
<li><a href="https://github.com/WordPress/openverse/issues/1765">#1765</a>: Come up with a solution for consuming crawler events (original #457)
<li><a href="https://github.com/WordPress/openverse/issues/1790">#1790</a>: Feed new images to the crawler (original #456)
<li><a href="https://github.com/WordPress/openverse/issues/1791">#1791</a>: Scrape CC REL data to identify CC-licensed images (original #182)
<li><a href="https://github.com/WordPress/openverse/issues/3803">#3803</a>: Not all DAGs have `DAG_DEFAULT_ARGS` applied
<li><a href="https://github.com/WordPress/openverse/issues/3908">#3908</a>: Freesound: Space present in URL
</ul>
<h4>Frontend</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/issues/2589">#2589</a>: Cleanup tag display with long lists of tags
<li><a href="https://github.com/WordPress/openverse/issues/3468">#3468</a>: Avoid `AxiosError` when requesting bad image links
<li><a href="https://github.com/WordPress/openverse/issues/3576">#3576</a>: Returning to results from the new content views does not load previously-loaded pages
<li><a href="https://github.com/WordPress/openverse/issues/3830">#3830</a>: Navigating between additional search views and single result pages and back does not update the single image
<li><a href="https://github.com/WordPress/openverse/issues/3884">#3884</a>: Search results are not updated when filters are unchecked but the search term is the same
<li><a href="https://github.com/WordPress/openverse/issues/3939">#3939</a>: Unmet `pinia` peer dependency (version issue)
<li><a href="https://github.com/WordPress/openverse/issues/3940">#3940</a>: Using &quot;skip to content&quot; button on search results page clears result counts (staging only)
</ul>
<h4>Ingestion Server</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/issues/744">#744</a>: Add Rawpixel to authority data as `CURATED`
</ul>
<h4>Management</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse/issues/1126">#1126</a>: Implementation Plan: Rekognition Data Evaluation
<li><a href="https://github.com/WordPress/openverse/issues/1163">#1163</a>: Update the Priority custom field when the issue priority label changes
<li><a href="https://github.com/WordPress/openverse/issues/1970">#1970</a>: Implementation Plan: Moderation queue metrification
</ul>
<h2><a href="https://github.com/WordPress/openverse-infrastructure">openverse-infrastructure</a></h2>
<h3>Merged PRs</h3>
<h4>API</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse-infrastructure/pull/824">#824</a>: Remove API environment variables that are no longer used
</ul>
<h4>Documentation</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse-infrastructure/pull/827">#827</a>: Update Nuxt HTTP 5xx responses runbook link
</ul>
<h4>Ingestion Server</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse-infrastructure/pull/825">#825</a>: Remove sudo calls from ingestion server init
</ul>
<h3>Closed issues</h3>
<h4>Management</h4>
<ul>
<li><a href="https://github.com/WordPress/openverse-infrastructure/issues/548">#548</a>: Remove unnecessary calls to `sudo` from ingestion server user-data script
</ul>
```

</details>


![image](https://github.com/WordPress/openverse/assets/10214785/d8652501-0a0c-4ae2-979a-742e7ffdfc1e)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
