### PR TITLE
Update payload of collection search analytics events

### DIFF
--- a/frontend/src/components/VImageCell/VImageCell.vue
+++ b/frontend/src/components/VImageCell/VImageCell.vue
@@ -63,15 +63,18 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue"
 
+import { useContext } from "@nuxtjs/composition-api"
+
 import type { AspectRatio, ImageDetail } from "~/types/media"
 import type { ResultKind } from "~/types/result"
 import { useImageCellSize } from "~/composables/use-image-cell-size"
 import { useI18n } from "~/composables/use-i18n"
-import { useAnalytics } from "~/composables/use-analytics"
 
 import { IMAGE } from "~/constants/media"
 
 import { useSensitiveMedia } from "~/composables/use-sensitive-media"
+
+import { useSearchStore } from "~/stores/search"
 
 import VLicense from "~/components/VLicense/VLicense.vue"
 import VLink from "~/components/VLink.vue"
@@ -182,7 +185,8 @@ export default defineComponent({
           })
     })
 
-    const { sendCustomEvent } = useAnalytics()
+    const { $sendCustomEvent } = useContext()
+    const searchStore = useSearchStore()
 
     /**
      * If the user left clicks on a search result, send
@@ -194,7 +198,7 @@ export default defineComponent({
         return
       }
 
-      sendCustomEvent("SELECT_SEARCH_RESULT", {
+      $sendCustomEvent("SELECT_SEARCH_RESULT", {
         id: props.image.id,
         kind: props.kind,
         mediaType: IMAGE,
@@ -203,6 +207,9 @@ export default defineComponent({
         relatedTo: props.relatedTo,
         sensitivities: props.image.sensitivity?.join(",") ?? "",
         isBlurred: shouldBlur.value,
+        collectionType:
+          searchStore.strategy !== "default" ? searchStore.strategy : null,
+        collectionValue: searchStore.collectionValue,
       })
     }
 

--- a/frontend/src/components/VLoadMore.vue
+++ b/frontend/src/components/VLoadMore.vue
@@ -13,6 +13,7 @@
     </VButton>
   </div>
 </template>
+
 <script lang="ts">
 import {
   computed,
@@ -33,6 +34,8 @@ import { defineEvent } from "~/types/emits"
 
 import type { ResultKind } from "~/types/result"
 import type { SupportedSearchType } from "~/constants/media"
+
+import { useSearchStore } from "~/stores/search"
 
 import VButton from "~/components/VButton.vue"
 
@@ -67,15 +70,22 @@ export default defineComponent({
     const route = useRoute()
     const i18n = useI18n()
     const mediaStore = useMediaStore()
+    const searchStore = useSearchStore()
     const { $sendCustomEvent } = useContext()
 
     const { currentPage } = storeToRefs(mediaStore)
 
     const eventPayload = computed(() => {
+      let kind: ResultKind =
+        searchStore.strategy === "default" ? "search" : "collection"
       return {
         searchType: props.searchType,
         query: props.searchTerm,
         resultPage: currentPage.value || 1,
+        kind,
+        collectionType:
+          searchStore.strategy !== "default" ? searchStore.strategy : null,
+        collectionValue: searchStore.collectionValue,
       }
     })
 

--- a/frontend/src/components/VSearchResultsGrid/VAudioResult.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAudioResult.vue
@@ -16,7 +16,8 @@
 <script lang="ts">
 import { defineComponent, PropType, toRefs } from "vue"
 
-import { useAnalytics } from "~/composables/use-analytics"
+import { useContext } from "@nuxtjs/composition-api"
+
 import { useAudioSnackbar } from "~/composables/use-audio-snackbar"
 import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 import { AUDIO } from "~/constants/media"
@@ -26,6 +27,8 @@ import type { AudioLayout, AudioSize } from "~/constants/audio"
 import type { AudioTrackClickEvent } from "~/types/events"
 import type { AudioDetail } from "~/types/media"
 import type { ResultKind } from "~/types/result"
+
+import { useSearchStore } from "~/stores/search"
 
 import VAudioTrack from "~/components/VAudioTrack/VAudioTrack.vue"
 
@@ -59,7 +62,8 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { sendCustomEvent } = useAnalytics()
+    const { $sendCustomEvent } = useContext()
+    const searchStore = useSearchStore()
 
     const { audio } = toRefs(props)
     const { isHidden: shouldBlur } = useSensitiveMedia(audio)
@@ -74,7 +78,7 @@ export default defineComponent({
         return
       }
       useAudioSnackbar().hide()
-      sendCustomEvent("SELECT_SEARCH_RESULT", {
+      $sendCustomEvent("SELECT_SEARCH_RESULT", {
         id: audio.id,
         kind: props.kind,
         mediaType: AUDIO,
@@ -83,6 +87,9 @@ export default defineComponent({
         relatedTo: props.relatedTo,
         sensitivities: audio.sensitivity?.join(",") ?? "",
         isBlurred: shouldBlur.value,
+        collectionType:
+          searchStore.strategy !== "default" ? searchStore.strategy : null,
+        collectionValue: searchStore.collectionValue,
       })
     }
     const sendInteractionEvent = (
@@ -94,7 +101,7 @@ export default defineComponent({
           : props.layout === "box"
             ? "VAllResultsGrid"
             : "AudioSearch"
-      sendCustomEvent("AUDIO_INTERACTION", { ...data, component })
+      $sendCustomEvent("AUDIO_INTERACTION", { ...data, component })
     }
 
     return {

--- a/frontend/src/stores/search.ts
+++ b/frontend/src/stores/search.ts
@@ -208,6 +208,27 @@ export const useSearchStore = defineStore("search", {
     searchTypeIsSupported(state) {
       return isSearchTypeSupported(state.searchType)
     },
+    /**
+     * Returns the unique string representation of the current collection
+     * when making collection searches.
+     */
+    collectionValue(): null | string {
+      if (this.collectionParams === null) {
+        return null
+      }
+
+      switch (this.collectionParams.collection) {
+        case "creator": {
+          return `${this.collectionParams.source}/${this.collectionParams.creator}`
+        }
+        case "source": {
+          return this.collectionParams.source
+        }
+        case "tag": {
+          return this.collectionParams.tag
+        }
+      }
+    },
   },
   actions: {
     getApiRequestQuery(mediaType: SupportedMediaType) {

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -6,9 +6,8 @@ import type {
 import type { ReportReason } from "~/constants/content-report"
 import type { FilterCategory } from "~/constants/filters"
 import { ResultKind } from "~/types/result"
-
-import { RequestKind } from "./fetch-state"
-import { Collection } from "./search"
+import { RequestKind } from "~/types/fetch-state"
+import { Collection } from "~/types/search"
 
 export type AudioInteraction = "play" | "pause" | "seek"
 export type AudioInteractionData = Exclude<

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -8,6 +8,7 @@ import type { FilterCategory } from "~/constants/filters"
 import { ResultKind } from "~/types/result"
 
 import { RequestKind } from "./fetch-state"
+import { Collection } from "./search"
 
 export type AudioInteraction = "play" | "pause" | "seek"
 export type AudioInteractionData = Exclude<
@@ -20,6 +21,19 @@ export type AudioComponent =
   | "AudioSearch"
   | "AudioDetailPage"
   | "VAllResultsGrid"
+
+/**
+ * Common properties related to searches
+ * on collection pages, added in the
+ * "Additional Search Views" project.
+ */
+type CollectionProperties = {
+  /** If a collection page, the type of collection */
+  collectionType: Collection | null
+  /** A string representing a unique identifier for the collection */
+  collectionValue: string | null
+}
+
 /**
  * Compound type of all custom events sent from the site; Index with `EventName`
  * to get the type of the payload for a specific event.
@@ -101,11 +115,13 @@ export type Events = {
   REACH_RESULT_END: {
     /** The media type being searched */
     searchType: SupportedSearchType
+    /** The kind of search reached (a collection, a standard search view, etc.)  */
+    kind: ResultKind
     /** The search term */
     query: string
     /** The current page of results the user is on. */
     resultPage: number
-  }
+  } & CollectionProperties
   /**
    * Description: The user clicks the CTA button to the external source to use the image
    * Questions:
@@ -269,7 +285,7 @@ export type Events = {
     sensitivities: string
     /** whether the result was blurred or visible when selected by the user */
     isBlurred: boolean | null
-  }
+  } & CollectionProperties
   /**
    * Description: When a user opens the external sources popover.
    * Questions:
@@ -297,12 +313,14 @@ export type Events = {
   LOAD_MORE_RESULTS: {
     /** The media type being searched */
     searchType: SearchType
+    /** The kind of search (a collection, a standard search view, etc.)  */
+    kind: ResultKind
     /** The search term */
     query: string
     /** The current page of results the user is on,
      * *before* loading more results.. */
     resultPage: number
-  }
+  } & CollectionProperties
   /**
    * Description: Whenever the user sets a filter. Filter category and key are the values used in code, not the user-facing filter labels.
    * Questions:

--- a/frontend/test/playwright/e2e/all-results-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-analytics.spec.ts
@@ -41,6 +41,8 @@ test.describe("all results grid analytics test", () => {
       provider: "jamendo",
       sensitivities: "",
       isBlurred: false,
+      collectionType: null,
+      collectionValue: null,
     })
   })
 
@@ -64,6 +66,8 @@ test.describe("all results grid analytics test", () => {
       relatedTo: null,
       sensitivities: "",
       isBlurred: false,
+      collectionType: null,
+      collectionValue: null,
     })
   })
 

--- a/frontend/test/playwright/e2e/audio-detail.spec.ts
+++ b/frontend/test/playwright/e2e/audio-detail.spec.ts
@@ -135,5 +135,7 @@ test("sends SELECT_SEARCH_RESULT event on related audio click", async ({
     query: "",
     sensitivities: "",
     isBlurred: false,
+    collectionType: null,
+    collectionValue: null,
   })
 })

--- a/frontend/test/playwright/e2e/image-detail.spec.ts
+++ b/frontend/test/playwright/e2e/image-detail.spec.ts
@@ -136,5 +136,7 @@ test("sends SELECT_SEARCH_RESULT event on related image click", async ({
     query: "",
     sensitivities: "",
     isBlurred: false,
+    collectionType: null,
+    collectionValue: null,
   })
 })

--- a/frontend/test/playwright/e2e/load-more.spec.ts
+++ b/frontend/test/playwright/e2e/load-more.spec.ts
@@ -157,6 +157,8 @@ test.describe("Load more button", () => {
       query: "cat",
       searchType: "all",
       resultPage: 1,
+      collectionType: null,
+      collectionValue: null,
     })
   })
 
@@ -177,6 +179,8 @@ test.describe("Load more button", () => {
       query: "cat",
       searchType: "all",
       resultPage: 1,
+      collectionType: null,
+      collectionValue: null,
     })
   })
 
@@ -202,6 +206,8 @@ test.describe("Load more button", () => {
         query: "cat",
         searchType: "all",
         resultPage: index + 1,
+        collectionType: null,
+        collectionValue: null,
       })
     )
   })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3619 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR updates the payload of search-related analytics events to include collection information on collection searches. These collection-related values are `null` on other searches. It also adds the existing `kind` custom property to the `LOAD_MORE_RESULTS` and `REACH_RESULT_END` events.

One aspect of this PR I do not like is the accessing the search store inside of the image cell and audio result components. It _does_ feel ideal to use a standardized approach to getting the current search strategy and the value (string of the name of the tag, source, or source/creator) from one centralized place, but I don't like accessing a global store in a component which is repeated several times on the page.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Enable `additional_search_views` on http://localhost:8443/preferences
2. Open your browser console
3. Make a standard search and scroll to the bottom of the page. Confirm the logged `REACH_RESULT_END` event matches this partial payload `{ kind: "search", collectionType: null, collectionValue: null }`
4. Load more results. Confirm the logged `LOAD_MORE_RESULTS` event matches this partial payload `{ kind: "search", collectionType: null, collectionValue: null }`.
5. Select a result. Confirm the logged `SELECT_SEARCH_RESULT` event matches this partial payload `{ kind: "search", collectionType: null, collectionValue: null }`.
6. Click on the new creator link below the title of the current result to visit the new creator collection page. Scroll to the bottom of the page.
7. Confirm the logged `REACH_RESULT_END` event matches this partial payload `{ kind: "collection", collectionType: "creator", collectionValue: {source}/{creatorName} }`
8. Load more results. Confirm the logged `LOAD_MORE_RESULTS` event matches this partial payload `{ kind: "collection", collectionType: "creator", collectionValue: {source}/{creatorName} }`.
9. Select a result. Confirm the logged `SELECT_SEARCH_RESULT` event matches this partial payload `{ kind: "collection", collectionType: "creator", collectionValue: {source}/{creatorName} }`.
10. Repeat steps 6-9 but for a tag page (by clicking on a tag). Repeat steps 6-9 for a source page (by clicking on a source button). Ensure the correct value for the type.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
