### PR TITLE
Fix load sample data script provider insertion

### DIFF
--- a/api/api/examples/audio_responses.py
+++ b/api/api/examples/audio_responses.py
@@ -98,6 +98,13 @@ audio_stats_200_example = {
             "logo_url": None,
             "media_count": 3992,
         },
+        {
+            "display_name": "CCMixter",
+            "logo_url": None,
+            "media_count": 1,
+            "source_name": "ccmixter",
+            "source_url": "https://ccmixter.org",
+        },
     ]
 }
 

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 set -e
+set -o pipefail
 WEB_SERVICE_NAME="${WEB_SERVICE_NAME:-web}"
 CACHE_SERVICE_NAME="${CACHE_SERVICE_NAME:-cache}"
 UPSTREAM_DB_SERVICE_NAME="${UPSTREAM_DB_SERVICE_NAME:-upstream_db}"
@@ -85,7 +86,7 @@ VALUES
 	(now(), 'stocksnap', 'StockSnap', 'https://stocksnap.io', false, 'image'),
 	(now(), 'freesound', 'Freesound', 'https://freesound.org/', false, 'audio'),
 	(now(), 'jamendo', 'Jamendo', 'https://www.jamendo.com', false, 'audio'),
-	(now(), 'wikimedia_audio', 'Wikimedia', 'https://commons.wikimedia.org', false, 'audio');
+	(now(), 'wikimedia_audio', 'Wikimedia', 'https://commons.wikimedia.org', false, 'audio'),
 	(now(), 'ccmixter', 'CCMixter', 'https://ccmixter.org', false, 'audio');
 "
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Addresses an issue introduced in #3931

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes a syntax issue in the provider insertion step of the load sample data script. I discovered this when I ran the script locally and observed this in the `just api/init` output:

```
env COMPOSE_PROFILES="api,ingestion_server,frontend,catalog" docker-compose -f docker-compose.yml exec -T db psql -AXqt
ERROR:  syntax error at or near "now"
LINE 1: (now(), 'ccmixter', 'CCMixter', 'https://ccmixter.org', fals...
         ^
```

I tried to determine why the error wasn't bubbled up any further, but was unable to do so in the short time that I was looking at this.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just api/init` on this branch and observe that the above step succeeds where it previously failed.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
