### PR TITLE
Add log insights querying information for Nuxt 5XX errors

### DIFF
--- a/documentation/meta/monitoring/runbooks/nuxt_http_5xx_above_threshold.md
+++ b/documentation/meta/monitoring/runbooks/nuxt_http_5xx_above_threshold.md
@@ -5,6 +5,7 @@ Status: **Stable**
 
 Alarm link:
 - [Alarm details](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/Nuxt+Production+HTTP+5XX+responses+count+over+threshold)
+- [Nuxt Production log group][log_group]
 - [ECS-Production-Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ECS-Production-Dashboard)
 ```
 
@@ -25,10 +26,36 @@ errors (this can be checked by observing paths in the Cloudflare logs).
   investigation into the API side is warranted to determine the cause for the
   5XX responses. Also refer to the
   [API 5XX runbook](/meta/monitoring/runbooks/api_http_5xx_above_threshold.md).
+- To gather more information check the [log group][log_group], use the "Logs
+  Insights" view to query for requests that failed using a CloudWatch query
+  similar to the following which can give more hints about where is the problem.
+
+```
+fields request, @timestamp, @message
+| filter status >= 500
+| sort @timestamp desc
+| limit 20
+```
+
+- Occasionally, we'll observe a high number of 5XX responses on the `/api/event`
+  endpoint. These are often the result of outages or issues with Plausible and
+  are not actionable for us. The following Log Insights query can be helpful in
+  determining the source of the 500s based on the endpoints.
+
+```
+fields request, @timestamp, @message
+| filter status >= 500
+| sort @timestamp desc
+| stats count(*) by request
+```
+
+[log_group]:
+  https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252Fproduction$252Ffrontend
 
 ## Historical false positives
 
-Nothing registered to date.
+- _2024-04-02, 15:22 UTC_: High number of 500s to the `/api/event` endpoint,
+  nothing actionable on our end.
 
 ## Related incident reports
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds some information for troubleshooting Nuxt 5XX errors that we found useful this morning when attempting to identify the root cause of an incident. It borrows a bit from the [API 5XX errors runbook](https://docs.openverse.org/meta/monitoring/runbooks/api_http_5xx_above_threshold.html). 


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Check the document and make sure it looks okay

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
