### PR TITLE
Add cache control headers to API responses

### DIFF
--- a/api/api/constants/sorting.py
+++ b/api/api/constants/sorting.py
@@ -4,6 +4,7 @@ SORT_FIELDS = [
     (RELEVANCE, "Relevance"),  # default
     (INDEXED_ON, "Indexing date"),  # date on which media was indexed into Openverse
 ]
+DEFAULT_SORT_FIELD = RELEVANCE
 
 DESCENDING = "desc"
 ASCENDING = "asc"
@@ -11,3 +12,4 @@ SORT_DIRECTIONS = [
     (DESCENDING, "Descending"),  # default
     (ASCENDING, "Ascending"),
 ]
+DEFAULT_SORT_DIRECTION = DESCENDING

--- a/api/api/utils/cache_control/__init__.py
+++ b/api/api/utils/cache_control/__init__.py
@@ -1,0 +1,26 @@
+from functools import wraps
+
+from api.utils.cache_control.backports import cache_control, never_cache  # noqa: E501
+
+
+def async_method_cache_control(**cache_control_kwargs):
+    """
+    Decorate an async method with `cache_control`.
+
+    Only necessary for async view methods because Django's `method_decorator`
+    does not work for async methods.
+    """
+
+    def do(async_method_view):
+
+        @wraps(async_method_view)
+        async def wrapper(self, *args, **kwargs):
+            @cache_control(**kwargs)
+            async def selfless_view_func(*inner_args, **inner_kwargs):
+                return await async_method_view(self, *inner_args, **inner_kwargs)
+
+            return await selfless_view_func(*args, **kwargs)
+
+        return wrapper
+
+    return do

--- a/api/api/utils/cache_control/backports.py
+++ b/api/api/utils/cache_control/backports.py
@@ -1,0 +1,84 @@
+"""
+Backport Django 5 async route support for cache control decorator.
+
+Delete me after updating the API to Django 5.
+
+Code in this file is under the Django BSD 3-Clause license.
+
+https://github.com/django/django/blob/main/LICENSE
+"""
+from asgiref.sync import iscoroutinefunction
+from functools import wraps
+
+from django.utils.cache import patch_cache_control, add_never_cache_headers
+
+
+def _check_request(request, decorator_name):
+    """
+    Check view return type looks correct.
+
+    Upstream version of the backported code:
+    https://github.com/django/django/blob/8665cf03d79c4b6222514c5943ccf3863a19cf08/django/views/decorators/cache.py#L31-L37
+    """
+    # Ensure argument looks like a request.
+    if not hasattr(request, "META"):
+        raise TypeError(
+            f"{decorator_name} didn't receive an HttpRequest. If you are "
+            "decorating a classmethod, be sure to use @method_decorator."
+        )
+
+
+def cache_control(**kwargs):
+    """
+    Add `cache-control` headers to response from decorated views.
+
+    Upstream version of the backported code:
+    https://github.com/django/django/blob/8665cf03d79c4b6222514c5943ccf3863a19cf08/django/views/decorators/cache.py#L40-L60
+    """
+    def _cache_controller(viewfunc):
+        if iscoroutinefunction(viewfunc):
+
+            async def _view_wrapper(request, *args, **kw):
+                _check_request(request, "cache_control")
+                response = await viewfunc(request, *args, **kw)
+                patch_cache_control(response, **kwargs)
+                return response
+
+        else:
+
+            def _view_wrapper(request, *args, **kw):
+                _check_request(request, "cache_control")
+                response = viewfunc(request, *args, **kw)
+                patch_cache_control(response, **kwargs)
+                return response
+
+        return wraps(viewfunc)(_view_wrapper)
+
+    return _cache_controller
+
+
+def never_cache(view_func):
+    """
+    Decorator that adds headers to a response so that it will never be cached.
+
+    Upstream version of the backported code:
+    https://github.com/django/django/blob/8665cf03d79c4b6222514c5943ccf3863a19cf08/django/views/decorators/cache.py#L63-L84
+    """
+
+    if iscoroutinefunction(view_func):
+
+        async def _view_wrapper(request, *args, **kwargs):
+            _check_request(request, "never_cache")
+            response = await view_func(request, *args, **kwargs)
+            add_never_cache_headers(response)
+            return response
+
+    else:
+
+        def _view_wrapper(request, *args, **kwargs):
+            _check_request(request, "never_cache")
+            response = view_func(request, *args, **kwargs)
+            add_never_cache_headers(response)
+            return response
+
+    return wraps(view_func)(_view_wrapper)

--- a/api/api/utils/ttl.py
+++ b/api/api/utils/ttl.py
@@ -1,0 +1,20 @@
+from typing import Unpack, get_type_hints
+from datetime import timedelta
+
+
+def ttl(days: int = 0, seconds: int = 0, minutes: int = 0, hours: int = 0, weeks: int = 0) -> int:
+    """
+    Retrieve the total number of seconds for kwargs.
+
+    Based on `timedelta` arguments, but leaves out anything smaller than
+    a second, because TTLs are defined in seconds, not milli or microseconds.
+
+    It also types all inputs as `int`, rather than `float`, and only returns an int.
+    """
+    return int(timedelta(
+        days=days,
+        seconds=seconds,
+        minutes=minutes,
+        hours=hours,
+        weeks=weeks,
+    ).total_seconds())

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.decorators import method_decorator
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException, NotFound
 from rest_framework.response import Response
@@ -23,6 +24,8 @@ from api.serializers.audio_serializers import (
     AudioWaveformSerializer,
 )
 from api.utils import image_proxy
+from api.utils.cache_control import cache_control
+from api.utils.ttl import ttl
 from api.utils.throttle import AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle
 from api.views.media_views import MediaViewSet
 
@@ -81,6 +84,7 @@ class AudioViewSet(MediaViewSet):
         serializer_class=AudioWaveformSerializer,
         throttle_classes=[AnonThumbnailRateThrottle, OAuth2IdThumbnailRateThrottle],
     )
+    @method_decorator(cache_control(max_age=ttl(weeks=52), public=True))
     def waveform(self, *_, **__):
         """
         Get the waveform peaks for an audio track.

--- a/api/api/views/health_views.py
+++ b/api/api/views/health_views.py
@@ -1,11 +1,14 @@
 from django.conf import settings
 from django.db import connection
+from django.utils.decorators import method_decorator
+
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from api.utils.cache_control import never_cache
 from api.utils.throttle import ExemptOAuth2IdRateThrottle, HealthcheckAnonRateThrottle
 
 
@@ -49,6 +52,7 @@ class HealthCheck(APIView):
         if (es_status := es_health["status"]) != "green":
             raise ElasticsearchHealthcheckException(f"es_status_{es_status}")
 
+    @method_decorator(never_cache)
     def get(self, request: Request):
         if "check_es" in request.query_params:
             self._check_es()

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -32,6 +32,8 @@ from api.serializers.image_serializers import (
 from api.utils import image_proxy
 from api.utils.aiohttp import get_aiohttp_session
 from api.utils.asyncio import aget_object_or_404
+from api.utils.cache_control import async_method_cache_control
+from api.utils.ttl import ttl
 from api.utils.watermark import UpstreamWatermarkException, watermark
 from api.views.media_views import MediaViewSet
 
@@ -69,6 +71,7 @@ class ImageViewSet(MediaViewSet):
         url_name="oembed",
         serializer_class=OembedSerializer,
     )
+    @async_method_cache_control(max_age=ttl(days=30), public=True)
     async def oembed(self, request, *_, **__):
         """
         Retrieve the structured data for a specified image URL as per the
@@ -77,7 +80,6 @@ class ImageViewSet(MediaViewSet):
         This info can be used to embed the image on the consumer's website. Only
         JSON format is supported.
         """
-
         params = OembedRequestSerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
         identifier = params.validated_data["identifier"]

--- a/api/api/views/oauth2_views.py
+++ b/api/api/views/oauth2_views.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.mail import send_mail
 from django.db import DataError
+from django.utils.decorators import method_decorator
+
 from rest_framework.exceptions import APIException, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -25,6 +27,7 @@ from api.serializers.oauth2_serializers import (
     OAuth2KeyInfoSerializer,
     OAuth2RegistrationSerializer,
 )
+from api.utils.cache_control import never_cache
 from api.utils.throttle import OnePerSecond, TenPerDay
 
 
@@ -42,6 +45,7 @@ class Register(APIView):
     throttle_classes = (TenPerDay,)
 
     @register
+    @method_decorator(never_cache)
     def post(self, request, format=None):
         """
         Register an application to access to API via OAuth2.
@@ -125,6 +129,7 @@ class VerifyEmail(APIView):
 
     schema = None  # Hide this view from the OpenAPI schema.
 
+    @method_decorator(never_cache)
     def get(self, request, code, format=None):
         try:
             verification = OAuth2Verification.objects.get(code=code)
@@ -151,6 +156,7 @@ class VerifyEmail(APIView):
 @extend_schema(tags=["auth"])
 class TokenView(APIView, BaseTokenView):
     @token
+    @method_decorator(never_cache)
     def post(self, request):
         """
         Get an access token using client credentials.
@@ -180,6 +186,7 @@ class CheckRates(APIView):
     throttle_classes = (OnePerSecond,)
 
     @key_info
+    @method_decorator(never_cache)
     def get(self, request: Request, format=None):
         """
         Get information about your API key.
@@ -187,7 +194,7 @@ class CheckRates(APIView):
         You can use this endpoint to get information about your API key such as
         `requests_this_minute`, `requests_today`, and `rate_limit_model`.
 
-        > ℹ️ **NOTE:** If you get a 403 Forbidden response, it means your access
+        > **NOTE:** If you get a 403 Forbidden response, it means your access
         > token has expired.
         """
 

--- a/api/justfile
+++ b/api/justfile
@@ -112,7 +112,7 @@ dbshell:
 
 # Run API tests inside the Docker container
 test *args: wait-up
-    env DC_USER="opener" just ../exec web pytest {{ args }}
+    env DC_USER="opener" just ../exec web pytest "{{ quote(args) }}"
 
 # Run API tests locally
 test-local *args:

--- a/justfile
+++ b/justfile
@@ -226,7 +226,7 @@ attach service:
 
 # Execute statement in service containers using Docker Compose
 exec +args:
-    just dc exec -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} {{ args }}
+    just dc exec -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "{{ args }}"
 
 # Execute statement in a new service container using Docker Compose
 run +args:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4005 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the `cache_control` decorator to our API views, or `never_cache` when appropriate.

Most of the complexity in this PR comes from needing to backport code from Django 5 to support async view functions in `never_cache` and `cache_control`, as well as an additional shim to work around a limitation of `method_decorator`.

Other than that, the main "actual" interesting code is the additional method on the search parameters serializer to determine whether the request is eligible for public caching. Public caches like Cloudflare will not cache responses at the edge if authentication headers are on the request, but will do so if you explicitly set `public` in the `cache-control` header. The PR sets `public` in the header for any requests that do not use search features that are limited to authenticated users only.

That is the only route (other than admin, of course) where authentication causes a difference in behaviour beyond rate limiting, at least that I can think of, so the other routes can all have `public` so that the edge always caches responses for those routes (given that authed and anon users are getting the same responses back in those cases).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the cache control configurations and confirm they make sense for each route.

Run the app locally using `just api/up` and test the views. In the rendered DRF page, you will see the cache-control header listed in the headers for the response, so it's easy to debug this visually.

Confirm the unit tests cover the new behaviours defined in the serializer method. I have avoided testing the configuration of the cache control for views where it was purely a question of configuration, rather than some business logic that needed to succeed like in the case of the variably public cache control of the search routes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
