### PR TITLE
Handle PR automations when quick succession of PR approved and merged

### DIFF
--- a/automations/js/src/project_automation/prs.mjs
+++ b/automations/js/src/project_automation/prs.mjs
@@ -84,7 +84,7 @@ export const main = async (octokit, core) => {
   if (eventName === 'pull_request_review') {
     if (pr.isDraft) {
       await prBoard.moveCard(prCard.id, prBoard.columns.Draft)
-    } else {
+    } else if (!pr.isMerged) {
       await syncReviews(core, pr, prBoard, prCard)
     }
   } else {

--- a/automations/js/src/project_automation/prs.mjs
+++ b/automations/js/src/project_automation/prs.mjs
@@ -85,6 +85,12 @@ export const main = async (octokit, core) => {
     if (pr.isDraft) {
       await prBoard.moveCard(prCard.id, prBoard.columns.Draft)
     } else if (!pr.isMerged) {
+      // Don't touch merged PRs to avoid race condition when a PR is merged
+      // right after the review and is already in a merged state when
+      // re-retrieved by the workflow, even though the triggering event was the
+      // second review.
+      // In that case we want our handling of merged PRs to take precedence,
+      // rather than updating the status based on the second review.
       await syncReviews(core, pr, prBoard, prCard)
     }
   } else {


### PR DESCRIPTION
## Hypothesis

My hypothesis behind merged PRs being found in the "Approved" column is as follows.

- When a PR is approved `pr_automations_init.yml` is triggered (call it run A).
- When the PR is quickly merged GitHub immediately moves it to the "Merged" column because that's a built-in automation of GitHub Projects.
- Run A completes and triggers `pr_automations.yml` (call it run B).
- Run B checks that the PR has two approvals and moves it back to the "Approved" column.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR handles situations where a PR is merged quickly after a second approval. It does so by explicitly not moving PR based on the PR review decision if it has already been merged.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
