### PR TITLE
Refine the admin UI for `UserPreferences`

### DIFF
--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -168,7 +168,16 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
         return qs.filter(user=request.user)
 
     def changelist_view(self, request, extra_context=None):
-        obj = self.get_queryset(request).first()
+        """
+        Redirect to the change form for the logged-in user's preferences. This
+        view automatically creates the ``UserPreferences`` instance, if one does
+        not already exist for the current user.
+        """
+
+        if (qs := self.get_queryset(request)).exists():
+            obj = qs.first()
+        else:
+            obj = UserPreferences.objects.create(user=request.user)
         return HttpResponseRedirect(
             reverse("admin:api_userpreferences_change", args=[obj.id])
         )

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -151,6 +151,11 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
     verbose_name = "My Preferences"
     form = UserPreferencesAdminForm
 
+    def render_change_form(self, request, context, *args, **kwargs):
+        """Remove the "Save and add another" button from the change form."""
+        context["show_save_and_add_another"] = False
+        return super().render_change_form(request, context, *args, **kwargs)
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.filter(user=request.user)

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -157,14 +157,15 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
         return super().render_change_form(request, context, *args, **kwargs)
 
     def get_queryset(self, request):
+        """
+        Restrict the user's ability to view and change only the
+        ``UserPreferences`` instance mapped to their own ``User`` instance.
+
+        :return: the queryset of just the logged-in user's preferences
+        """
+
         qs = super().get_queryset(request)
         return qs.filter(user=request.user)
-
-    def has_change_permission(self, request, obj=None):
-        if not obj:
-            # the changelist itself
-            return True
-        return obj.user == request.user
 
     def changelist_view(self, request, extra_context=None):
         obj = self.get_queryset(request).first()

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -177,10 +177,7 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
         not already exist for the current user.
         """
 
-        if (qs := self.get_queryset(request)).exists():
-            obj = qs.first()
-        else:
-            obj = UserPreferences.objects.create(user=request.user)
+        obj = self.get_queryset(request).first()
         return HttpResponseRedirect(
             reverse("admin:api_userpreferences_change", args=[obj.id])
         )

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -156,6 +156,14 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
         context["show_save_and_add_another"] = False
         return super().render_change_form(request, context, *args, **kwargs)
 
+    def has_add_permission(self, request):
+        """Remove functionality to add new ``UserPreferences`` objects."""
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """Remove functionality to delete ``UserPreferences`` objects."""
+        return False
+
     def get_queryset(self, request):
         """
         Restrict the user's ability to view and change only the

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -151,11 +151,6 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
     verbose_name = "My Preferences"
     form = UserPreferencesAdminForm
 
-    def render_change_form(self, request, context, *args, **kwargs):
-        """Remove the "Save and add another" button from the change form."""
-        context["show_save_and_add_another"] = False
-        return super().render_change_form(request, context, *args, **kwargs)
-
     def has_add_permission(self, request):
         """Remove functionality to add new ``UserPreferences`` objects."""
         return False

--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -147,7 +147,6 @@ class IndividualUserPreferencesAdmin(admin.ModelAdmin):
     currently logged-in user's preferences
     """
 
-    can_delete = False
     verbose_name_plural = "My Preferences"
     verbose_name = "My Preferences"
     form = UserPreferencesAdminForm


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes modifications to the admin view of `UserPreferences` to restrict actions that can be performed.

This automatically removes the following UI elements.
- "Save and add another" button on the change form
- "Delete" button on the change form
- "Add" button besides "My Preferences" on the admin UI homepage

This PR also removes redundant attributes (like `can_delete`) and functions (like `has_change_permission`).

This PR also enables the automatic creation of `UserPreferences` when requested so that users that do not have one associated with them will get it created when the try to access the preferences page.

This PR targets branch `feature/moderator-user-preferences` i.e. PR #3914.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
