### PR TITLE
Turn on additional search views frontend

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -12,10 +12,10 @@
     "additional_search_views": {
       "status": {
         "staging": "switchable",
-        "production": "disabled"
+        "production": "switchable"
       },
       "description": "Toggle additional search views for tag/creator/source.",
-      "defaultState": "off",
+      "defaultState": "on",
       "storage": "cookie"
     },
     "additional_search_types": {

--- a/frontend/src/components/VMediaInfo/VMediaTags.vue
+++ b/frontend/src/components/VMediaInfo/VMediaTags.vue
@@ -58,6 +58,7 @@ import type { Tag } from "~/types/media"
 import type { SupportedMediaType } from "~/constants/media"
 import { useFeatureFlagStore } from "~/stores/feature-flag"
 import { useSearchStore } from "~/stores/search"
+import { useI18n } from "~/composables/use-i18n"
 
 import { focusElement } from "~/utils/focus-management"
 
@@ -87,7 +88,8 @@ export default defineComponent({
 
     const searchStore = useSearchStore()
     const featureFlagStore = useFeatureFlagStore()
-    const { app, $sendCustomEvent } = useContext()
+    const { $sendCustomEvent } = useContext()
+    const i18n = useI18n()
 
     const additionalSearchViews = computed(() =>
       featureFlagStore.isOn("additional_search_views")
@@ -106,7 +108,7 @@ export default defineComponent({
 
     const collapsibleRowsStartAt = ref<number>()
     const dir = computed(() => {
-      return app.i18n.localeProperties.dir
+      return i18n.localeProperties.dir
     })
 
     function isFurtherInline(previous: HTMLElement, current: HTMLElement) {

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -58,9 +58,9 @@ describe("AudioTrack", () => {
 
   it("should render the full audio track component even without duration", () => {
     options.propsData.layout = "full"
-    const { getByText } = render(VAudioTrack, options, configureVue)
-    const creator = getByText(props.audio.creator)
-    expect(creator).toBeInstanceOf(HTMLAnchorElement)
+    const { getByRole } = render(VAudioTrack, options, configureVue)
+    const creator = getByRole("link", { name: props.audio.creator })
+    expect(creator).toBeVisible()
   })
 
   it("should show audio title as main page title in full layout", () => {
@@ -73,10 +73,13 @@ describe("AudioTrack", () => {
 
   it("should show audio creator in a full layout with link", () => {
     options.propsData.layout = "full"
-    const { getByText } = render(VAudioTrack, options, configureVue)
-    const element = getByText(props.audio.creator)
-    expect(element).toBeInstanceOf(HTMLAnchorElement)
-    expect(element).toHaveAttribute("href", props.audio.creator_url)
+    const { getByRole } = render(VAudioTrack, options, configureVue)
+    const element = getByRole("link", { name: props.audio.creator })
+    expect(element).toBeVisible()
+    expect(element).toHaveAttribute(
+      "href",
+      `/audio/collection?source=jamendo&creator=${props.audio.creator}`
+    )
   })
 
   it("should render the row audio track component even without duration", () => {

--- a/frontend/test/unit/test-utils/i18n.js
+++ b/frontend/test/unit/test-utils/i18n.js
@@ -2,10 +2,12 @@ import VueI18n from "vue-i18n"
 
 const messages = require("~/locales/en.json")
 
-export const i18n = new VueI18n({
+const i18n = new VueI18n({
   locale: "en",
   fallbackLocale: "en",
   messages: {
     en: messages,
   },
 })
+i18n.localeProperties = { code: "en", dir: "ltr" }
+export { i18n }

--- a/frontend/test/unit/test-utils/pinia.js
+++ b/frontend/test/unit/test-utils/pinia.js
@@ -25,7 +25,12 @@ export const createPinia = () =>
         },
       },
       error: jest.fn(),
-      localePath: jest.fn(),
+      localePath: jest.fn((val) => {
+        const queryString = Object.keys(val?.query)
+          .map((key) => key + "=" + val?.query[key])
+          .join("&")
+        return `${val?.path ?? "/"}?${queryString}`
+      }),
     },
   }))
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4035 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes the `additional_search_views` flag switchable in prod, and turns it on by default, effectively launching the additional search views.
The test setup and checks had to be updated because the single result pages have slightly changed.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Build and run the app using `just frontend/run build` and `just frontend/run start`
Go to `https://localhost:8443/search?q=cat` and select a search result (image/audio). The new page with link buttons and tags as links should be displayed by default.
You should also be able to open the source/creator/tag pages, without setting the preferences previously.
If you go to `https://localhost:8443/preferences`, you can turn `additional_search_views` off to view the site without the additional views.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
