### PR TITLE
Add logging to all dag-sync exits

### DIFF
--- a/dag-sync.sh
+++ b/dag-sync.sh
@@ -19,14 +19,20 @@ git fetch origin
 # Get new commit hash *one commit ahead* of this one
 new=$(git rev-list --reverse --topo-order HEAD..origin/main | head -1)
 # If there is no new commit hash to move to, nothing has changed, quit early
-[ -z "$new" ] && exit
+if [ -z "$new" ]; then
+  echo "No new commits, nothing has changed, nothing to do."
+  exit
+fi
 
 # Move ahead to this new commit
 git reset --hard "$new"
 # Verify if have /dags/ in the last commit
 have_dag=$(git log -p -1 "$new" --pretty=format: --name-only | grep "catalog/dags/")
 # If there is no files under /dags/ folder, no need to notify, quit early
-[ -z "$have_dag" ] && exit
+if [ -z "$have_dag" ]; then
+  echo "No changes to DAGs, nothing to do."
+  exit
+fi
 
 # Pull out the subject from the new commit
 subject=$(git log -1 --format='%s')


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #2037

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The DAG sync script does not log except when it made changes. This makes it hard to observe in a production environment to confirm that it is working and running as expected (in a systemd timer).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `./dag-sync.sh` and confirm it logs and exits as expected ("no changes"... unless there _are_ changes on `main`, in which case you will see something else!).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
