### PR TITLE
Fix: Escape space in `just catalog/test` directory injection

### DIFF
--- a/catalog/justfile
+++ b/catalog/justfile
@@ -103,7 +103,7 @@ _mount-test command: up-deps
         --rm \
         -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 \
         -w /opt/airflow/catalog \
-        --volume {{ justfile_directory() }}/../docker:/opt/airflow/docker/ \
+        --volume \'{{ justfile_directory() }}/../docker\':/opt/airflow/docker/ \
         {{ SERVICE }} \
         {{ command }}
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
When running `just catalog/test`, script fails when there is a space in the directory path.
```
just catalog/test
just _mount-test "bash -c \'pytest \'"
env COMPOSE_PROFILES="catalog_dependencies" just ../up 
env COMPOSE_PROFILES="catalog_dependencies" docker compose -f docker-compose.yml up -d
[+] Running 3/3
 ✔ Container openverse-upstream_db-1  Running                                                                                                                                                        0.0s 
 ✔ Container openverse-s3-1           Running                                                                                                                                                        0.0s 
 ✔ Container openverse-load_to_s3-1   Started                                                                                                                                                        0.0s 

================================================================================
                                 Service Ports                                  
================================================================================
webserver (catalog):
-  http://0.0.0.0:9090  (→ 8080)
s3 (minio/minio):
-  http://0.0.0.0:5010  (→ 5000)
-  http://0.0.0.0:5011  (→ 5001)
upstream_db (upstream_db):
-  http://0.0.0.0:50255 (→ 5432)
================================================================================
env DC_USER="airflow" just ../run --rm -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 -w /opt/airflow/catalog --volume /PATH/PATH SPACED/openverse/catalog/../docker:/opt/airflow/docker/ scheduler bash -c \'pytest \'
just dc run -u airflow  "--rm -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 -w /opt/airflow/catalog --volume /PATH/PATH SPACED/openverse/catalog/../docker:/opt/airflow/docker/ scheduler bash -c 'pytest '"
env COMPOSE_PROFILES="api,ingestion_server,frontend,catalog" docker compose -f docker-compose.yml run -u airflow --rm -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 -w /opt/airflow/catalog --volume /PATH/PATH SPACED/openverse/catalog/../docker:/opt/airflow/docker/ scheduler bash -c 'pytest '
no such service: SPACED/openverse/catalog/../docker:/opt/airflow/docker/
error: Recipe `dc` failed on line 160 with exit code 1
error: Recipe `run` failed on line 233 with exit code 1
error: Recipe `_mount-test` failed on line 108 with exit code 1
error: Recipe `test` failed on line 117 with exit code 1
```


## Testing Instructions
When cloning the repository, ensure a directory in further in the path has a space. Then run `just catalog/test`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
