### PR TITLE
Refactor: Remove `get_media_type()` redundant override in providers with a single media type 

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/auckland_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/auckland_museum.py
@@ -99,9 +99,6 @@ class AucklandMuseumDataIngester(ProviderDataIngester):
 
         return True
 
-    def get_media_type(self, record: dict):
-        return IMAGE
-
     def get_record_data(self, data: dict) -> dict | list[dict] | None:
         # check if _id is empty then foreign_landing_url and
         # foreign_identifier doesn't exist

--- a/catalog/dags/providers/provider_api_scripts/auckland_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/auckland_museum.py
@@ -20,7 +20,6 @@ Resource | Requests per second | Requests per day
 import logging
 from datetime import datetime, timedelta
 
-from common.constants import IMAGE
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -22,9 +22,6 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         self.api_key = Variable.get("API_KEY_BROOKLYN_MUSEUM")
         self.headers = {"api_key": self.api_key}
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         if not prev_query_params:
             return {

--- a/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -3,7 +3,6 @@ import logging
 import lxml.html as html
 from airflow.models import Variable
 
-from common import constants
 from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/cc_mixter.py
+++ b/catalog/dags/providers/provider_api_scripts/cc_mixter.py
@@ -141,9 +141,6 @@ class CcMixterDataIngester(ProviderDataIngester):
         # less than the batch limit.
         return len(response_json) >= self.batch_limit
 
-    def get_media_type(self, record: dict) -> Literal["audio"]:
-        return constants.AUDIO
-
     @staticmethod
     def _get_duration(ps: str | None) -> int | None:
         """

--- a/catalog/dags/providers/provider_api_scripts/cc_mixter.py
+++ b/catalog/dags/providers/provider_api_scripts/cc_mixter.py
@@ -14,9 +14,7 @@ Notes:                  Documentation: https://ccmixter.org/query-api
 import json
 import logging
 import re
-from typing import Literal
 
-from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester

--- a/catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -27,10 +27,6 @@ class ClevelandDataIngester(ProviderDataIngester):
                 "skip": prev_query_params["skip"] + self.batch_limit,
             }
 
-    def get_media_type(self, record):
-        # This provider only supports Images.
-        return "image"
-
     def get_batch_data(self, response_json):
         if response_json:
             return response_json.get("data")

--- a/catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -18,7 +18,6 @@ Notes:                  https://api.finna.fi/swagger-ui/
 import logging
 from itertools import chain
 
-from common import constants
 from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.time_delineated_provider_data_ingester import (

--- a/catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -91,9 +91,6 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
             return response_json.get("resultCount", 0)
         return 0
 
-    def get_media_type(self, record):
-        return constants.IMAGE
-
     def get_batch_data(self, response_json):
         if (
             not response_json

--- a/catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/catalog/dags/providers/provider_api_scripts/flickr.py
@@ -17,7 +17,6 @@ from datetime import datetime, timedelta
 import lxml.html as html
 from airflow.models import Variable
 
-from common import constants
 from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from common.loader.provider_details import ImageCategory

--- a/catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/catalog/dags/providers/provider_api_scripts/flickr.py
@@ -175,10 +175,6 @@ class FlickrDataIngester(TimeDelineatedProviderDataIngester):
             # Increment the page number on subsequent requests
             return {**prev_query_params, "page": prev_query_params["page"] + 1}
 
-    def get_media_type(self, record):
-        # We only ingest images from Flickr
-        return constants.IMAGE
-
     def get_batch_data(self, response_json):
         self.requests_count += 1
         if response_json is None or response_json.get("stat") != "ok":

--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -20,7 +20,6 @@ from airflow.models import Variable
 from requests.exceptions import ConnectionError, HTTPError, SSLError
 from retry import retry
 
-from common import constants
 from common.licenses.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -53,9 +53,6 @@ class FreesoundDataIngester(ProviderDataIngester):
 
         super().__init__(*args, **kwargs)
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.AUDIO
-
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         if not prev_query_params:
             start_date = "*"

--- a/catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -45,9 +45,6 @@ class JamendoDataIngester(ProviderDataIngester):
     batch_limit = 200
     headers = {"Accept": "application/json"}
 
-    def get_media_type(self, record):
-        return constants.AUDIO
-
     def get_next_query_params(self, prev_query_params, **kwargs):
         if not prev_query_params:
             # On first request, build default params.

--- a/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
+++ b/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
@@ -14,7 +14,6 @@ import logging
 
 from airflow.models import Variable
 
-from common.constants import IMAGE
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
+++ b/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
@@ -45,9 +45,6 @@ class JusttakeitfreeDataIngester(ProviderDataIngester):
             return data
         return None
 
-    def get_media_type(self, record: dict):
-        return IMAGE
-
     def get_record_data(self, data: list[dict]) -> dict | None:
         data = data[0]
         if not (foreign_landing_url := data.get("page_link")):

--- a/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -167,10 +167,6 @@ class MetMuseumDataIngester(ProviderDataIngester):
     def _get_artist_name(self, object_json: dict) -> str | None:
         return object_json.get("artistDisplayName")
 
-    def get_media_type(self, object_json: dict):
-        # This provider only supports Images.
-        return constants.IMAGE
-
 
 def main(date: str):
     logger.info("Begin: Metropolitan Museum data ingestion")

--- a/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -28,7 +28,6 @@ Notes:                  https://metmuseum.github.io/#search
 import argparse
 import logging
 
-from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/museum_victoria.py
+++ b/catalog/dags/providers/provider_api_scripts/museum_victoria.py
@@ -114,9 +114,6 @@ class VictoriaDataIngester(ProviderDataIngester):
             images.append(image)
         return images
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     @staticmethod
     def _get_image_data(
         media: dict,

--- a/catalog/dags/providers/provider_api_scripts/museum_victoria.py
+++ b/catalog/dags/providers/provider_api_scripts/museum_victoria.py
@@ -1,7 +1,6 @@
 import logging
 from typing import TypedDict
 
-from common import constants
 from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/nappy.py
+++ b/catalog/dags/providers/provider_api_scripts/nappy.py
@@ -52,9 +52,6 @@ class NappyDataIngester(ProviderDataIngester):
     def get_should_continue(self, response_json):
         return bool(response_json.get("next_page"))
 
-    def get_media_type(self, record: dict):
-        return constants.IMAGE
-
     @staticmethod
     def _convert_filesize(raw_filesize_string: str) -> int:
         """Convert sizes from strings to byte integers, ex. "187.8kB" to 188."""

--- a/catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/catalog/dags/providers/provider_api_scripts/nypl.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qs, urlparse
 
 from airflow.models import Variable
 
-from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.loader.provider_details import ImageCategory

--- a/catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/catalog/dags/providers/provider_api_scripts/nypl.py
@@ -75,10 +75,6 @@ class NyplDataIngester(ProviderDataIngester):
                 "page": prev_query_params["page"] + 1,
             }
 
-    def get_media_type(self, record):
-        # This provider only supports Images.
-        return constants.IMAGE
-
     def get_batch_data(self, response_json):
         if response_json:
             return response_json.get("nyplAPI", {}).get("response", {}).get("result")

--- a/catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -91,9 +91,6 @@ class RawpixelDataIngester(ProviderDataIngester):
         super().__init__(*args, **kwargs)
         self.api_key: str = Variable.get("API_KEY_RAWPIXEL")
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     def _get_signature(self, query_params: dict) -> str:
         """
         Get the query signature for a request.

--- a/catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -98,10 +98,6 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
             "date[to]": to_,
         }
 
-    def get_media_type(self, record):
-        # This provider only supports Images.
-        return "image"
-
     def get_batch_data(self, response_json):
         if response_json:
             return response_json.get("data")

--- a/catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -14,7 +14,6 @@ from airflow.exceptions import AirflowException
 from airflow.models import Variable
 from retry import retry
 
-from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -115,9 +115,6 @@ class SmithsonianDataIngester(ProviderDataIngester):
             license_url="https://creativecommons.org/publicdomain/zero/1.0/"
         )
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         # On the first request, `prev_query_params` will be `None`. We can detect this
         # and return our default params.

--- a/catalog/dags/providers/provider_api_scripts/smk.py
+++ b/catalog/dags/providers/provider_api_scripts/smk.py
@@ -27,9 +27,6 @@ class SmkDataIngester(ProviderDataIngester):
     headers = {"Accept": "application/json"}
     providers = {"image": prov.SMK_DEFAULT_PROVIDER}
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         if not prev_query_params:
             return {

--- a/catalog/dags/providers/provider_api_scripts/smk.py
+++ b/catalog/dags/providers/provider_api_scripts/smk.py
@@ -11,7 +11,6 @@ Notes:                  https://www.smk.dk/en/article/smk-api/
 import logging
 import urllib.parse
 
-from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester

--- a/catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -45,9 +45,6 @@ class StockSnapDataIngester(ProviderDataIngester):
         self._page_counter += 1
         return {}
 
-    def get_media_type(self, record):
-        return "image"
-
     @property
     def endpoint(self):
         return f"{ENDPOINT_BASE}/{self._page_counter}"

--- a/catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -53,9 +53,6 @@ class WordPressDataIngester(ProviderDataIngester):
         self.total_pages = None
         self.current_page = 1
 
-    def get_media_type(self, record: dict) -> str:
-        return constants.IMAGE
-
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         if self.total_pages is None:
             # On the first request, make a HEAD request to get the number of pages of


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1385  by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
https://github.com/WordPress/openverse-catalog/pull/821 introduced a default implementation for `ProviderDataIngester::get_media_type`. All overrides of `get_media_type` where a constant or literal value is returned (e.i. single media type providers) are removed.

The only exception is `INaturalistDataIngester`, which modifies the signature of `get_media_type()` to be static. Otherwise, it would be eligible to use the parent method.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
