### PR TITLE
Bugfix to ensure image type is correctly extracted from content type

### DIFF
--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -80,6 +80,5 @@ def _get_file_extension_from_content_type(content_type: str) -> str | None:
     header.
     """
     if content_type and "/" in content_type:
-        #filtered_type = content_type.split("/")[1].split(";")[0].split("+")[0]
         return mimetypes.guess_extension(content_type.split(";")[0], strict=False).strip('.')
     return None

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -79,6 +79,6 @@ def _get_file_extension_from_content_type(content_type: str) -> str | None:
     Return the image extension if present in the Response's content type
     header.
     """
-    if content_type and "/" in content_type:
-        return mimetypes.guess_extension(content_type.split(";")[0], strict=False).strip('.')
+    if content_type and "/" in content_type and (ext := mimetypes.guess_extension(content_type.split(";")[0], strict=False)):
+        return ext.strip('.')
     return None

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -1,7 +1,7 @@
 import logging
+import mimetypes
 from os.path import splitext
 from urllib.parse import urlparse
-import mimetypes
 
 import aiohttp
 import django_redis
@@ -79,6 +79,10 @@ def _get_file_extension_from_content_type(content_type: str) -> str | None:
     Return the image extension if present in the Response's content type
     header.
     """
-    if content_type and "/" in content_type and (ext := mimetypes.guess_extension(content_type.split(";")[0], strict=False)):
-        return ext.strip('.')
+    if (
+        content_type
+        and "/" in content_type
+        and (ext := mimetypes.guess_extension(content_type.split(";")[0], strict=False))
+    ):
+        return ext.strip(".")
     return None

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -1,6 +1,7 @@
 import logging
 from os.path import splitext
 from urllib.parse import urlparse
+import mimetypes
 
 import aiohttp
 import django_redis
@@ -79,5 +80,6 @@ def _get_file_extension_from_content_type(content_type: str) -> str | None:
     header.
     """
     if content_type and "/" in content_type:
-        return content_type.split("/")[1].split(";")[0]
+        #filtered_type = content_type.split("/")[1].split(";")[0].split("+")[0]
+        return mimetypes.guess_extension(content_type.split(";")[0], strict=False).strip('.')
     return None

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -79,5 +79,5 @@ def _get_file_extension_from_content_type(content_type: str) -> str | None:
     header.
     """
     if content_type and "/" in content_type:
-        return content_type.split("/")[1]
+        return content_type.split("/")[1].split(";")[0]
     return None

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -527,7 +527,7 @@ def test__get_extension_from_url(image_url, expected_ext):
         ("audio/wav", None),
         ("video/webm", "webm"),
         (None, None),
-        ("foobar", None)
+        ("foobar", None),
     ],
 )
 def test_get_extension_from_content_type(content_type, expected_ext):

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -511,6 +511,22 @@ def test_get_unsuccessful_request_raises_custom_exception(photon_get):
 def test__get_extension_from_url(image_url, expected_ext):
     assert extension._get_file_extension_from_url(image_url) == expected_ext
 
+@pytest.mark.parametrize(
+    "content_type","expected_ext",
+    [
+        ("image/jpeg", "jpeg"),
+        ("image/png", ".png"),
+        ("image/gif", ".gif"),
+        ("image/svg+xml", ".svg"),
+        ("audio/midi", ".mid"),
+        ("audio/mpeg", ".mp3"),
+        ("audio/ogg", ".oga"),
+        ("application/ogg", ".ogx"),
+        ("audio/opus", ".opus"),
+        ("audio/wav",".wav"),
+        ("video/webm", ".webm")
+    ]
+)
 def test_get_extension_from_content_type(content_type, expected_ext):
     assert extension._get_file_extension_from_content_type(content_type) == expected_ext
 

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -516,7 +516,7 @@ def test__get_extension_from_url(image_url, expected_ext):
     "content_type, expected_ext",
     [
         ("image/png;charset=UTF-8", "png"),
-        ("image/jpeg", "jpeg"),
+        ("image/jpeg", "jpg"),
         ("image/png", "png"),
         ("image/gif", "gif"),
         ("image/svg+xml", "svg"),

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -515,6 +515,7 @@ def test__get_extension_from_url(image_url, expected_ext):
 @pytest.mark.parametrize(
     "content_type, expected_ext",
     [
+        ("image/png;charset=UTF-8", "png"),
         ("image/jpeg", "jpeg"),
         ("image/png", "png"),
         ("image/gif", "gif"),
@@ -522,7 +523,6 @@ def test__get_extension_from_url(image_url, expected_ext):
         ("audio/midi", "mid"),
         ("audio/mpeg", "mp3"),
         ("audio/ogg", "oga"),
-        ("application/ogg", "ogx"),
         ("audio/opus", "opus"),
         ("audio/wav", "wav"),
         ("video/webm", "webm"),

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -514,7 +514,7 @@ def test__get_extension_from_url(image_url, expected_ext):
 @pytest.mark.parametrize(
     "content_type","expected_ext",
     [
-        ("image/jpeg", "jpeg"),
+        ("image/jpeg", ".jpeg"),
         ("image/png", ".png"),
         ("image/gif", ".gif"),
         ("image/svg+xml", ".svg"),

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -511,8 +511,10 @@ def test_get_unsuccessful_request_raises_custom_exception(photon_get):
 def test__get_extension_from_url(image_url, expected_ext):
     assert extension._get_file_extension_from_url(image_url) == expected_ext
 
+
 @pytest.mark.parametrize(
-    "content_type","expected_ext",
+    "content_type",
+    "expected_ext",
     [
         ("image/jpeg", ".jpeg"),
         ("image/png", ".png"),
@@ -523,12 +525,13 @@ def test__get_extension_from_url(image_url, expected_ext):
         ("audio/ogg", ".oga"),
         ("application/ogg", ".ogx"),
         ("audio/opus", ".opus"),
-        ("audio/wav",".wav"),
-        ("video/webm", ".webm")
-    ]
+        ("audio/wav", ".wav"),
+        ("video/webm", ".webm"),
+    ],
 )
 def test_get_extension_from_content_type(content_type, expected_ext):
     assert extension._get_file_extension_from_content_type(content_type) == expected_ext
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("image_type", ["apng", "tiff", "bmp"])

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -527,8 +527,7 @@ def test__get_extension_from_url(image_url, expected_ext):
         ("audio/wav", None),
         ("video/webm", "webm"),
         (None, None),
-        (5, None),
-        ([], None)
+        ("foobar", None)
     ],
 )
 def test_get_extension_from_content_type(content_type, expected_ext):

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -520,12 +520,15 @@ def test__get_extension_from_url(image_url, expected_ext):
         ("image/png", "png"),
         ("image/gif", "gif"),
         ("image/svg+xml", "svg"),
-        ("audio/midi", "mid"),
+        ("audio/midi", "midi"),
         ("audio/mpeg", "mp3"),
-        ("audio/ogg", "oga"),
+        ("audio/ogg", None),
         ("audio/opus", "opus"),
-        ("audio/wav", "wav"),
+        ("audio/wav", None),
         ("video/webm", "webm"),
+        (None, None),
+        (5, None),
+        ([], None)
     ],
 )
 def test_get_extension_from_content_type(content_type, expected_ext):

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -513,20 +513,19 @@ def test__get_extension_from_url(image_url, expected_ext):
 
 
 @pytest.mark.parametrize(
-    "content_type",
-    "expected_ext",
+    "content_type, expected_ext",
     [
-        ("image/jpeg", ".jpeg"),
-        ("image/png", ".png"),
-        ("image/gif", ".gif"),
-        ("image/svg+xml", ".svg"),
-        ("audio/midi", ".mid"),
-        ("audio/mpeg", ".mp3"),
-        ("audio/ogg", ".oga"),
-        ("application/ogg", ".ogx"),
-        ("audio/opus", ".opus"),
-        ("audio/wav", ".wav"),
-        ("video/webm", ".webm"),
+        ("image/jpeg", "jpeg"),
+        ("image/png", "png"),
+        ("image/gif", "gif"),
+        ("image/svg+xml", "svg"),
+        ("audio/midi", "mid"),
+        ("audio/mpeg", "mp3"),
+        ("audio/ogg", "oga"),
+        ("application/ogg", "ogx"),
+        ("audio/opus", "opus"),
+        ("audio/wav", "wav"),
+        ("video/webm", "webm"),
     ],
 )
 def test_get_extension_from_content_type(content_type, expected_ext):

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -511,6 +511,8 @@ def test_get_unsuccessful_request_raises_custom_exception(photon_get):
 def test__get_extension_from_url(image_url, expected_ext):
     assert extension._get_file_extension_from_url(image_url) == expected_ext
 
+def test_get_extension_from_content_type(content_type, expected_ext):
+    assert extension._get_file_extension_from_content_type(content_type) == expected_ext
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("image_type", ["apng", "tiff", "bmp"])


### PR DESCRIPTION
## Fixes

Fixes #3750 by @obulat 
In `api/utils/image_proxy/extension.py`, `_get_file_extension_from_content_type()` was modified to split the returned `content_type` by `; `in order to remove undesirable appended section of string to the file type. I also made sure to strip any preceding `.` that occurred when passing `content_type` to `mimetypes.guess_extension()`. Finally, `None` was returned anytime the call to `mimetypes.guess_extension()` returned `None`.  

## Description

When you attempt to go to [the following link](https://api.openverse.engineering/v1/images/cf168b67-00be-4e4c-8985-ccf388afecd5/thumb), the following 415 error is returned:
`{"detail":"Unsupported media type \"Image extension png;charset=UTF-8 is not supported by the thumbnail proxy.\" in request."}`
`charset=UTF-8` is incorrectly appended to `png`. To solve this, I wrote a function to remove the undesirable appended section of the content file type. I also wrote a `@pytest.mark.parametrize` decorator that contains tests for various file extensions. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Created a draft pull request so that I can get assistance on running the tests utilizing the Docker container. 


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
