### PR TITLE
Fix: Remove unwanted leading/trailing whitespaces in attributions

### DIFF
--- a/frontend/src/components/VMediaInfo/VCopyLicense.vue
+++ b/frontend/src/components/VMediaInfo/VCopyLicense.vue
@@ -28,16 +28,14 @@
         :media-id="media.id"
         :media-type="media.frontendMediaType"
       >
-        <p id="attribution-html" class="break-all font-mono" dir="ltr">
-          {{ getAttributionMarkup() }}
-        </p>
+        <p id="attribution-html" class="break-all font-mono" dir="ltr">{{ getAttributionMarkup() }}</p>
       </VLicenseTabPanel>
       <VLicenseTabPanel
         :tab="tabs[2]"
         :media-id="media.id"
         :media-type="media.frontendMediaType"
       >
-        {{ getAttributionMarkup({ isPlaintext: true }) }}
+        <p>{{ getAttributionMarkup({ isPlaintext: true }) }}</p>
       </VLicenseTabPanel>
     </VTabs>
   </div>

--- a/frontend/src/utils/attribution-html.ts
+++ b/frontend/src/utils/attribution-html.ts
@@ -244,7 +244,7 @@ export const getAttribution = (
     })
   }
 
-  const attribution = tFn("text", attributionParts).replace(/\s{2}/g, " ")
+  const attribution = tFn("text", attributionParts).replace(/\s{2}/g, " ").trim()
 
   return isPlaintext
     ? attribution


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #553 by @ krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

There are two issues that contributed to unwanted leading/trailing whitespaces around the attribution copy:
1. The translation used expects a `viewLegal` property, which is empty
2. The interpolated string has leading/trailing whitespace within the parent `<p>` element

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
