### PR TITLE
Fix the feature flags in production on hydration

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -10,10 +10,7 @@
       "storage": "cookie"
     },
     "additional_search_views": {
-      "status": {
-        "staging": "switchable",
-        "production": "switchable"
-      },
+      "status": "switchable",
       "description": "Toggle additional search views for tag/creator/source.",
       "defaultState": "on",
       "storage": "cookie"

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -346,6 +346,7 @@ const config: NuxtConfig = {
         environment: process.env.SENTRY_ENVIRONMENT,
       },
     },
+    deploymentEnv: process.env.DEPLOYMENT_ENV ?? "local",
   },
 }
 

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -32,6 +32,20 @@ export interface FeatureFlagState {
   flags: Record<FlagName, FeatureFlag>
 }
 
+export const _getFlagStatus = (flag: FeatureFlag, deployEnv: DeployEnv) => {
+  if (typeof flag.status === "string") {
+    return flag.status
+  } else {
+    const envIndex = DEPLOY_ENVS.indexOf(deployEnv)
+    for (let i = envIndex; i < DEPLOY_ENVS.length; i += 1) {
+      if (DEPLOY_ENVS[i] in flag.status) {
+        return flag.status[DEPLOY_ENVS[i]]
+      }
+    }
+  }
+  return DISABLED
+}
+
 const FEATURE_FLAG = "feature_flag"
 
 export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
@@ -158,17 +172,7 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
      * @param flag - the flag for which to get the status
      */
     getFlagStatus(flag: FeatureFlag): FlagStatus {
-      if (typeof flag.status === "string") {
-        return flag.status
-      } else {
-        const envIndex = DEPLOY_ENVS.indexOf(this.deploymentEnv)
-        for (let i = envIndex; i < DEPLOY_ENVS.length; i += 1) {
-          if (DEPLOY_ENVS[i] in flag.status) {
-            return flag.status[DEPLOY_ENVS[i]]
-          }
-        }
-      }
-      return DISABLED
+      return _getFlagStatus(flag, this.deploymentEnv)
     },
 
     /**

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -73,7 +73,6 @@ test.describe("switchable features", () => {
 
       const featureCookie = await getFeatureCookies(page, feature.storageCookie)
       expect(featureCookie[name]).toEqual(feature.to)
-      expect(1).toEqual(9)
     })
   }
 })

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -35,11 +35,11 @@ const getSwitchableInput = async (
   checked: boolean
 ) => {
   const checkbox = page.locator(`input[type=checkbox]#${name}`).first()
-  expect(await checkbox.getAttribute("disabled")).toBeNull()
+  await expect(checkbox).toBeEnabled()
   if (checked) {
-    await expect(checkbox).toHaveAttribute("checked", "checked")
+    await expect(checkbox).toBeChecked()
   } else {
-    await expect(checkbox).not.toHaveAttribute("checked")
+    await expect(checkbox).not.toBeChecked()
   }
   return checkbox
 }
@@ -57,11 +57,12 @@ test.describe("switchable features", () => {
       const featureFlag = await getSwitchableInput(page, name, feature.checked)
       await featureFlag.click()
 
-      const inputCheckedStatus = await page
-        .locator(`#${name}`)
-        .first()
-        .getAttribute("checked")
-      expect(inputCheckedStatus).toEqual(feature.checked ? "checked" : null)
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (feature.checked) {
+        await expect(featureFlag).not.toBeChecked()
+      } else {
+        await expect(featureFlag).toBeChecked()
+      }
     })
 
     test(`switching ${name} from ${feature.from} to ${feature.to} saves state in a cookie`, async ({

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, Page } from "@playwright/test"
+
+import { preparePageForTests } from "~~/test/playwright/utils/navigation"
+
+const getFeatureCookies = async (page: Page, cookieName: string) => {
+  const cookies = await page.context().cookies()
+  const cookieValue = cookies.find(
+    (cookie) => cookie.name === cookieName
+  )?.value
+  if (!cookieValue) {
+    console.error("no cookie value found for", cookieName, "cookie", cookies)
+    return {}
+  }
+  return JSON.parse(decodeURIComponent(cookieValue))
+}
+
+const features = {
+  fetch_sensitive: {
+    checked: false,
+    from: "off",
+    to: "on",
+    storageCookie: "sessionFeatures",
+  },
+  additional_search_views: {
+    checked: true,
+    from: "on",
+    to: "off",
+    storageCookie: "features",
+  },
+}
+
+const getSwitchableInput = async (
+  page: Page,
+  name: string,
+  checked: boolean
+) => {
+  const checkbox = page.locator(`input[type=checkbox]#${name}`).first()
+  expect(await checkbox.getAttribute("disabled")).toBeNull()
+  if (checked) {
+    await expect(checkbox).toHaveAttribute("checked", "checked")
+  } else {
+    await expect(checkbox).not.toHaveAttribute("checked")
+  }
+  return checkbox
+}
+
+test.describe("switchable features", () => {
+  test.beforeEach(async ({ page }) => {
+    await preparePageForTests(page, "xl")
+  })
+
+  for (const [name, feature] of Object.entries(features)) {
+    test(`can switch ${name} from ${feature.from} to ${feature.to}`, async ({
+      page,
+    }) => {
+      await page.goto(`/preferences`)
+      const featureFlag = await getSwitchableInput(page, name, feature.checked)
+      await featureFlag.click()
+
+      const inputCheckedStatus = await page
+        .locator(`#${name}`)
+        .first()
+        .getAttribute("checked")
+      expect(inputCheckedStatus).toEqual(feature.checked ? "checked" : null)
+    })
+
+    test(`switching ${name} from ${feature.from} to ${feature.to} saves state in a cookie`, async ({
+      page,
+    }) => {
+      await page.goto(`/preferences`)
+      const featureFlag = await getSwitchableInput(page, name, feature.checked)
+      await featureFlag.click()
+
+      const featureCookie = await getFeatureCookies(page, feature.storageCookie)
+      expect(featureCookie[name]).toEqual(feature.to)
+      expect(1).toEqual(9)
+    })
+  }
+})

--- a/frontend/test/playwright/playwright.config.ts
+++ b/frontend/test/playwright/playwright.config.ts
@@ -28,7 +28,6 @@ const config: PlaywrightTestConfig = {
       API_URL,
       UPDATE_TAPES: UPDATE_TAPES,
       PW: "true",
-      DEPLOYMENT_ENV: "staging",
     },
   },
   use: {

--- a/frontend/test/playwright/playwright.config.ts
+++ b/frontend/test/playwright/playwright.config.ts
@@ -28,6 +28,7 @@ const config: PlaywrightTestConfig = {
       API_URL,
       UPDATE_TAPES: UPDATE_TAPES,
       PW: "true",
+      DEPLOYMENT_ENV: "staging",
     },
   },
   use: {

--- a/frontend/test/playwright/utils/navigation.ts
+++ b/frontend/test/playwright/utils/navigation.ts
@@ -205,7 +205,7 @@ export const preparePageForTests = async (
 ) => {
   const { dismissBanners = true, dismissFilter = true } = options
 
-  const cookiesToSet: Record<string, unknown> = {
+  const cookiesToSet: CookieMap = {
     ui: {
       dismissedBanners: dismissBanners ? ALL_TEST_BANNERS : [],
       isFilterDismissed: dismissFilter ?? false,
@@ -378,7 +378,7 @@ export interface CookieMap {
 
 export const setCookies = async (
   context: BrowserContext,
-  cookies: Record<string, unknown>
+  cookies: CookieMap
 ) => {
   const existingCookies = await context.cookies()
   const cookiesToSet = Object.entries(cookies).map(([name, value]) => {

--- a/frontend/test/unit/specs/stores/feature-flag-store.spec.js
+++ b/frontend/test/unit/specs/stores/feature-flag-store.spec.js
@@ -1,6 +1,6 @@
 import { setActivePinia, createPinia } from "~~/test/unit/test-utils/pinia"
 
-import { useFeatureFlagStore, getFlagStatus } from "~/stores/feature-flag"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
 import { OFF, COOKIE, SESSION } from "~/constants/feature-flag"
 
 jest.mock(
@@ -145,20 +145,14 @@ describe("Feature flag store", () => {
   `(
     "returns $expectedState for $environment",
     ({ environment, featureState }) => {
-      // Back up value of `DEPLOYMENT_ENV` and replace it
-      const old_env = process.env.DEPLOYMENT_ENV
-      process.env.DEPLOYMENT_ENV = environment
-
       const featureFlagStore = useFeatureFlagStore()
+      featureFlagStore.$nuxt.$config.deploymentEnv = environment
       expect(featureFlagStore.featureState("feat_env_specific")).toEqual(
         featureState
       )
       expect(featureFlagStore.isOn("feat_env_specific")).toEqual(
         featureState === "on"
       )
-
-      // Restore `DEPLOYMENT_ENV` value
-      process.env.DEPLOYMENT_ENV = old_env
     }
   )
 
@@ -170,16 +164,13 @@ describe("Feature flag store", () => {
   `(
     "handles fallback for missing $environment",
     ({ environment, flagStatus }) => {
-      // Back up value of `DEPLOYMENT_ENV` and replace it
-      const old_env = process.env.DEPLOYMENT_ENV
-      process.env.DEPLOYMENT_ENV = environment
-
-      expect(getFlagStatus({ status: { staging: "switchable" } })).toEqual(
-        flagStatus
-      )
-
-      // Restore `DEPLOYMENT_ENV` value
-      process.env.DEPLOYMENT_ENV = old_env
+      const featureFlagStore = useFeatureFlagStore()
+      featureFlagStore.$nuxt.$config.deploymentEnv = environment
+      expect(
+        useFeatureFlagStore().getFlagStatus({
+          status: { staging: "switchable" },
+        })
+      ).toEqual(flagStatus)
     }
   )
 

--- a/frontend/test/unit/test-utils/pinia.js
+++ b/frontend/test/unit/test-utils/pinia.js
@@ -6,6 +6,9 @@ import { normalizeFetchingError } from "~/plugins/errors"
 export const createPinia = () =>
   pinia.createPinia().use(() => ({
     $nuxt: {
+      $config: {
+        deploymentEnv: "staging",
+      },
       $openverseApiToken: "",
       $processFetchingError: jest.fn(normalizeFetchingError),
       $sentry: {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4082 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The feature flag store was using the env variable to get the deployment environment and the flag state for this environment. However, the env variable is not available on the client. I moved the setting to `publicRuntimeConfig`. To use the config in the feature flag store functions (`getFlagStatus`, `getFeatureState`), I had to move them inside the store itself. Because `this` was not available in some getters that used these functions, I converted them to actions.

I also updated the e2e setup to only set the feature cookies when we explicitly set some feature state in `preparePageForTests`, otherwise we don't set it to not change the default state.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On main, run the app in production mode using `just frontend/run build` and then `DEPLOYMENT_ENV=production just frontend/run start`.
Go to http://localhost:8443/preferences and open console. You should see the errors mentioned in the linked issue in the console. When you attempt to click on the switchable input, the inner circle disappears.

Do the same in this branch, and you should be able to change the state of the switchable flags without errors. You can check the cookie state to confirm the flag was set. You can also see that additional search views are visible when you turn them on.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
