### PR TITLE
Add a redirect on 503 to frontend nginx

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -81,5 +81,20 @@ server {
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host  $host;
+
+        proxy_intercept_errors on;
+        error_page 503 = @custom_424;  # Redirect 503 errors when Plausible is down
+    }
+
+    # Replace 503 Plausible errors when the service is down with a 424 error.
+    location @custom_424 {
+        internal;
+        add_header Content-Type "application/json";
+
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+
+        return 424 '{"error": "Failed Dependency", "message": "Plausible service unavailable."}';
     }
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2996 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR rewrites the error code when Plausible is unavailable (503) to a 424 error to allow us to count frontend 5xx errors separately from Plausible 5xx errors.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I don't know how to test this.

I tried adding the following patch:
```
Subject: [PATCH] Add a redirect on 503 to frontend nginx
---
Index: frontend/nginx.conf.template
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/frontend/nginx.conf.template b/frontend/nginx.conf.template
--- a/frontend/nginx.conf.template	(revision 19cde7cdff2d8b785ebb4dee50966a37be5dd4eb)
+++ b/frontend/nginx.conf.template	(date 1712906826225)
@@ -73,7 +73,8 @@
     resolver $OPENVERSE_NGINX_DNS_RESOLVER;
     set $plausible_event_url $OPENVERSE_NGINX_PLAUSIBLE_EVENT_URL;
     location = /api/event {
-        proxy_pass $plausible_event_url;
+        return 503;
+        # proxy_pass $plausible_event_url;
         proxy_set_header Host plausible.io;
         proxy_buffering on;
         proxy_http_version 1.1;
```
And running `just frontend/up` and `just frontend/dev` (or `just frontend/build` & `just frontend/start`), but the event was still sent. I also updated the Plausible settings in the `nuxt.config` to use the local url instead of plausible.io, but could not mock a 503 error.
@sarayourfriend, do you know how we could test this?

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
