### PR TITLE
Fill out query params for Stocksnap DAG, allow restarts

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -38,7 +38,7 @@ class StockSnapDataIngester(ProviderDataIngester):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._page_counter = 0
+        self._page_counter = 1
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         if prev_query_params:

--- a/catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -41,9 +41,22 @@ class StockSnapDataIngester(ProviderDataIngester):
         self._page_counter = 0
 
     def get_next_query_params(self, prev_query_params, **kwargs):
-        # StockSnap uses /{page} at the end of the endpoint url instead of query params.
-        self._page_counter += 1
-        return {}
+        if prev_query_params:
+            return {"page": prev_query_params["page"] + 1}
+        return {"page": 1}
+
+    def _get_query_params(
+        self, prev_query_params: dict | None, **kwargs
+    ) -> dict | None:
+        query_params = super()._get_query_params(prev_query_params, **kwargs)
+        if query_params:
+            # Record the page that we are currently on so that it can be used as part of
+            # the endpoint URL.
+            self._page_counter = query_params.get("page", 1)
+        # We still return a "fake" query parameter in order to allow appropriate
+        # starting/stopping of the ingestion process at a specific page.
+        # This query parameter is not used.
+        return query_params
 
     @property
     def endpoint(self):

--- a/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -39,7 +39,7 @@ def test_get_media_type():
 
 
 def test_endpoint_with_initialized_page_counter():
-    expect_result = "https://stocksnap.io/api/load-photos/date/desc/0"
+    expect_result = "https://stocksnap.io/api/load-photos/date/desc/1"
     actual_result = stocksnap.endpoint
     assert expect_result == actual_result
 
@@ -123,7 +123,9 @@ def test_endpoint_increment():
 
 def test_initial_params_respected():
     stocksnap = StockSnapDataIngester(conf={"initial_query_params": {"page": 5}})
+    query_params = stocksnap._get_query_params(None)
     assert stocksnap._page_counter == 5
+    assert query_params == {"page": 5}
 
 
 def test_get_record_data_returns_none_when_media_data_none():

--- a/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -114,11 +114,16 @@ def test_process_batch(filesize_mock):
 
 
 def test_endpoint_increment():
-    expect_result = ({}, "https://stocksnap.io/api/load-photos/date/desc/1")
+    expect_result = ({"page": 1}, "https://stocksnap.io/api/load-photos/date/desc/1")
     query_params = stocksnap.get_next_query_params(None)
     next_endpoint = stocksnap.endpoint
     actual_result = (query_params, next_endpoint)
     assert expect_result == actual_result
+
+
+def test_initial_params_respected():
+    stocksnap = StockSnapDataIngester(conf={"initial_query_params": {"page": 5}})
+    assert stocksnap._page_counter == 5
 
 
 def test_get_record_data_returns_none_when_media_data_none():


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #4101

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds some machinery around the `query_params` handling for the Stocksnap DAG so that we can leverage the options we already have available for query parameters for manipulating the page(s) that the Stocksnap DAG operates on. This doesn't address the error described in the above issue, but it should make it much easier to reproduce (since we should now receive a specific page for where the run failed rather than having to wait 9 hours!).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Run the Stocksnap DAG locally, with a sensible ingestion limit. This should behave normally. Use `just catalog/pgcli` and `SELECT count(*) from images;` to verify that the ingestion limit records were loaded.
1. Trigger a new Stocksnap run with the `initial_query_params` set to `{"page": 100}`. Use the same commands as above to verify that there are now twice as many records (e.g. new data and not the same page was loaded).
1. Add a `raise ValueError("Whoops")` in the `get_record_data` function of the Stocksnap ingester, and check that the error logs show which page failed.
1. (Optional) Use the query params list (e.g. `[{"page": 5}, {"page": 10}]`) to trigger a new DAG to only run over a few different sets of parameters.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
