### PR TITLE
Modify `add_license_url` DAG for more specific null check

### DIFF
--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -224,8 +224,8 @@ def save_to_s3(
 )
 def add_license_url():
     license_groups = get_license_groups()
-    updated = update_license_url.expand(
-        license_group=license_groups, batch_size="{{ params.batch_size }}"
+    updated = update_license_url.partial(batch_size="{{ params.batch_size }}").expand(
+        license_group=license_groups
     )
     # save_to_s3(invalid_items)
     final_report(updated)

--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -1,13 +1,11 @@
 """
 # Add license URL
 
-Add `license_url` to all rows that have `NULL` in their `meta_data` fields.
-This PR sets the meta_data value to  "{license_url: https://... }", where the
+Add `license_url` to rows without one in their `meta_data` fields.
+This PR merges the `meta_data` value with "{license_url: https://... }", where the
 url is constructed from the `license` and `license_version` columns.
 
-This is a maintenance DAG that should be run once. If all the null values in
-the `meta_data` column are updated, the DAG will only run the first and the
-last step, logging the statistics.
+This is a maintenance DAG that should be run once.
 """
 
 import logging

--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -127,7 +127,7 @@ def update_license_url(
     update_query = dedent(
         f"""
         UPDATE image
-        SET meta_data = ({Json(license_url_dict)}::jsonb || meta_data)
+        SET meta_data = ({Json(license_url_dict)}::jsonb || meta_data), updated_on = now()
         WHERE identifier IN (
             SELECT identifier
             FROM image

--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -156,7 +156,7 @@ def report_completion(updated, dag_task: AbstractOperator = None):
     :param updated: total number of records updated
     :param dag_task: automatically passed by Airflow, used to set the execution timeout.
     """
-    total_updated = sum(updated)
+    total_updated = sum(updated) if updated else 0
     query = "SELECT COUNT(*) from image WHERE meta_data->>'license_url' IS NULL"
     null_counts = run_sql(query, method="get_first", dag_task=dag_task)[0]
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -184,13 +184,11 @@ The following is documentation associated with each DAG (where available):
 
 #### Add license URL
 
-Add `license_url` to all rows that have `NULL` in their `meta_data` fields. This
-PR sets the meta_data value to "{license_url: https://... }", where the url is
-constructed from the `license` and `license_version` columns.
+Add `license_url` to rows without one in their `meta_data` fields. This PR
+merges the `meta_data` value with "{license_url: https://... }", where the url
+is constructed from the `license` and `license_version` columns.
 
-This is a maintenance DAG that should be run once. If all the null values in the
-`meta_data` column are updated, the DAG will only run the first and the last
-step, logging the statistics.
+This is a maintenance DAG that should be run once.
 
 ### `airflow_log_cleanup`
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3885 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR modifies the existing DAG submitted by @obulat to correct all the rows without a `license_url` in their `meta_data` field. Yesterday, I queried upstream DB and the distribution of rows to fix was the following:

```sql
openledger> SELECT license, license_version, count(identifier)
 FROM image WHERE meta_data->>'license_url' IS NULL
 GROUP BY license, license_version;
+----------+-----------------+----------+
| license  | license_version | count    |
|----------+-----------------+----------|
| by       | 2.0             | 18013988 |
| by       | 3.0             | 109      |
| by       | 4.0             | 20280    |
| by-nc    | 2.0             | 12378526 |
| by-nc    | 3.0             | 84       |
| by-nc    | 4.0             | 34596    |
| by-nc-nd | 2.0             | 23425098 |
| by-nc-nd | 3.0             | 292      |
| by-nc-nd | 4.0             | 15547    |
| by-nc-sa | 2.0             | 26487161 |
| by-nc-sa | 3.0             | 9229     |
| by-nc-sa | 4.0             | 9575     |
| by-nd    | 2.0             | 5184389  |
| by-nd    | 3.0             | 112      |
| by-nd    | 4.0             | 175      |
| by-sa    | 2.0             | 9843818  |
| by-sa    | 3.0             | 137      |
| by-sa    | 4.0             | 15819    |
| cc0      | 1.0             | 884224   |
| pdm      | 1.0             | 1452034  |
| pdm      | 4.0             | 43       |
+----------+-----------------+----------+
SELECT 21
Time: 2181.062s (36 minutes 21 seconds), executed in: 2181.030s (36 minutes 21 seconds)
```

This version does not interact with AWS S3; given the low number of license-version combinations, it's not necessary. Instead, if some failed pairs are found, it's notified at the end.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Spin up the catalog stack, `just catalog/up`, and remove the targeted field from some rows. You could try the next update statement on the sample data.

```sql
UPDATE image SET meta_data = '{"foo": "bar"}'::jsonb WHERE identifier IN (
	'd74da171-0347-435c-a32a-74a4526d3950',
	'bc4120e9-1ed3-4499-9a10-69d5bebb03e4',
	'22c54bc1-df4e-4bd7-ab19-9e649aacada1',
	'093344ca-9aa7-4f96-b40a-1fd493c41a15'
);
```

Then, run the dag and observe the original `meta_data` is preserved with the addition of the corresponding `license_url`.

```sql
SELECT identifier, updated_on, license, license_version, meta_data
FROM image WHERE identifier IN (
	'd74da171-0347-435c-a32a-74a4526d3950',
	'bc4120e9-1ed3-4499-9a10-69d5bebb03e4',
	'22c54bc1-df4e-4bd7-ab19-9e649aacada1',
	'093344ca-9aa7-4f96-b40a-1fd493c41a15'
)
```

To observe the failed pairs alert task being run, you can simply modify the `license_version` of one of the rows to a non-existing one with a high number. The individual mapped task for it will be skipped.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
