### PR TITLE
Decode and deduplicate tags in the API

### DIFF
--- a/api/api/examples/audio_responses.py
+++ b/api/api/examples/audio_responses.py
@@ -28,7 +28,6 @@ base_audio = {
         {"accuracy": None, "name": "strings"},
         {"accuracy": None, "name": "energetic"},
         {"accuracy": None, "name": "acoustic"},
-        {"accuracy": None, "name": "vocal"},
         {"accuracy": None, "name": "voice"},
         {"accuracy": None, "name": "funkyhouse"},
     ],

--- a/api/api/serializers/media_serializers.py
+++ b/api/api/serializers/media_serializers.py
@@ -33,6 +33,7 @@ from api.serializers.docs import (
 from api.serializers.fields import SchemableHyperlinkedIdentityField
 from api.utils.help_text import make_comma_separated_help_text
 from api.utils.licenses import get_license_url
+from api.utils.strings import clean_tags
 from api.utils.url import add_protocol
 
 
@@ -749,6 +750,9 @@ class MediaSerializer(BaseModelSerializer):
         url_fields = ["url", "creator_url", "foreign_landing_url"]
         for url_field in url_fields:
             output[url_field] = add_protocol(output[url_field])
+
+        # Decode and deduplicate the tags
+        output["tags"] = clean_tags(output.get("tags", []))
 
         return output
 

--- a/api/api/utils/strings.py
+++ b/api/api/utils/strings.py
@@ -1,0 +1,53 @@
+import re
+from urllib.parse import quote, unquote
+
+
+def convert_grp(grp: str) -> str | None:
+    """
+    Convert a hex value into a character. Return None if the conversion results in
+    a character that cannot be used as a URI component.
+    """
+    try:
+        converted = chr(int(grp, 16))
+        # Decoded strings should be usable as URI components
+        quote(converted)
+        return converted
+    except UnicodeEncodeError:
+        return None
+
+
+def decode_data(data: str | None = "") -> str:
+    if not data:
+        return ""
+
+    regexes = [
+        r"\\(x)([\da-f]{2})",  # \\xe9 - é
+        r"\\(u)([\da-f]{4})",  # \\u00e9 - é
+        r"(u)([\da-f]{4})",  # u00e9 - é
+    ]
+
+    def replace_func(match):
+        """Replace the matched group with the converted character if possible, otherwise return the original string."""
+        prefix, grp = match.groups()
+        if converted := convert_grp(grp):
+            return converted
+        return f"{prefix}{grp}"
+
+    for regex in regexes:
+        data = re.sub(regex, replace_func, data, flags=re.IGNORECASE)
+
+    return unquote(data)
+
+
+def clean_tags(tags: list[dict]) -> list[dict]:
+    """Decode tag names and then remove duplicate tags."""
+    for tag in tags:
+        tag["name"] = decode_data(tag["name"])
+    seen = set()
+    unique_tags = []
+    for i, tag in enumerate(tags):
+        tag_tuple = (tag["name"], tag.get("provider"), tag.get("accuracy"))
+        if tag_tuple not in seen:
+            seen.add(tag_tuple)
+            unique_tags.append(tag)
+    return unique_tags

--- a/api/test/test_examples.py
+++ b/api/test/test_examples.py
@@ -27,7 +27,11 @@ def execute_request(request):
 
 @pytest.mark.parametrize("in_val, out_val", list(audio_mappings.items()))
 def test_audio_success_examples(in_val, out_val):
+    print(f"in_val: {in_val}")
+    print(f"out_val: {out_val}")
     res = execute_request(in_val)
+    print(f"res: {res}")
+    print(f"out_val['application/json']: {out_val['application/json']}")
     assert res == out_val["application/json"]
 
 

--- a/api/test/unit/utils/test_strings.py
+++ b/api/test/unit/utils/test_strings.py
@@ -1,0 +1,87 @@
+import pytest
+
+from api.utils.strings import clean_tags, convert_grp, decode_data
+
+
+p = pytest.param
+
+
+@pytest.mark.parametrize(
+    "grp, output",
+    [
+        p(r"03b1", "α", id="u-escaped without backslash"),
+        p(r"e9", "é", id="x-escaped with double backslashes"),
+        p(r"0000", "\x00", id="min-value"),
+        p(r"ffff", "\uffff", id="max-value"),
+        p(r"dadd", None, id="non-encodable value"),
+    ],
+)
+def test_convert_grp(grp, output):
+    assert convert_grp(grp) == output
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        p("", "", id="empty string"),
+        p(None, "", id="None"),
+        p("muséo", "muséo", id="single non-ASCII character"),
+        p("mus\xe9o", "muséo", id="x-escaped with single backslash"),
+        p("mus\u00e9o", "muséo", id="u-escaped with single backslash"),
+        p("musu00e9o", "muséo", id="u-escaped without backslash"),
+        p("mus\\u00e9o", "muséo", id="u-escaped with double backslash"),
+        p(
+            "mus\\u00E9o",
+            "muséo",
+            id="u-escaped with double backslash and uppercase hex",
+        ),
+        p("u03b9u03c4u03b1u03bbu03afu03b1", "ιταλία", id="1"),
+        p("u0438u0442u0430u043bu0438u044f", "италия", id="5"),
+        p("u0645u062au062du0641", "متحف", id="7"),
+        p("ιταλία", "ιταλία", id="8"),
+        p("太陽", "太陽", id="9"),
+        p("u592Au967D", "太陽", id="10"),
+        p(
+            "ciudaddelasartesylasciencias",
+            "ciudaddelasartesylasciencias",
+            id="does not convert to non-encodeable characters",
+        ),
+    ],
+)
+def test_decode_data(data, expected):
+    assert decode_data(data) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_tags,cleaned",
+    [
+        p(
+            [("musée", "provider", None), ("mus\\u00e9e", "provider", None)],
+            [("musée", "provider", None)],
+            id="correctly-encoded duplicate tag is retained",
+        ),
+        p(
+            [("cat", "provider1", None), ("cat", "provider2", None)],
+            [("cat", "provider1", None), ("cat", "provider2", None)],
+            id="does not deduplicate tags with different providers",
+        ),
+        p(
+            [("cat", "provider", None), ("cat", "clarifai", 0.9)],
+            [("cat", "provider", None), ("cat", "clarifai", 0.9)],
+            id="does not deduplicate tags with different accuracies and providers",
+        ),
+        p(
+            [("ciudaddelasartesylasciencias", "provider", None)],
+            [("ciudaddelasartesylasciencias", "provider", None)],
+            id="does not decode non-encodable characters",
+        ),
+    ],
+)
+def test_clean_tags(raw_tags, cleaned):
+    def tuple_to_tags(x):
+        return [{"name": tag[0], "provider": tag[1], "accuracy": tag[2]} for tag in x]
+
+    tags = tuple_to_tags(raw_tags)
+
+    cleaned_tags = clean_tags(tags)
+    assert cleaned_tags == tuple_to_tags(cleaned)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4125 by @obulat
Fixes #1927 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR copies the string decoding code from the frontend to the API to decode the incorrectly-encoded tag names. It also adds a step to check that the decoded characters can be URI-encoded. This is done so that the tag names can be used as the URL query parameter in the frontend, to fix #4125.

A follow-up to this PR should remove this code from the frontend. It should only be done after the API changes are deployed.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check that the tests run and test the edgecases.

Try adding the invalid tags to sample data using this patch:
```
Subject: [PATCH] Decode and deduplicate tags in the API
---
Index: sample_data/sample_image.csv
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/sample_data/sample_image.csv b/sample_data/sample_image.csv
--- a/sample_data/sample_image.csv	(revision 06904ebc6c4c1747bdaf18b22e781b1ccbadd209)
+++ b/sample_data/sample_image.csv	(date 1713333760883)
@@ -5,7 +5,7 @@
 cdbd3bf6-1745-45bb-b399-61ee149cd58a,2022-12-28 15:41:34.000000+00,2022-12-28 15:41:34.000000+00,provider_api,flickr,flickr,51745389858,https://www.flickr.com/photos/126744325@N07/51745389858,https://live.staticflickr.com/65535/51745389858_c10358e1a3_b.jpg,https://live.staticflickr.com/65535/51745389858_c10358e1a3_m.jpg,1024,683,157497,by,2.0,Kristoffer Trolle,https://www.flickr.com/photos/126744325@N07,Train area in Copenhagen South / Tog område i Syd København,"{""views"": ""1337"", ""pub_date"": ""1639441947"", ""date_taken"": ""2021-07-14 23:49:46"", ""description"": ""This old train area in Copenhagen South will soon be transformed into a residential area. I love to go there and take photos. I used a Tiffen Black Pro Mist 1/4 filter for this photo, it gives that diffused highlights look, read more about it on my blog here . The photo is Creative Commons license: Use it for free. Keywords: train, tog, DSB, område, syd, København, south, Copenhagen, Danmark, Denmark, Fujifilm X-H1, Fujifilm XF 35mm f2 R WR, Tiffen Black Pro-Mist 1/4 filter"", ""license_url"": ""https://creativecommons.org/licenses/by/2.0/"", ""raw_license_url"": null}","[{""name"": ""copenhagen"", ""provider"": ""flickr""}, {""name"": ""danmark"", ""provider"": ""flickr""}, {""name"": ""denmark"", ""provider"": ""flickr""}, {""name"": ""dsb"", ""provider"": ""flickr""}, {""name"": ""fujifilmxf35mmf2rwr"", ""provider"": ""flickr""}, {""name"": ""fujifilmxh1"", ""provider"": ""flickr""}, {""name"": ""københavn"", ""provider"": ""flickr""}, {""name"": ""område"", ""provider"": ""flickr""}, {""name"": ""south"", ""provider"": ""flickr""}, {""name"": ""syd"", ""provider"": ""flickr""}, {""name"": ""tiffenblackpromist14filter"", ""provider"": ""flickr""}, {""name"": ""tog"", ""provider"": ""flickr""}, {""name"": ""train"", ""provider"": ""flickr""}]",f,2021-12-15 20:49:19.976193+00,f,jpg,photograph,
 a3583692-349d-4ab7-8649-dfb6ab25a9a6,2022-05-10 05:38:53.000000+00,2022-05-10 05:38:53.000000+00,provider_api,flickr,flickr,51748188420,https://www.flickr.com/photos/38959360@N07/51748188420,https://live.staticflickr.com/65535/51748188420_cac46bb1f3_b.jpg,https://live.staticflickr.com/65535/51748188420_cac46bb1f3_m.jpg,579,1024,131055,by,2.0,...Amame hasta con los dientes....,https://www.flickr.com/photos/38959360@N07,Say you'll see me again....,"{""views"": ""1188"", ""pub_date"": ""1639527704"", ""date_taken"": ""2021-12-14 19:21:36"", ""description"": ""♡ Click Here for Details., Credits ♡and More Photos ♡ ♡ My Facebook ♡ My Instagram"", ""license_url"": ""https://creativecommons.org/licenses/by/2.0/"", ""raw_license_url"": null}","[{""name"": ""altier"", ""provider"": ""flickr""}, {""name"": ""blog"", ""provider"": ""flickr""}, {""name"": ""blogger"", ""provider"": ""flickr""}, {""name"": ""cute"", ""provider"": ""flickr""}, {""name"": ""dress"", ""provider"": ""flickr""}, {""name"": ""event"", ""provider"": ""flickr""}, {""name"": ""gown"", ""provider"": ""flickr""}, {""name"": ""hollyhood"", ""provider"": ""flickr""}, {""name"": ""kaya"", ""provider"": ""flickr""}, {""name"": ""kimo"", ""provider"": ""flickr""}, {""name"": ""log"", ""provider"": ""flickr""}, {""name"": ""maitreya"", ""provider"": ""flickr""}, {""name"": ""nightdress"", ""provider"": ""flickr""}, {""name"": ""nitedress"", ""provider"": ""flickr""}, {""name"": ""thirsty"", ""provider"": ""flickr""}, {""name"": ""versa"", ""provider"": ""flickr""}]",f,2021-12-15 22:14:02.778385+00,f,jpg,photograph,
-94fa6f0a-1819-4297-9fc5-758bf8e5c71d,2022-06-15 22:50:55.000000+00,2022-06-15 22:50:55.000000+00,provider_api,flickr,flickr,51746016845,https://www.flickr.com/photos/56830712@N03/51746016845,https://live.staticflickr.com/65535/51746016845_7fcae21f7d_b.jpg,https://live.staticflickr.com/65535/51746016845_7fcae21f7d_m.jpg,1024,683,127991,by-nc-nd,2.0,shadobb,https://www.flickr.com/photos/56830712@N03,***,"{""views"": ""1095"", ""pub_date"": ""1639441180"", ""date_taken"": ""2016-07-22 12:53:54"", ""description"": ""Instagram: Street: instagram.com/moscow_and_the_people Portraits&arts: instagram.com/dances_with_arts MyLife&arts: instagram.com/imanishi17"", ""license_url"": ""https://creativecommons.org/licenses/by-nc-nd/2.0/"", ""raw_license_url"": null}","[{""name"": ""beatiful"", ""provider"": ""flickr""}, {""name"": ""gmaster"", ""provider"": ""flickr""}, {""name"": ""model"", ""provider"": ""flickr""}, {""name"": ""portrait"", ""provider"": ""flickr""}, {""name"": ""russia"", ""provider"": ""flickr""}, {""name"": ""russianmodel"", ""provider"": ""flickr""}, {""name"": ""sony"", ""provider"": ""flickr""}]",f,2021-12-15 20:49:19.976193+00,f,jpg,photograph,
+94fa6f0a-1819-4297-9fc5-758bf8e5c71d,2022-06-15 22:50:55.000000+00,2022-06-15 22:50:55.000000+00,provider_api,flickr,flickr,51746016845,https://www.flickr.com/photos/56830712@N03/51746016845,https://live.staticflickr.com/65535/51746016845_7fcae21f7d_b.jpg,https://live.staticflickr.com/65535/51746016845_7fcae21f7d_m.jpg,1024,683,127991,by-nc-nd,2.0,shadobb,https://www.flickr.com/photos/56830712@N03,***,"{""views"": ""1095"", ""pub_date"": ""1639441180"", ""date_taken"": ""2016-07-22 12:53:54"", ""description"": ""Instagram: Street: instagram.com/moscow_and_the_people Portraits&arts: instagram.com/dances_with_arts MyLife&arts: instagram.com/imanishi17"", ""license_url"": ""https://creativecommons.org/licenses/by-nc-nd/2.0/"", ""raw_license_url"": null}","[{""name"": ""ciudaddelassiencias"", ""provider"": ""flickr""}, {""name"": ""muséo"", ""provider"": ""flickr""}, {""name"": ""muséo"", ""provider"": ""recognition"", ""accuracy"": 0.96},  {""name"": ""mus\\xe9o"", ""provider"": ""flickr""}, {""name"": ""mus\\u00e9o"", ""provider"": ""flickr""}, {""name"": ""musu00e9o"", ""provider"": ""flickr""}, {""name"": ""mus\\u00e9o"", ""provider"": ""flickr""}, {""name"": ""mus\\u00E9o"", ""provider"": ""flickr""}]",f,2021-12-15 20:49:19.976193+00,f,jpg,photograph,
 4e8fff2c-5e81-4f1f-8cda-fa29d3dcef6c,2022-09-21 15:36:29.000000+00,2022-09-21 15:36:29.000000+00,provider_api,flickr,flickr,51745392113,https://www.flickr.com/photos/23465276@N04/51745392113,https://live.staticflickr.com/65535/51745392113_4e9af1dd55_b.jpg,https://live.staticflickr.com/65535/51745392113_4e9af1dd55_m.jpg,1024,972,143647,by-nc-nd,2.0,Antonio Marín Segovia,https://www.flickr.com/photos/23465276@N04,Marilyn Monroe: la poeta que se convirtió en sex symbol,"{""views"": ""828"", ""pub_date"": ""1639442005"", ""date_taken"": ""2021-12-14 01:33:21"", ""description"": ""Marilyn Monroe: la poeta que se convirtió en sex symbol ¿Qué hizo de Marilyn Monroe un rostro perdurable tan conocido como La Gioconda, un icono transgeneracional, una leyenda viva? Por qué después de medio siglo, a diferencia de muchos de sus contemporáneos su imagen sigue siendo tan actual? Quizá porque Marilyn Monroe no sólo fue bella, ni sólo fue sexy, ni sólo fue inteligente. Quizá porque fue todo eso y una rubia boba en sus personajes y una mujer con intensa curiosidad crítica que resistió los embates del macartismo y su cacería de brujas, que quiso modificar y modificó su vida y su mundo que fue Hollywood (esa industria que devora y fabrica imágenes como ganado a decir de Hitchcock) y el circuito de la alta política que como en la época de los Kennedy inventa y desecha personajes. De que modificó su vida no cabe duda. Pasar su infancia en cinco o seis hogares de refugio y un orfanato y llegar a las fiestas de los Kennedy no es cosa fácil; y crear sus reglas y legislación propias en un mundo esclerotizado por las formas de la política donde caravanas y genuflexiones son el santo y seña de la sobrevivencia, tampoco es algo que resulte sencillo. Randdy Taraborrelli en La vida secreta de Marilyn Monroe rescata un momento que describe muy bien cómo se manejaba con los personajes de la Casa Blanca. Resumo su relato: En febrero de 1962 invitaron a Marilyn Monroe a una cena en honor del presidente Kennedy. La cena era a las ocho y a las siete treinta un automóvil pasó por ella. Marilyn, por supuesto no estaba lista. Según su mucama aún no sabía qué vestido ponerse y su estilista Kenneth Battelle estaba tratando de peinarla. A las ocho el asistente personal de Kennedy regresó a la fiesta y mandó una limusina por ella que llegó 15 minutos después. Milt Ebbins, el encargado de llevarla, a las 8:45 seguía esperando. Presionado telefónicamente por el asistente de Kennedy, a las nueve Ebbins entró a la habitación y encontró a Marilyn totalmente desnuda aunque con z"", ""license_url"": ""https://creativecommons.org/licenses/by-nc-nd/2.0/"", ""raw_license_url"": null}",,f,2021-12-15 20:49:19.976193+00,f,jpg,photograph,
 28d4a996-1c98-4a7e-893f-fed2aefdc6af,2022-06-03 19:28:02.000000+00,2022-06-03 19:28:02.000000+00,provider_api,flickr,flickr,51745124976,https://www.flickr.com/photos/109715245@N06/51745124976,https://live.staticflickr.com/65535/51745124976_0456ba00ee_b.jpg,https://live.staticflickr.com/65535/51745124976_0456ba00ee_m.jpg,768,1024,150344,by-nd,2.0,paaddor,https://www.flickr.com/photos/109715245@N06,A Narrow Alley Downtown Zurich,"{""views"": ""813"", ""pub_date"": ""1639440834"", ""date_taken"": ""2020-09-02 12:57:01"", ""description"": ""Where I come from is Zurich, the biggest city in Switzerland. The city was founded in its present form at the end of the Middle Ages, between 1000 and 1200, and gained imperial freedom in the 13th century. Many narrow alleys, like this one, bear witness to the medieval architecture."", ""license_url"": ""https://creativecommons.org/licenses/by-nd/2.0/"", ""raw_license_url"": null}","[{""name"": ""alley"", ""provider"": ""flickr""}, {""name"": ""architecture"", ""provider"": ""flickr""}, {""name"": ""blur"", ""provider"": ""flickr""}, {""name"": ""blurred"", ""provider"": ""flickr""}, {""name"": ""city"", ""provider"": ""flickr""}, {""name"": ""flickr"", ""provider"": ""flickr""}, {""name"": ""houses"", ""provider"": ""flickr""}, {""name"": ""icm"", ""provider"": ""flickr""}, {""name"": ""people"", ""provider"": ""flickr""}, {""name"": ""reflection"", ""provider"": ""flickr""}, {""name"": ""switzerland"", ""provider"": ""flickr""}]",f,2021-12-15 20:49:19.976193+00,f,jpg,photograph,
```
and duplicate tags to the sample data and re-run `just init` to load the items to ES.
Then, go to http://localhost:50280/v1/images/94fa6f0a-1819-4297-9fc5-758bf8e5c71d/ and check that there are only 3 tags. 
- `ciudaddelassiencias` is left as is, even though it contains the regex that we use to decode incorrectly encoded strings without a backslash (`udadd`), because when converted, this symbol is not URI-encodable
- only two `muséo` tags are left: they have different `accuracy`
Run `just up` and check that the item you updated does not show duplicate or incorrectly-encoded tags.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
