### PR TITLE
Decode and deduplicate tags during data refresh

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -21,7 +21,7 @@ from psycopg2.extras import DictCursor, Json
 
 from ingestion_server.db_helpers import database_connect
 from ingestion_server.indexer import DB_BUFFER_SIZE
-from ingestion_server.strings import decode_data, deduplicate_tags
+from ingestion_server.strings import decode_data
 
 
 # Number of records to buffer in memory at once
@@ -161,7 +161,7 @@ class CleanupFunctions:
                 tag["name"] = decoded_tag_name
             tag_output.append(tag)
 
-        deduplicated_tags = deduplicate_tags(tag_output)
+        deduplicated_tags = CleanupFunctions.deduplicate_tags(tag_output)
         if len(deduplicated_tags) != len(tag_output):
             update_required = True
             tag_output = deduplicated_tags

--- a/ingestion_server/ingestion_server/strings.py
+++ b/ingestion_server/ingestion_server/strings.py
@@ -1,0 +1,47 @@
+import logging
+import re
+from urllib.parse import quote, unquote
+
+
+DOUBLE_BACKSLASH_ESCAPE = re.compile(
+    r"\\(x)([\da-f]{2})|\\(u)([\da-f]{4})", re.IGNORECASE
+)
+NO_BACKSLASH_ESCAPE = re.compile(r"(u)([\da-f]{4})", re.IGNORECASE)
+
+
+def convert_grp(grp: str) -> str | None:
+    """
+    Convert a hex value into a character. Return None if the conversion results in
+    a character that cannot be used as a URI component.
+    """
+    try:
+        converted = chr(int(grp, 16))
+        # Decoded strings should be usable as URI components
+        quote(converted)
+        return converted
+    except UnicodeEncodeError:
+        return None
+
+
+def decode_data(data: str | None = "") -> str:
+    if not data:
+        return ""
+
+    def replace_func(match):
+        """Replace the matched group with the converted character if possible, otherwise return the original string."""
+        prefix, grp = match.groups()
+        if converted := convert_grp(grp):
+            return converted
+        return f"{prefix}{grp}"
+
+    # Handle characters encoded with double backslashes
+    if DOUBLE_BACKSLASH_ESCAPE.search(data):
+        try:
+            decoded_data = data.encode().decode("unicode_escape")
+            data = decoded_data
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            logging.debug(f"Failed to decode data with double backslash: {data}")
+    # Handle characters encoded without backslashes
+    data = re.sub(NO_BACKSLASH_ESCAPE, replace_func, data)
+
+    return unquote(data)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4125 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is an alternative to #4142 that decodes and deduplicates tags in the cleanup process during ingestion instead of the API serializer. I opened it as a reply to @sarayourfriend's comment in #4142.

This might make the cleanup process longer than usual, so I would prefer to add these changes once we have the process of saving the updated data to a TSV(#3912) and updating the upstream catalog with it (#3415), from Data normalization project.

It is important to fix the encoding quickly because it can cause a gray Nuxt error screen for pages that contain tags with character sequences that cannot be URI-encoded (such as `udadd` from "ciudaddelassiencias").

## Update
I realized that we do need to update the incorrect decoding of combinations such as `udada` in the frontend in any case to fix all strings, not only the tags. That's why I opened #4144.

So, the question is now this: should we add tag decoding/deduplicating to the cleanup process during data refresh now, or only after the data normalization process is merged, @WordPress/openverse-catalog ? I'm afraid that this update could make the data refresh process too long, and think that it might be better to finish the data normalization project, and only add this cleanup after the other cleanup processes are removed.


## Outdated alternatives, for the record
_There are three alternatives to fix this:_
_1. Add a fix to the frontend fixes. We already do some decoding in the frontend, so we can add one step. Then, after the data normalization project pieces are in place, we can add the decoding/deduplicating of tags to the tag cleanup (this PR). After updating the upstream catalog data, we can remove the decoding/deduplicating from both the frontend and the ingestion._
_2. Add the decoding and deduplicating of tags to the API serializer. Then, remove the frontend decoding/deduplicating. After the data normalization process is ready, add the decoding/deduplicating of tags to the tag cleanup (this PR). After updating the upstream catalog data, we can remove the decoding/deduplicating from both the API and the ingestion._
_3. Only add the cleanup to the ingestion server. If the data cleanup process does not become too much longer, use it until the data normalization pieces are ready, and remove the cleanup steps from the frontend.~~_

_I would prefer the alternative number 3, but I'm a bit hesitant because I don't know how much longer data refresh will become.
After writing these steps, I think I'd prefer alternative number 1 because it has fewer changes (we already do the cleanup in the frontend).
What do you think?__

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
