### PR TITLE
Fix string decoding in the frontend

### DIFF
--- a/frontend/test/unit/specs/utils/decode-data.spec.js
+++ b/frontend/test/unit/specs/utils/decode-data.spec.js
@@ -42,4 +42,10 @@ describe("decodeData", () => {
 
     expect(decodeData(data)).toBe(data)
   })
+
+  it("shouldn't return non-uri-encodable characters", () => {
+    const data = "ciudaddelasartesylasciencias"
+
+    expect(decodeData(data)).toBe(data)
+  })
 })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4125 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the `decode-data` function to not convert the character combinations that are not URI-encodable.

Some tags contain incorrectly encoded tag names without the backslash for u-encoded characters. We compensate for that in the frontend by converting them correctly to unicode characters. However, there's an edge case where the combinations of characters such as `udada` are considered as incorrectly-encoded sequence of characters, but the result is a symbol that is not valid in a URL, so when we try to create a tag URL from it in a single result page, the page shows an error.

We will move the tag cleanup from the frontend to the data cleanup process in the future, but for now, to fix the Nuxt server error page[^1], we need to add a hot-fix in the frontend.

[^1]: `udada` in "ciudada" in tags for item https://api.openverse.engineering/v1/images/076a0436-1d9e-449a-a224-01301f4d8c8e/ causes a Nuxt server error: https://openverse.org/image/076a0436-1d9e-449a-a224-01301f4d8c8e

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app using `just frontend/run dev:only` 
Open http://localhost:8443/image/076a0436-1d9e-449a-a224-01301f4d8c8e
You should see the page loaded correctly.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
