### PR TITLE
Always remove containers when using `just run`

### DIFF
--- a/catalog/justfile
+++ b/catalog/justfile
@@ -84,7 +84,6 @@ shell:
 # Launch an IPython shell in a new container under `SERVICE`
 ipython *args: up-deps
     env DC_USER="airflow" just ../run \
-        --rm \
         --workdir /opt/airflow/catalog/dags \
         {{ SERVICE }} \
         bash -c \'ipython {{ args }}\'
@@ -100,7 +99,6 @@ pgcli db_user_pass="deploy" db_name="openledger": up
 # Run a command in a test container under `SERVICE`
 _mount-test command: up-deps
     env DC_USER="airflow" just ../run \
-        --rm \
         -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 \
         -w /opt/airflow/catalog \
         --volume \'{{ justfile_directory() }}/../docker\':/opt/airflow/docker/ \

--- a/justfile
+++ b/justfile
@@ -230,7 +230,7 @@ exec +args:
 
 # Execute statement in a new service container using Docker Compose
 run +args:
-    just dc run -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "{{ args }}"
+    just dc run --rm -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "{{ args }}"
 
 # Execute pgcli against one of the database instances
 _pgcli container db_user_pass db_name db_host db_port="5432":


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

I kept finding containers that had been left exited but not removed from my system. Recent investigation led me to find that it was the catalog's `generate-docs` recipe, which hadn't added the `--rm`. There isn't a case where we really care to _keep_ the containers after running something with `just run`, so I've removed the instances where we were explicitly calling `--rm` and moved it to the top level `just run` recipe. Now containers will be removed by default and we don't have to declare it for every new recipe which uses `just run`!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `just catalog/generate-docs` and then `docker ps -a` and observe that the container which got started to run the documentation generation no longer exists.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
