### PR TITLE
Don't show sources if their count has not changed

### DIFF
--- a/catalog/dags/data_refresh/reporting.py
+++ b/catalog/dags/data_refresh/reporting.py
@@ -29,7 +29,7 @@ def report_record_difference(before: dict, after: dict, media_type: str, dag_id:
     breakdown_diff = {k: after.get(k, 0) - before.get(k, 0) for k in all_keys}
     if breakdown_diff:
         breakdown_message = "\n".join(
-            f"`{k}`:{v:+,}" for k, v in breakdown_diff.items()
+            f"`{k}`:{v:+,}" for k, v in breakdown_diff.items() if v != 0
         )
     else:
         breakdown_message = "Both indices missing? No breakdown to show"

--- a/catalog/dags/data_refresh/reporting.py
+++ b/catalog/dags/data_refresh/reporting.py
@@ -31,6 +31,8 @@ def report_record_difference(before: dict, after: dict, media_type: str, dag_id:
         breakdown_message = "\n".join(
             f"`{k}`:{v:+,}" for k, v in breakdown_diff.items() if v != 0
         )
+        if any(v == 0 for v in breakdown_diff.values()):
+            breakdown_message += "\n_Sources not listed had no change in count_"
     else:
         breakdown_message = "Both indices missing? No breakdown to show"
 
@@ -40,8 +42,8 @@ _Note: All values are retrieved from elasticsearch_
 *Record count difference for `{media_type}`*: {total_before:,} → {total_after:,}
 *Change*: {count_diff:+,} ({percent_diff:+}% Δ)
 *Breakdown of changes*:
+{breakdown_message}
 """
-    message += breakdown_message
     slack.send_message(
         text=message, dag_id=dag_id, username="Data refresh record difference"
     )

--- a/catalog/tests/dags/data_refresh/test_reporting.py
+++ b/catalog/tests/dags/data_refresh/test_reporting.py
@@ -19,6 +19,7 @@ from data_refresh.reporting import report_record_difference, report_status
         [
             {"src1": 4, "src2": 21},
             {"src1": 4},
+            # Unchanged source count shouldn't show up
             ["25 → 4", "-21 (-84.0%", "`src2`:-21"],
         ],
         [
@@ -36,6 +37,7 @@ from data_refresh.reporting import report_record_difference, report_status
             {},
             ["20 → 0", "-20 (-100.0%", "`src1`:-10", "`src2`:-10"],
         ],
+        [{"src1": 4}, {"src1": 4}, ["Sources not listed had no change in count"]],
         [{}, {}, ["Both indices missing? No breakdown to show"]],
     ],
 )

--- a/catalog/tests/dags/data_refresh/test_reporting.py
+++ b/catalog/tests/dags/data_refresh/test_reporting.py
@@ -19,7 +19,7 @@ from data_refresh.reporting import report_record_difference, report_status
         [
             {"src1": 4, "src2": 21},
             {"src1": 4},
-            ["25 → 4", "-21 (-84.0%", "`src1`:+0", "`src2`:-21"],
+            ["25 → 4", "-21 (-84.0%", "`src2`:-21"],
         ],
         [
             {"src1": 4000, "src2": 20},


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Follow-up to #4067

Here's the report from the most recent audio data refresh:

![image](https://github.com/WordPress/openverse/assets/10214785/5c2062b8-7438-4bce-bd1f-a45907a9f402)

The current logic is set to show all sources, regardless of whether there was a change or not. This PR changes the logic so only sources that have increased or decreased in size are shown in the final report. While this doesn't have a huge effect on audio data refreshes, it will for image data refreshes since we have significantly more sources there.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Updated tests should pass. Alternatively, run the data refresh locally after `just api/init` and see that no sources are listed in the completion message because none of the counts changed. 


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
