### PR TITLE
Convert OperationalError into unhealthy health check response

### DIFF
--- a/api/api/views/health_views.py
+++ b/api/api/views/health_views.py
@@ -36,9 +36,7 @@ class HealthCheck(APIView):
         try:
             connection.ensure_connection()
         except OperationalError as err:
-            raise HealthCheckException(
-                code="postgres", detail=f"Database unavailable: {err}"
-            )
+            raise HealthCheckException(f"postgres: {err}")
 
     @staticmethod
     def _check_es() -> None:
@@ -50,12 +48,10 @@ class HealthCheck(APIView):
         es_health = settings.ES.cluster.health(timeout="5s")
 
         if es_health["timed_out"]:
-            raise HealthCheckException(code="elasticsearch", detail="es_timed_out")
+            raise HealthCheckException("elasticsearch: es_timed_out")
 
         if (es_status := es_health["status"]) != "green":
-            raise HealthCheckException(
-                code="elasticsearch", detail=f"es_status_{es_status}"
-            )
+            raise HealthCheckException(f"elasticsearch: es_status_{es_status}")
 
     def get(self, request: Request):
         if "check_es" in request.query_params:

--- a/api/api/views/health_views.py
+++ b/api/api/views/health_views.py
@@ -1,12 +1,11 @@
 from django.conf import settings
 from django.db import connection
+from django.db.utils import OperationalError
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from psycopg import OperationalError
 
 from api.utils.throttle import ExemptOAuth2IdRateThrottle, HealthcheckAnonRateThrottle
 
@@ -41,7 +40,7 @@ class HealthCheck(APIView):
         try:
             connection.ensure_connection()
         except OperationalError as err:
-            raise DatabaseHealthCheckException(str(err))
+            raise DatabaseHealthCheckException(f"Database unavailable: {err}")
 
     @staticmethod
     def _check_es() -> None:

--- a/api/test/unit/views/test_health_views.py
+++ b/api/test/unit/views/test_health_views.py
@@ -40,6 +40,7 @@ def test_health_check_calls__check_db_with_failure(api_client):
         mock_ensure_connection.side_effect = OperationalError("Database has gone away")
         res = api_client.get("/healthcheck/")
         assert res.status_code == 503
+        assert res.json() == {"detail": "Database unavailable: Database has gone away"}
         mock_ensure_connection.assert_called_once()
 
 
@@ -49,7 +50,7 @@ def test_health_check_es_timed_out(api_client):
         res = api_client.get("/healthcheck/", data={"check_es": True})
 
     assert res.status_code == 503
-    assert res.json()["detail"] == "es_timed_out"
+    assert res.json() == {"detail": "es_timed_out"}
 
 
 @pytest.mark.parametrize("status", ("yellow", "red"))
@@ -59,7 +60,7 @@ def test_health_check_es_status_bad(status, api_client):
         res = api_client.get("/healthcheck/", data={"check_es": True})
 
     assert res.status_code == 503
-    assert res.json()["detail"] == f"es_status_{status}"
+    assert res.json() == {"detail": f"es_status_{status}"}
 
 
 @pytest.mark.django_db

--- a/api/test/unit/views/test_health_views.py
+++ b/api/test/unit/views/test_health_views.py
@@ -1,8 +1,9 @@
 from unittest import mock
 
+from django.db.utils import OperationalError
+
 import pook
 import pytest
-from psycopg import OperationalError
 
 
 def mock_health_response(status="green", timed_out=False):

--- a/api/test/unit/views/test_health_views.py
+++ b/api/test/unit/views/test_health_views.py
@@ -40,7 +40,7 @@ def test_health_check_calls__check_db_with_failure(api_client):
         mock_ensure_connection.side_effect = OperationalError("Database has gone away")
         res = api_client.get("/healthcheck/")
         assert res.status_code == 503
-        assert res.json() == {"detail": "Database unavailable: Database has gone away"}
+        assert res.json() == {"detail": "postgres: Database has gone away"}
         mock_ensure_connection.assert_called_once()
 
 
@@ -50,7 +50,7 @@ def test_health_check_es_timed_out(api_client):
         res = api_client.get("/healthcheck/", data={"check_es": True})
 
     assert res.status_code == 503
-    assert res.json() == {"detail": "es_timed_out"}
+    assert res.json() == {"detail": "elasticsearch: es_timed_out"}
 
 
 @pytest.mark.parametrize("status", ("yellow", "red"))
@@ -60,7 +60,7 @@ def test_health_check_es_status_bad(status, api_client):
         res = api_client.get("/healthcheck/", data={"check_es": True})
 
     assert res.status_code == 503
-    assert res.json() == {"detail": f"es_status_{status}"}
+    assert res.json() == {"detail": f"elasticsearch: es_status_{status}"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3746

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR captures `OperationalError`s that are emitted when the database is no longer available and the `connections.ensure_connection()` function is called as part of the health check for the API. Rather than raise an uncaught exception, this instead converts the exception into an HTTP 503 response (similar to if the Elasticsearch cluster is not in a healthy state).


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass, but additionally, you can observe this operationally:

1. Run `just a` to start the API stack
1. Run `docker stop openverse-db-1`
1. Visit http://localhost:50280/healthcheck/ and observe that a 503 instead of a generic 500 is returned


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
