### PR TITLE
Warn on `license_url` computation in the API

### DIFF
--- a/api/api/models/media.py
+++ b/api/api/models/media.py
@@ -127,8 +127,9 @@ class AbstractMedia(
             return url
 
         logger.warning(
-            f"The {self.__class__.__name__.lower()} with identifier={self.identifier} "
-            f"has no `license_url` in `meta_data`."
+            "Media item missing `license_url` in `meta_data`",
+            media_class=self.__class__.__name__,
+            identifier=self.identifier,
         )
         try:
             return License(self.license.lower(), self.license_version).url

--- a/api/api/models/media.py
+++ b/api/api/models/media.py
@@ -125,6 +125,11 @@ class AbstractMedia(
 
         if self.meta_data and (url := self.meta_data.get("license_url")):
             return url
+
+        logger.warning(
+            f"The {self.__class__.__name__.lower()} with identifier={self.identifier} "
+            f"has no `license_url` in `meta_data`."
+        )
         try:
             return License(self.license.lower(), self.license_version).url
         except ValueError:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #703 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In the interest of closing this PR, I changed the approach only to warn when the license is computed, as suggested by @obulat. The #703 issue will addressed when we confirm #4318 is not an issue anymore.

---

### Old description
My understanding is that the computation from `openverse_attribution.license.License` can be removed but we still need the property.

This PR should not be merged until the updated `add_license_url` run is completed and it's confirmed the `image` table in the Catalog does not have more `NULL` values for this field. 

If you are wondering about `audio` I confirmed all items have this field set to something else than `NULL`.

```sql
openledger> SELECT COUNT(identifier) FROM audio WHERE meta_data->>'license_url' IS NULL;
+-------+
| count |
|-------|
| 0     |
+-------+
SELECT 1
Time: 17.712s (17 seconds), executed in: 17.695s (17 seconds)
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the API and remove the license_url of an image. Then, visit its media page and check the logs.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
