### PR TITLE
Fix advanced provider options for dags that override ingest records

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/auckland_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/auckland_museum.py
@@ -70,7 +70,7 @@ class AucklandMuseumDataIngester(ProviderDataIngester):
             }
         }
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         # Return default query params on the first request
         # primaryRepresentation contain a image url for each data
         # "+" is a query string syntax for must be present

--- a/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -21,7 +21,7 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         self.api_key = Variable.get("API_KEY_BROOKLYN_MUSEUM")
         self.headers = {"api_key": self.api_key}
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return {
                 "has_images": 1,

--- a/catalog/dags/providers/provider_api_scripts/cc_mixter.py
+++ b/catalog/dags/providers/provider_api_scripts/cc_mixter.py
@@ -112,7 +112,7 @@ class CcMixterDataIngester(ProviderDataIngester):
             delay=self.delay, headers=self.headers
         )
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             # This means this is the first request, so we start with offset 0.
             return {

--- a/catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -16,7 +16,7 @@ class ClevelandDataIngester(ProviderDataIngester):
     batch_limit = 1000
     delay = 5
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params: dict | None):
         if not prev_query_params:
             # Return default query params on the first request
             return {"cc": "1", "has_image": "1", "limit": self.batch_limit, "skip": 0}

--- a/catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/catalog/dags/providers/provider_api_scripts/europeana.py
@@ -231,7 +231,7 @@ class EuropeanaDataIngester(ProviderDataIngester):
 
         return f"timestamp_update:[{start_timestamp} TO {end_timestamp}]"
 
-    def get_next_query_params(self, prev_query_params) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return self.base_request_body
 

--- a/catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -54,10 +54,23 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
     min_divisions = 12
     max_divisions = 20
 
-    def ingest_records(self, **kwargs):
+    def get_fixed_query_params(self):
+        timestamp_pairs = super().get_fixed_query_params()
+        fixed_query_params = []
+
         for building in self.buildings:
-            logger.info(f"Obtaining images of building {building}")
-            super().ingest_records(building=building)
+            fixed_query_params += [
+                {
+                    "filter[]": [
+                        f'format:"{self.format_type}"',
+                        f'building:"{building}"',
+                        f'last_indexed:"[{ts["start_ts"]} TO {ts["end_ts"]}]"',
+                    ]
+                }
+                for ts in timestamp_pairs
+            ]
+
+        return fixed_query_params
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         if not prev_query_params:

--- a/catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -77,12 +77,14 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
 
     def _replace_single_quotes_in_params(self, params: dict | None):
         """Ensure that the values in the "filter[]" param do not contain single quotes."""
-        if params is None:
+        if not params:
             return None
 
         return {
             **params,
-            "filter[]": [param.replace("'", '"') for param in params.get("filter[]")],
+            "filter[]": [
+                param.replace("'", '"') for param in params.get("filter[]", [])
+            ],
         }
 
     def get_fixed_query_params(self):

--- a/catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -57,7 +57,39 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
     min_divisions = 12
     max_divisions = 20
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # The Finnish Museums API expected double quotes in the params (for
+        # example, 'format:"0/Image"'). Since query params supplied through the
+        # DagRun conf advanced options must be supplied as valid json with outer
+        # double quotes, these inner quotes must be escaped in the form
+        # (i.e., "format:\"0/Image\""). For convenience and to prevent the DAG
+        # from breaking if the user inputs single quotes, they are replaced here.
+        self.initial_query_params = self._replace_single_quotes_in_params(
+            self.initial_query_params
+        )
+
+        if self.override_query_params_list:
+            self.override_query_params = (
+                self._replace_single_quotes_in_params(qp)
+                for qp in self.override_query_params_list
+            )
+
+    def _replace_single_quotes_in_params(self, params: dict | None):
+        """Ensure that the values in the "filter[]" param do not contain single quotes."""
+        if params is None:
+            return None
+
+        return {
+            **params,
+            "filter[]": [param.replace("'", '"') for param in params.get("filter[]")],
+        }
+
     def get_fixed_query_params(self):
+        """
+        Get the set of fixed params. Ingestion will be run separately for each of
+        these.
+        """
         fixed_query_params = []
 
         # Build out timestamp pairs for each building.
@@ -73,11 +105,13 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
         # records for this ingestion date for any of the buildings), then skip
         if not fixed_query_params:
             raise AirflowSkipException("No data to ingest.")
+
         return fixed_query_params
 
     def get_timestamp_query_params(
         self, start: datetime, end: datetime, **kwargs
     ) -> dict:
+        """Format the timestamp params appropriately."""
         building = kwargs.get("building")
         return {
             "filter[]": [
@@ -88,6 +122,10 @@ class FinnishMuseumsDataIngester(TimeDelineatedProviderDataIngester):
         }
 
     def get_next_query_params(self, prev_query_params: dict | None):
+        """
+        Get the next query params, based on the previous ones. Fixed query params
+        will be merged in by the base class as appropriate.
+        """
         if not prev_query_params:
             return {
                 "field[]": [

--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -53,7 +53,7 @@ class FreesoundDataIngester(ProviderDataIngester):
 
         super().__init__(*args, **kwargs)
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             start_date = "*"
             # Allow self.date to be undefined, necessary for the first full, successful

--- a/catalog/dags/providers/provider_api_scripts/inaturalist.py
+++ b/catalog/dags/providers/provider_api_scripts/inaturalist.py
@@ -55,7 +55,7 @@ COL_URL = "https://download.checklistbank.org/col/latest_coldp.zip"
 class INaturalistDataIngester(ProviderDataIngester):
     providers = {"image": provider_details.INATURALIST_DEFAULT_PROVIDER}
 
-    def get_next_query_params(self, prev_query_params=None, **kwargs):
+    def get_next_query_params(self, prev_query_params=None):
         raise NotImplementedError(
             "Instead we use get_batches to dynamically create subtasks."
         )

--- a/catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -45,7 +45,7 @@ class JamendoDataIngester(ProviderDataIngester):
     batch_limit = 200
     headers = {"Accept": "application/json"}
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params):
         if not prev_query_params:
             # On first request, build default params.
             return {

--- a/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
+++ b/catalog/dags/providers/provider_api_scripts/justtakeitfree.py
@@ -30,7 +30,7 @@ class JusttakeitfreeDataIngester(ProviderDataIngester):
     creator = "Justtakeitfree Free Photos"
     creator_url = "https://justtakeitfree.com"
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return {"page": 1, "key": Variable.get("API_KEY_JUSTTAKEITFREE")}
         else:

--- a/catalog/dags/providers/provider_api_scripts/museum_victoria.py
+++ b/catalog/dags/providers/provider_api_scripts/museum_victoria.py
@@ -48,12 +48,11 @@ class VictoriaDataIngester(ProviderDataIngester):
     def get_fixed_query_params(self):
         return [{"imagelicense": license_} for license_ in self.LICENSE_LIST]
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return {
                 "hasimages": "yes",
                 "perpage": self.batch_limit,
-                "imagelicense": kwargs["license_"],
                 "page": 0,
             }
         else:

--- a/catalog/dags/providers/provider_api_scripts/museum_victoria.py
+++ b/catalog/dags/providers/provider_api_scripts/museum_victoria.py
@@ -42,12 +42,11 @@ class VictoriaDataIngester(ProviderDataIngester):
         # This set is used to prevent duplicate images of the same items
         self.RECORDS_IDS = set()
 
-    def ingest_records(self, **kwargs):
-        for license_ in self.LICENSE_LIST:
-            super().ingest_records(license_=license_)
-
     def get_batch_data(self, response_json):
         return response_json or None
+
+    def get_fixed_query_params(self):
+        return [{"imagelicense": license_} for license_ in self.LICENSE_LIST]
 
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         if not prev_query_params:

--- a/catalog/dags/providers/provider_api_scripts/nappy.py
+++ b/catalog/dags/providers/provider_api_scripts/nappy.py
@@ -32,7 +32,7 @@ class NappyDataIngester(ProviderDataIngester):
         "https://creativecommons.org/publicdomain/zero/1.0/"
     )
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return {
                 "page": 1,

--- a/catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/catalog/dags/providers/provider_api_scripts/nypl.py
@@ -58,7 +58,7 @@ class NyplDataIngester(ProviderDataIngester):
         NyplDataIngester.headers = {"Authorization": f"Token token={NYPL_API}"}
         super().__init__(*args, **kwargs)
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params):
         if not prev_query_params:
             return {
                 "q": "CC_0",

--- a/catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -79,7 +79,7 @@ class PhylopicDataIngester(ProviderDataIngester):
             f"Total pages: {self.total_pages}."
         )
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if prev_query_params is not None:
             self.current_page += 1
 

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -441,7 +441,7 @@ class ProviderDataIngester(ABC):
         return []
 
     @abstractmethod
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         """
         Get the next set of query parameters.
 
@@ -452,7 +452,6 @@ class ProviderDataIngester(ABC):
         Required arguments:
         prev_query_params: dictionary of query string params used in the previous
                            request. If None, this is the first request.
-        **kwargs:          Optional kwargs passed through from `ingest_records`.
 
         """
         pass

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -402,7 +402,7 @@ class ProviderDataIngester(ABC):
         return None
 
     def _get_query_params(
-        self, prev_query_params: dict | None, fixed_query_params: dict | None
+        self, prev_query_params: dict | None, fixed_query_params: dict | None = None
     ) -> dict | None:
         """
         Return the next set of query_params for the next request.

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -173,9 +173,10 @@ class ProviderDataIngester(ABC):
         # An optional list of `query_params`. When provided, ingestion will be run for
         # just these sets of params.
         self.override_query_params = None
-        if query_params_list := conf.get("query_params_list"):
+        self.override_query_params_list = conf.get("query_params_list")
+        if self.override_query_params_list:
             # Create a generator to facilitate fetching the next set of query_params.
-            self.override_query_params = (qp for qp in query_params_list)
+            self.override_query_params = (qp for qp in self.override_query_params_list)
 
         # An optional set of query params to add to all queries
         self.additional_query_params = conf.get("additional_query_params", {})

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -337,8 +337,7 @@ class ProviderDataIngester(ABC):
                 )
 
                 logger.info(
-                    "First fixed query parameter matching the initial_query_params"
-                    f" was: {initial_fixed_params}."
+                    f"==Starting ingestion with fixed params: {initial_fixed_params}=="
                 )
 
                 # Run ingestion on the first batch, passing in the initial_query_params
@@ -348,9 +347,6 @@ class ProviderDataIngester(ABC):
                 fixed_query_params = fixed_query_params[
                     fixed_query_params.index(initial_fixed_params) + 1 :
                 ]
-                logger.info(
-                    f"Only the following fixed query parameters will be used: {fixed_query_params}"
-                )
 
             for fixed_params in fixed_query_params:
                 logger.info(f"==Starting ingestion with fixed params: {fixed_params}==")

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -323,7 +323,7 @@ class ProviderDataIngester(ABC):
                 f" fixed query parameters: {fixed_query_params}"
             )
 
-            # If initial_query_params were also provided, we should being ingestion
+            # If initial_query_params were also provided, we should begin ingestion
             # from the first set of fixed_query_params that is included in the
             # initial_query_params
             if self.initial_query_params:

--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -177,7 +177,7 @@ class ProviderDataIngester(ABC):
             # Create a generator to facilitate fetching the next set of query_params.
             self.override_query_params = (qp for qp in query_params_list)
 
-        # An optional set of query params to add to each query
+        # An optional set of query params to add to all queries
         self.additional_query_params = conf.get("additional_query_params", {})
 
         # A configuration option that is used to skip over ALL errors and continue
@@ -207,17 +207,31 @@ class ProviderDataIngester(ABC):
 
         return media_stores
 
-    def ingest_records(self, **kwargs) -> None:
+    def _ingest_records(
+        self, initial_query_params: dict | None, fixed_query_params: dict | None
+    ) -> None:
         """
-        Ingest all records.
+        Perform ingestion.
 
-        This is the main ingestion function that is called during the `pull_data` task.
+        Required Arguments:
 
         Optional Arguments:
-        **kwargs: Optional arguments to be passed to `get_next_query_params`.
+        initial_query_params:    Optional override for the query params to be used in the
+                                 first batch.
+        fixed_query_params:      Optional, fixed query params which should be passed to
+                                 `get_next_query_params`. These should not change during this
+                                 round of ingestion.
         """
         should_continue = True
-        query_params = None
+        # Use initial_query_params if provided, or get the next set of params.
+        query_params = initial_query_params or self._get_query_params(
+            None, fixed_query_params
+        )
+        if initial_query_params:
+            logger.info(
+                "Using initial_query_params from dag_run conf:"
+                f" {json.dumps(self.initial_query_params)}"
+            )
 
         # If an ingestion limit has been set and we have already ingested records
         # in excess of the limit, exit early. This may happen if `ingest_records`
@@ -228,7 +242,6 @@ class ProviderDataIngester(ABC):
         logger.info(f"Begin ingestion for {self.__class__.__name__}")
 
         while should_continue:
-            query_params = self._get_query_params(query_params, **kwargs)
             if query_params is None:
                 # Break out of ingestion if no query_params are supplied. This can
                 # happen when the final `override_query_params` is processed.
@@ -268,6 +281,11 @@ class ProviderDataIngester(ABC):
                     # Add this to the errors list but continue processing
                     self.ingestion_errors.append(ingestion_error)
                     logger.error(f"Skipping batch due to ingestion error: {error}")
+
+                    # Continue from the next batch
+                    query_params = self._get_query_params(
+                        query_params, fixed_query_params
+                    )
                     continue
 
                 # Commit whatever records we were able to process, and rethrow the
@@ -279,12 +297,66 @@ class ProviderDataIngester(ABC):
                 logger.info(f"Ingestion limit of {self.limit} has been reached.")
                 should_continue = False
 
+            # Get next query params
+            query_params = self._get_query_params(query_params, fixed_query_params)
+
         # Commit whatever records we were able to process
         self._commit_records()
 
         # If errors were caught during processing, raise them now
         if error_summary := self._get_ingestion_errors():
             raise error_summary
+
+    def ingest_records(self) -> None:
+        """
+        Ingest all records.
+
+        If fixed_query_params are provided, ingestion will be performed separately
+        for each set of fixed_query_params.
+
+        This is the main ingestion function that is called during the `pull_data` task.
+        """
+        # If no fixed params were provided, simply begin ingestion
+        if not (fixed_query_params := self.get_fixed_query_params()):
+            return self._ingest_records(self.initial_query_params, {})
+
+        # Else, ingestion should be run separately for each set of fixed_query_params.
+
+        # If initial_query_params were also provided, we should being ingestion
+        # from the first set of fixed_query_params that is included in the
+        # initial_query_params
+        if self.initial_query_params:
+            initial_fixed_params = next(
+                (
+                    qp
+                    for qp in fixed_query_params
+                    if qp.items() <= self.initial_query_params.items()
+                ),
+                fixed_query_params[0],
+            )
+
+            logger.info(
+                "First fixed query parameter matching the initial_query_params"
+                f" was: {initial_fixed_params}."
+            )
+
+            # Run ingestion on the first batch, passing in the initial_query_params
+            self._ingest_records(self.initial_query_params, initial_fixed_params)
+
+            # Resume from the _next_ set of fixed_query_params
+            fixed_query_params = fixed_query_params[
+                fixed_query_params.index(initial_fixed_params) + 1 :
+            ]
+
+        logger.info(
+            "Ingestion will be performed for each of the following sets of"
+            f" fixed query parameters: {fixed_query_params}"
+        )
+
+        for fixed_params in fixed_query_params:
+            logger.info(f"==Starting ingestion with fixed params: {fixed_params}==")
+            # Subsequent batches should not start at the initial_query_params
+            self._ingest_records(None, fixed_params)
 
     def _should_skip_ingestion_error(self, error: Exception) -> bool:
         """Determine whether an error should be skipped."""
@@ -330,7 +402,7 @@ class ProviderDataIngester(ABC):
         return None
 
     def _get_query_params(
-        self, prev_query_params: dict | None, **kwargs
+        self, prev_query_params: dict | None, fixed_query_params: dict | None
     ) -> dict | None:
         """
         Return the next set of query_params for the next request.
@@ -338,15 +410,6 @@ class ProviderDataIngester(ABC):
         This handles optional overrides via the dag_run conf.
         This method should not be overridden; instead override get_next_query_params.
         """
-        # If we are getting query_params for the first batch and initial_query_params
-        # have been set, return them.
-        if prev_query_params is None and self.initial_query_params:
-            logger.info(
-                "Using initial_query_params from dag_run conf:"
-                f" {json.dumps(self.initial_query_params)}"
-            )
-            return self.initial_query_params
-
         # If a list of query_params was provided, return the next value.
         if self.override_query_params:
             next_params = next(self.override_query_params, None)
@@ -356,10 +419,24 @@ class ProviderDataIngester(ABC):
             )
             return next_params
 
-        # Default behavior; build the next set of query params, given the previous,
-        # along with any extra params if additional_query_params were provided
-        next_query_params = self.get_next_query_params(prev_query_params, **kwargs)
-        return next_query_params | self.additional_query_params
+        # Default behavior: build the next set of query params, given the previous.
+        # The final set of query params returned merges:
+        # * the `next_query_params` calculated based on the previous params
+        # * any `fixed_query_params`, which are fixed params that do not change
+        #   depending on the previous params, and are applied to all batches in this
+        #   round of ingestion
+        # * any `additional_query_params`, which are provided via the DagRun conf
+        #   and applied to all batches, in every round of ingestion
+        next_query_params = self.get_next_query_params(prev_query_params)
+        fixed_query_params = fixed_query_params or {}
+        return next_query_params | fixed_query_params | self.additional_query_params
+
+    def get_fixed_query_params(self) -> list[dict] | None:
+        """
+        Return a list of fixed query params, for each of which ingestion will be
+        performed.
+        """
+        return []
 
     @abstractmethod
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:

--- a/catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -120,7 +120,7 @@ class RawpixelDataIngester(ProviderDataIngester):
         # Convert back to a string
         return signature.decode("utf-8")
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             params = {
                 "tags": "$publicdomain",

--- a/catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -90,7 +90,7 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
             self.page_number = 0
         else:
             # Increment the page number
-            self.page_number += 1
+            self.page_number = prev_query_params["page[number]"] + 1
 
         return {
             "has_image": 1,

--- a/catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -72,7 +72,7 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         year_ranges.extend(
             [(x, min(x + 5, final_year)) for x in range(1925, final_year, 5)]
         )
-        return [{"date[from]": from_, "date[to]": to_} for from_, to_ in year_ranges]
+        return year_ranges
 
     def get_fixed_query_params(self):
         """
@@ -80,7 +80,9 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         with the dates set as fixed query params.
         """
         next_year = date.today().year + 1
-        return self._get_year_ranges(next_year)
+        year_ranges = self._get_year_ranges(next_year)
+
+        return [{"date[from]": from_, "date[to]": to_} for from_, to_ in year_ranges]
 
     def get_next_query_params(self, prev_query_params):
         if not prev_query_params:

--- a/catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -121,7 +121,7 @@ class SmithsonianDataIngester(ProviderDataIngester):
             for hash_prefix in self._get_hash_prefixes()
         ]
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         # On the first request, `prev_query_params` will be `None`. We can detect this
         # and return our default params.
 

--- a/catalog/dags/providers/provider_api_scripts/smk.py
+++ b/catalog/dags/providers/provider_api_scripts/smk.py
@@ -26,7 +26,7 @@ class SmkDataIngester(ProviderDataIngester):
     headers = {"Accept": "application/json"}
     providers = {"image": prov.SMK_DEFAULT_PROVIDER}
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if not prev_query_params:
             return {
                 "keys": "*",

--- a/catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -40,15 +40,15 @@ class StockSnapDataIngester(ProviderDataIngester):
         super().__init__(*args, **kwargs)
         self._page_counter = 1
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params: dict | None):
         if prev_query_params:
             return {"page": prev_query_params["page"] + 1}
         return {"page": 1}
 
     def _get_query_params(
-        self, prev_query_params: dict | None, **kwargs
+        self, prev_query_params: dict | None, fixed_query_params: dict | None = None
     ) -> dict | None:
-        query_params = super()._get_query_params(prev_query_params, **kwargs)
+        query_params = super()._get_query_params(prev_query_params, fixed_query_params)
         if query_params:
             # Record the page that we are currently on so that it can be used as part of
             # the endpoint URL.

--- a/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -183,7 +183,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         self.current_props = self.default_props.copy()
         self.popularity_cache: dict[str, int] = {}
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params: dict | None):
         # NOTE: If more sub-properties are added here, an additional contingency for
         # iterating over that property's "continue" token will need to be added
         # to the `adjust_parameters_for_next_iteration` function, otherwise the

--- a/catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -53,7 +53,7 @@ class WordPressDataIngester(ProviderDataIngester):
         self.total_pages = None
         self.current_page = 1
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         if self.total_pages is None:
             # On the first request, make a HEAD request to get the number of pages of
             # results, so we know when to halt ingestion. This prevents errors

--- a/catalog/templates/template_provider.py_template
+++ b/catalog/templates/template_provider.py_template
@@ -43,7 +43,7 @@ class {provider}DataIngester(ProviderDataIngester):
     batch_limit = 100
     headers = {}
 
-    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, prev_query_params: dict | None) -> dict:
         # On the first request, `prev_query_params` will be `None`. We can detect this
         # and return our default params.
         if not prev_query_params:

--- a/catalog/tests/dags/common/test_resources/fake_provider_data_ingester.py
+++ b/catalog/tests/dags/common/test_resources/fake_provider_data_ingester.py
@@ -15,7 +15,7 @@ class FakeDataIngester(ProviderDataIngester):
     def endpoint(self):
         return ""
 
-    def get_next_query_params(self, old_query_params: dict | None, **kwargs) -> dict:
+    def get_next_query_params(self, old_query_params: dict | None) -> dict:
         return old_query_params
 
     def get_batch_data(self, response_json):

--- a/catalog/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -36,7 +36,7 @@ class MockProviderDataIngesterMixin:
     providers = {"audio": AUDIO_PROVIDER, "image": IMAGE_PROVIDER}
     endpoint = ENDPOINT
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
+    def get_next_query_params(self, prev_query_params):
         return DEFAULT_QUERY_PARAMS
 
     def get_batch_data(self, response_json):
@@ -90,17 +90,16 @@ class MockTimeDelineatedProviderDataIngester(
     min_divisions = MIN_DIVISIONS
     max_divisions = MAX_DIVISIONS
 
-    def get_next_query_params(self, prev_query_params, **kwargs):
-        return {
-            **DEFAULT_QUERY_PARAMS,
-            "start_ts": kwargs.get("start_ts"),
-            "end_ts": kwargs.get("end_ts"),
-        }
+    def get_next_query_params(self, prev_query_params):
+        return DEFAULT_QUERY_PARAMS
 
     def get_record_count_from_response(self, response_json):
         if response_json:
             return response_json.get("count")
         return 0
+
+    def get_timestamp_query_params(self, start, end, **kwargs):
+        return {"start_ts": start, "end_ts": end}
 
 
 # Expected result of calling `get_batch_data` with `response_success.json`

--- a/catalog/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -37,7 +37,9 @@ class MockProviderDataIngesterMixin:
     endpoint = ENDPOINT
 
     def get_next_query_params(self, prev_query_params):
-        return DEFAULT_QUERY_PARAMS
+        if prev_query_params is None:
+            return DEFAULT_QUERY_PARAMS
+        return {**prev_query_params, "page": prev_query_params["page"] + 1}
 
     def get_batch_data(self, response_json):
         if response_json:

--- a/catalog/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
@@ -47,19 +47,25 @@ def test_get_record_count(response_json, expected_count):
         assert actual_count == expected_count
 
 
-def test_build_query_param_default():
-    actual_param_made = fm.get_next_query_params(
-        None,
+def test_get_timestamp_query_params():
+    actual_fixed_params = fm.get_timestamp_query_params(
+        start=FROZEN_UTC_DATE,
+        end=FROZEN_UTC_DATE + timedelta(days=1),
         building="0/Museovirasto/",
-        start_ts=FROZEN_UTC_DATE,
-        end_ts=FROZEN_UTC_DATE + timedelta(days=1),
     )
-    expected_param = {
+    expected_fixed_params = {
         "filter[]": [
             'format:"0/Image/"',
             'building:"0/Museovirasto/"',
             'last_indexed:"[2020-04-01T00:00:00Z TO 2020-04-02T00:00:00Z]"',
         ],
+    }
+    assert actual_fixed_params == expected_fixed_params
+
+
+def test_build_query_param_default():
+    actual_param_made = fm.get_next_query_params(None)
+    expected_param = {
         "field[]": [
             "authors",
             "buildings",

--- a/catalog/tests/dags/providers/provider_api_scripts/test_flickr.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_flickr.py
@@ -369,7 +369,7 @@ def test_ingest_records():
             "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester.ingest_records"
         ),
         mock.patch(
-            "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester.ingest_records_for_timestamp_pair"
+            "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester._ingest_records"
         ) as ingest_for_pair_mock,
     ):
         flickr.ingest_records()
@@ -384,7 +384,7 @@ def test_ingest_records_when_large_batches_detected():
             "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester.ingest_records"
         ),
         mock.patch(
-            "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester.ingest_records_for_timestamp_pair"
+            "providers.provider_api_scripts.time_delineated_provider_data_ingester.TimeDelineatedProviderDataIngester._ingest_records"
         ) as ingest_for_pair_mock,
     ):
         # Set large_batches to include one timestamp pair

--- a/catalog/tests/dags/providers/provider_api_scripts/test_flickr.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_flickr.py
@@ -25,8 +25,6 @@ _get_resource_json = make_resource_json_func("flickr")
 
 def test_get_next_query_params():
     expected_params = {
-        "min_upload_date": "1516060900",
-        "max_upload_date": "1516060800",
         "page": 0,
         "api_key": "not_set",
         "license": "1,2,3,4,5,6,9,10",
@@ -45,16 +43,23 @@ def test_get_next_query_params():
     flickr.api_key = "not_set"
 
     # First request
-    first_params = flickr.get_next_query_params(
-        None, start_ts="1516060900", end_ts="1516060800"
-    )
+    first_params = flickr.get_next_query_params(None)
     assert first_params == expected_params
 
     # Updated page on second request
-    second_params = flickr.get_next_query_params(
-        first_params, start_ts="1516060900", end_ts="1516060800"
-    )
+    second_params = flickr.get_next_query_params(first_params)
     assert second_params == {**expected_params, "page": 1}
+
+
+def test_get_timestamp_query_params():
+    expected_params = {
+        "min_upload_date": "1516060900",
+        "max_upload_date": "1516060800",
+    }
+    actual_params = flickr.get_timestamp_query_params(
+        start="1516060900", end="1516060800"
+    )
+    assert actual_params == expected_params
 
 
 def test_get_media_type():

--- a/catalog/tests/dags/providers/provider_api_scripts/test_museum_victoria.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_museum_victoria.py
@@ -30,14 +30,26 @@ _get_resource_json = make_resource_json_func("museumvictoria")
 
 
 def test_get_query_param_default():
-    actual_param = mv.get_next_query_params(None, **{"license_": mv.LICENSE_LIST[0]})
+    actual_param = mv.get_next_query_params(None)
     expected_param = {
         "hasimages": "yes",
         "perpage": 100,
-        "imagelicense": "public domain",
         "page": 0,
     }
 
+    assert actual_param == expected_param
+
+
+def test_get_fixed_query_params():
+    actual_param = mv.get_fixed_query_params()
+    expected_param = [
+        {"imagelicense": "public domain"},
+        {"imagelicense": "cc by"},
+        {"imagelicense": "cc by-nc"},
+        {"imagelicense": "cc by-nc-sa"},
+        {"imagelicense": "cc by-nc-nd"},
+        {"imagelicense": "cc by-sa"},
+    ]
     assert actual_param == expected_param
 
 

--- a/catalog/tests/dags/providers/provider_api_scripts/test_science_museum.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_science_museum.py
@@ -82,11 +82,9 @@ def test_get_year_ranges():
 
 
 def test_get_query_param_default():
-    actual_param = sm.get_next_query_params({}, **{"year_range": (0, 1500)})
+    actual_param = sm.get_next_query_params({})
     expected_param = default_params | {
         "page[number]": 0,
-        "date[from]": 0,
-        "date[to]": 1500,
     }
 
     assert actual_param == expected_param
@@ -95,13 +93,9 @@ def test_get_query_param_default():
 def test_get_query_param_offset_page_number():
     sm = ScienceMuseumDataIngester()
     sm.page_number = 10
-    actual_param = sm.get_next_query_params(
-        default_params | {"page[number]": 10}, **{"year_range": (1500, 2000)}
-    )
+    actual_param = sm.get_next_query_params(default_params | {"page[number]": 10})
     expected_param = default_params | {
         "page[number]": 11,
-        "date[from]": 1500,
-        "date[to]": 2000,
     }
 
     assert actual_param == expected_param

--- a/catalog/tests/dags/providers/provider_api_scripts/test_smithsonian.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_smithsonian.py
@@ -101,14 +101,19 @@ def test_get_hash_prefixes_with_other_len(
     assert actual_list[-1] == expect_last
 
 
-def test_get_next_query_params_first_call():
-    hash_prefix = "ff"
-    actual_params = ingester.get_next_query_params(
-        prev_query_params=None, hash_prefix=hash_prefix
-    )
+def test_get_fixed_query_params():
+    with patch.object(ingester, "_get_hash_prefixes", return_value=["aa", "bb"]):
+        actual_fixed_params = ingester.get_fixed_query_params()
+        assert actual_fixed_params == [
+            {"q": "online_media_type:Images AND media_usage:CC0 AND hash:aa*"},
+            {"q": "online_media_type:Images AND media_usage:CC0 AND hash:bb*"},
+        ]
+
+
+def test_get_query_params_first_call():
+    actual_params = ingester.get_next_query_params(None)
     actual_params.pop("api_key")  # Omitting the API key
     expected_params = {
-        "q": f"online_media_type:Images AND media_usage:CC0 AND hash:{hash_prefix}*",
         "start": 0,
         "rows": 1000,
     }

--- a/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -123,9 +123,15 @@ def test_endpoint_increment():
 
 def test_initial_params_respected():
     stocksnap = StockSnapDataIngester(conf={"initial_query_params": {"page": 5}})
-    query_params = stocksnap._get_query_params(None)
-    assert stocksnap._page_counter == 5
-    assert query_params == {"page": 5}
+    with patch.object(stocksnap, "_ingest_records") as _ingest_mock:
+        stocksnap.ingest_records()
+        _ingest_mock.assert_called_with({"page": 5}, {})
+
+        # Assert that the next time _get_query_params is called, the page counter
+        # increments appropriately instead of starting back at the beginning
+        query_params = stocksnap._get_query_params({"page": 5})
+        assert query_params == {"page": 6}
+        assert stocksnap._page_counter == 6
 
 
 def test_get_record_data_returns_none_when_media_data_none():


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4207 by @stacimc 

This PR aimed to fix a problem with Science Museum, but it turned out the source of the problem was a larger failure in the way many of our providers override aspects of the ProviderDataIngester base class. Consequently this PR actually ends up fixing quite a bit more!

When this is merged, we will be able to do a full DagRun of Science Museum with `skip_ingestion_errors` enabled, and actually process all possible records. This is blocking in order to enable Science Museum in production (see #4013 for context).

This is a difficult one to explain, so please ping me if anything needs further explanation.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Our provider workflows have several advanced options in DagRun confs -- notably, `initial_query_params` (which overrides the starting point of the DAG, allowing us to resume a DAG from a point of failure) and `skip_ingestion_errors` (which skips batches with errors rather than halting the DAG, and then reports them in aggregate at the end).

We also have a number of DAGs that override the `ingest_records` method in order to run ingestion multiple times for a set of fixed query params. (For example, Science Museum runs `ingest_records` multiple times for different date ranges. Within each date range, the page number and other params advance as normal). **This breaks the advanced conf options for all of these DAGs.** For example:

* If you supply `initial_query_params` to a DAG that overrides `ingest_records`, it will start the first batch on those query params. It will also do so _every time_ `ingest_records` is called. This completely breaks the fixed params.
* If you enable `skip_ingestion_errors`, ingestion errors will be skipped and then reported in aggregate -- but at the end of the _current call to `ingest_records`_. **So for Science Museum for example, enabling `skipped_ingestion_errors` will only allow the DAG to get through the first date range where it encounters an error. In production, this was in the 1500-1750 date range. So we did not ingest any records after 1750, even though we had `skip_ingestion_errors` enabled!**

This PR updates the ProviderDataIngester base class to add support for `fixed_query_params` in a way that does not break the advanced conf options, and allows all the DAGs that were previously overriding `ingest_records` to no longer do so. It does this by adding a `get_fixed_query_params` method to the class which can optionally be overridden to provide a set of fixed query params, for each of which `ingest_records` will be called. It also updates the TimeDelineatedProviderDataIngester to work with this new feature. Finally it updates all of the DAGs to use this.

Unfortunately it was not really possible to do this in smaller pieces. The good news is that this PR fixes `initial_query_params` and `skip_ingestion_errors` for a ton of DAGs that they would not have previously reliably worked for!


ℹ️ Tip for reviewing: look at the changes to ProviderDataIngester first, then TimeDelineatedProviderDataIngester

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

To test this more easily, I applied the diff below to ProviderDataIngester to make it run more quickly (only processing the first two batches of each fixed param), and to log the query_params being used so you can see that they're advancing as expected.

```diff
diff --git a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
index 3624062b1..bc002e2ef 100644
--- a/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -241,14 +241,17 @@ class ProviderDataIngester(ABC):
             return
 
         logger.info(f"Begin ingestion for {self.__class__.__name__}")
+        count = 0
 
-        while should_continue:
+        while should_continue and count < 2:
+            count += 1
             if query_params is None:
                 # Break out of ingestion if no query_params are supplied. This can
                 # happen when the final `override_query_params` is processed.
                 break
 
             try:
+                logger.info(query_params)
                 batch, should_continue = self.get_batch(query_params)
 
                 if batch and len(batch) > 0:
```

### Test some provider DAGs that were not changed/should not be affected

For example I ran Cleveland and ensured that it passed.

### Test DAGs that previously overrode `ingest_records`

Run all the DAGs that previously overrode `ingest_records` and ensure they do not fail:

* Finnish Museums (Try setting the `date` conf option to 2024-04-24 to ensure you get a day with data)
* Flickr
* Museum Victoria
* Science Museum
* Smithsonian

You should see in the logs that the DAGs run ingestion multiple times for each of their fixed params. Science Museum for example will run `_ingest_records` for each of its date ranges. You can see in the logs something like this (I've omitted logs that are not relevant for brevity):

```
[2024-04-27, 00:52:56 UTC] {provider_data_ingester.py:359} INFO - ==Starting ingestion with fixed params: {'date[from]': 0, 'date[to]': 200}==
[2024-04-27, 00:52:56 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 0, 'date[from]': 0, 'date[to]': 200}
[2024-04-27, 00:53:01 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 1, 'date[from]': 0, 'date[to]': 200}
[2024-04-27, 00:53:08 UTC] {provider_data_ingester.py:359} INFO - ==Starting ingestion with fixed params: {'date[from]': 200, 'date[to]': 1500}==
[2024-04-27, 00:53:08 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 0, 'date[from]': 200, 'date[to]': 1500}
[2024-04-27, 00:53:13 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 1, 'date[from]': 200, 'date[to]': 1500}
[2024-04-27, 00:53:23 UTC] {provider_data_ingester.py:359} INFO - ==Starting ingestion with fixed params: {'date[from]': 1500, 'date[to]': 1750}==
...
```

### Test `initial_query_params`

Try running Science Museum with `initial_query_params` set to `{"has_image": 1, "image_license": "CC", "page[size]": 100, "page[number]": 4, "date[from]": 200, "date[to]": 1500}`. Note that I've started at the second date range (a fixed param) and I've also started at a later page (a non fixed param).

Verify in the logs that it starts ingestion on the correct date range and page number. The page number advances appropriately instead of resetting back to 1. When it advances to the next date range, it advances appropriately (200-1500 to 1500-1750, instead of resetting back to 0-200):

```
[2024-04-27, 01:06:32 UTC] {provider_data_ingester.py:342} INFO - ==Starting ingestion with fixed params: {'date[from]': 200, 'date[to]': 1500}==
[2024-04-27, 01:06:32 UTC] {provider_data_ingester.py:232} INFO - Using initial_query_params from dag_run conf: {"has_image": 1, "image_license": "CC", "page[size]": 100, "page[number]": 4, "date[from]": 200, "date[to]": 1500}
[2024-04-27, 01:06:32 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 4, 'date[from]': 200, 'date[to]': 1500}
[2024-04-27, 01:06:35 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 5, 'date[from]': 200, 'date[to]': 1500}
[2024-04-27, 01:06:44 UTC] {provider_data_ingester.py:355} INFO - ==Starting ingestion with fixed params: {'date[from]': 1500, 'date[to]': 1750}==
[2024-04-27, 01:06:44 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 0, 'date[from]': 1500, 'date[to]': 1750}
[2024-04-27, 01:06:49 UTC] {provider_data_ingester.py:254} INFO - {'has_image': 1, 'image_license': 'CC', 'page[size]': 100, 'page[number]': 1, 'date[from]': 1500, 'date[to]': 1750}
```

### Test `skip_ingestion_errors`

Update science_museum.py to raise a ValueError in `get_batch_data`. Keep your other patch applied so that it will only try to pull 2 batches per date range, and then run the DAG again. This time enable the `skip_ingestion_errors` option and verify that not only does it skip errors for the first date range, but it continues to the next date range as well.

```
[2024-04-27, 01:12:42 UTC] {provider_data_ingester.py:342} INFO - ==Starting ingestion with fixed params: {'date[from]': 0, 'date[to]': 200}==
[2024-04-27, 01:12:45 UTC] {provider_data_ingester.py:287} ERROR - Skipping batch due to ingestion error: foo
[2024-04-27, 01:12:49 UTC] {provider_data_ingester.py:287} ERROR - Skipping batch due to ingestion error: foo
[2024-04-27, 01:12:54 UTC] {provider_data_ingester.py:355} INFO - ==Starting ingestion with fixed params: {'date[from]': 200, 'date[to]': 1500}==
[2024-04-27, 01:12:59 UTC] {provider_data_ingester.py:287} ERROR - Skipping batch due to ingestion error: foo
...
```

### Test both options at the same time, with a TimeDelineated provider

The TimeDelineatedProviderDataIngester should be tested separately. You can do this for Finnish or Flickr. Finnish is particularly finicky because it uses fixed params (iterating over `buildings`) _and_ timestamp pairs.

Update Finnish museums to raise an error during `get_batch_data`. Then run the DAG with `date` set to `2024-04-24`, `skip_ingestion_errors` enabled, and `initial_query_params`: 
```
{
    "field[]":[
        "authors","buildings","id","imageRights","images","subjects","title"
    ],
    "filter[]":[
        "format:'0/Image/'",
        "building:'0/Museovirasto/'",
        "last_indexed:'[2024-04-24T20:09:00Z TO 2024-04-24T20:12:00Z]'"
    ],
    "limit":100,
    "page":650
}
```

You will have to wait for it to generate all the timestamp pairs. Once it begins ingestion, you should see in the logs that it begins at the `Museovirasto` building for timestamps `[2024-04-24T20:09:00Z TO 2024-04-24T20:12:00Z]` and page 650. It should get an error which it will skip and advance to page 651. It should then proceed to the next chronological timestamp for the same building, starting at page 1.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
