### PR TITLE
Change search query approach to include only available providers

### DIFF
--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl.response import Hit
 from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
 from api.controllers.search_controller import (
     _post_process_results,
-    get_enabled_providers_query,
+    get_enabled_sources_query,
 )
 
 
@@ -55,8 +55,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
             related_query["should"].append(Q("terms", tags__name__keyword=tags))
 
     # Exclude the dynamically disabled sources.
-    if enabled_providers_query := get_enabled_providers_query():
-        related_query["filter"].append(enabled_providers_query)
+    if enabled_sources_query := get_enabled_sources_query():
+        related_query["filter"].append(enabled_sources_query)
     # Exclude the current item and mature content.
     related_query["must_not"].extend(
         [Q("term", mature=True), Q("term", identifier=uuid)]

--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl.response import Hit
 from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
 from api.controllers.search_controller import (
     _post_process_results,
-    get_excluded_providers_query,
+    get_filtered_providers_query,
 )
 
 
@@ -55,8 +55,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
             related_query["should"].append(Q("terms", tags__name__keyword=tags))
 
     # Exclude the dynamically disabled sources.
-    if excluded_providers_query := get_excluded_providers_query():
-        related_query["must_not"].append(excluded_providers_query)
+    if filtered_providers_query := get_filtered_providers_query():
+        related_query["must"].append(filtered_providers_query)
     # Exclude the current item and mature content.
     related_query["must_not"].extend(
         [Q("term", mature=True), Q("term", identifier=uuid)]

--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl.response import Hit
 from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
 from api.controllers.search_controller import (
     _post_process_results,
-    get_filtered_providers_query,
+    get_enabled_providers_query,
 )
 
 
@@ -36,7 +36,7 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
     tags = getattr(item_hit, "tags", None)
     creator = getattr(item_hit, "creator", None)
 
-    related_query = {"must_not": [], "must": [], "should": []}
+    related_query = {"filter": [], "must_not": [], "should": []}
 
     if not title and not tags:
         if not creator:
@@ -55,8 +55,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
             related_query["should"].append(Q("terms", tags__name__keyword=tags))
 
     # Exclude the dynamically disabled sources.
-    if filtered_providers_query := get_filtered_providers_query():
-        related_query["must"].append(filtered_providers_query)
+    if enabled_providers_query := get_enabled_providers_query():
+        related_query["filter"].append(enabled_providers_query)
     # Exclude the current item and mature content.
     related_query["must_not"].extend(
         [Q("term", mature=True), Q("term", identifier=uuid)]

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -41,12 +41,8 @@ logger = structlog.get_logger(__name__)
 NESTING_THRESHOLD = config("POST_PROCESS_NESTING_THRESHOLD", cast=int, default=5)
 SOURCE_CACHE_TIMEOUT = 60 * 60 * 4  # 4 hours
 FILTER_CACHE_TIMEOUT = 30
-FILTERED_PROVIDERS_CACHE_KEY = "filtered_providers"
-FILTERED_PROVIDERS_CACHE_VERSION = 2
-THUMBNAIL = "thumbnail"
-URL = "url"
-PROVIDER = "provider"
-QUERY_SPECIAL_CHARACTER_ERROR = "Unescaped special characters are not allowed."
+ENABLED_SOURCES_CACHE_KEY = "enabled_sources"
+ENABLED_SOURCES_CACHE_VERSION = 2
 DEFAULT_BOOST = 10000
 DEFAULT_SEARCH_FIELDS = ["title", "description", "tags.name"]
 DEFAULT_SQS_FLAGS = "AND|NOT|PHRASE|WHITESPACE"
@@ -162,26 +158,29 @@ def _post_process_results(
     return results[:page_size]
 
 
-def get_enabled_providers_query() -> Q | None:
+def get_enabled_sources_query() -> Q | None:
     """
-    Get a query that only includes enabled providers.
+    Get a query that only includes enabled sources.
 
-    To exclude a provider, set ``filter_content`` to ``True`` in the
+    To exclude a source, set ``filter_content`` to ``True`` in the
     ``ContentProvider`` model in Django admin.
     The list of ``provider_identifier``s is cached in Redis with
-    `:FILTERED_PROVIDERS_CACHE_VERSION:FILTERED_PROVIDERS_CACHE_KEY` key.
+    `:ENABLED_SOURCES_CACHE_VERSION:ENABLED_SOURCES_CACHE_KEY` key.
     """
 
     try:
-        enabled_providers = cache.get(
-            key=FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION
+        enabled_sources = cache.get(
+            key=ENABLED_SOURCES_CACHE_KEY, version=ENABLED_SOURCES_CACHE_VERSION
         )
     except ConnectionError:
-        logger.warning("Redis connect failed, cannot get cached filtered providers.")
-        enabled_providers = None
+        logger.warning("Redis connect failed, cannot get cached enabled sources.")
+        enabled_sources = None
 
-    if not enabled_providers:
-        enabled_providers = list(
+    if not enabled_sources:
+        # `ContentProvider` currently only handles _sources_, not providers.
+        # TODO: This is a legacy naming convention that should be updated.
+        # https://github.com/WordPress/openverse/issues/4346
+        enabled_sources = list(
             models.ContentProvider.objects.filter(filter_content=False).values_list(
                 "provider_identifier", flat=True
             )
@@ -189,16 +188,16 @@ def get_enabled_providers_query() -> Q | None:
 
         try:
             cache.set(
-                key=FILTERED_PROVIDERS_CACHE_KEY,
-                version=FILTERED_PROVIDERS_CACHE_VERSION,
+                key=ENABLED_SOURCES_CACHE_KEY,
+                version=ENABLED_SOURCES_CACHE_VERSION,
                 timeout=FILTER_CACHE_TIMEOUT,
-                value=enabled_providers,
+                value=enabled_sources,
             )
         except ConnectionError:
-            logger.warning("Redis connect failed, cannot cache filtered providers.")
+            logger.warning("Redis connect failed, cannot cache enabled sources.")
 
-    if enabled_providers:
-        return Q("terms", provider=enabled_providers)
+    if enabled_sources:
+        return Q("terms", source=enabled_sources)
     return None
 
 
@@ -286,8 +285,8 @@ def build_search_query(
     if not search_params.validated_data["include_sensitive_results"]:
         search_queries["must_not"].append(Q("term", mature=True))
     # Exclude dynamically disabled sources (see Redis cache)
-    if enabled_providers_query := get_enabled_providers_query():
-        search_queries["filter"].append(enabled_providers_query)
+    if enabled_sources_query := get_enabled_sources_query():
+        search_queries["filter"].append(enabled_sources_query)
 
     # Search either by generic multimatch or by "advanced search" with
     # individual field-level queries specified.
@@ -397,8 +396,8 @@ def build_collection_query(
     if not include_sensitive_by_params:
         search_query["must_not"].append({"term": {"mature": True}})
 
-    if enabled_providers_query := get_enabled_providers_query():
-        search_query["filter"].append(enabled_providers_query)
+    if enabled_sources_query := get_enabled_sources_query():
+        search_query["filter"].append(enabled_sources_query)
 
     return Q("bool", **search_query)
 

--- a/api/conf/settings/__init__.py
+++ b/api/conf/settings/__init__.py
@@ -10,7 +10,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 
-from decouple import config
 from split_settings.tools import include
 
 

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -20,12 +20,12 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def filtered_providers_cache(django_cache, monkeypatch):
+def enabled_providers_cache(django_cache, monkeypatch):
     cache = django_cache
     monkeypatch.setattr("api.controllers.search_controller.cache", cache)
 
-    filtered_provider = "filtered_provider"
-    cache_value = [filtered_provider]
+    enabled_provider = "enabled_provider"
+    cache_value = [enabled_provider]
     cache.set(
         key=FILTERED_PROVIDERS_CACHE_KEY,
         version=FILTERED_PROVIDERS_CACHE_VERSION,
@@ -33,7 +33,7 @@ def filtered_providers_cache(django_cache, monkeypatch):
         timeout=1,
     )
 
-    yield filtered_provider
+    yield enabled_provider
 
     cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
 
@@ -47,7 +47,7 @@ def test_related_media(
     wrapped_related_results,
     image_media_type_config,
     settings,
-    filtered_providers_cache,
+    enabled_providers_cache,
 ):
     image = ImageFactory.create()
 
@@ -82,8 +82,8 @@ def test_related_media(
         "from": 0,
         "query": {
             "bool": {
-                "must": [
-                    {"terms": {"provider": [filtered_providers_cache]}},
+                "filter": [
+                    {"terms": {"provider": [enabled_providers_cache]}},
                 ],
                 "must_not": [
                     {"term": {"mature": True}},

--- a/api/test/unit/controllers/elasticsearch/test_related.py
+++ b/api/test/unit/controllers/elasticsearch/test_related.py
@@ -5,8 +5,8 @@ import pytest
 
 from api.controllers.elasticsearch import related
 from api.controllers.search_controller import (
-    FILTERED_PROVIDERS_CACHE_KEY,
-    FILTERED_PROVIDERS_CACHE_VERSION,
+    ENABLED_SOURCES_CACHE_KEY,
+    ENABLED_SOURCES_CACHE_VERSION,
 )
 from test.factory.es_http import (
     MOCK_LIVE_RESULT_URL_PREFIX,
@@ -20,22 +20,22 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def enabled_providers_cache(django_cache, monkeypatch):
+def enabled_sources_cache(django_cache, monkeypatch):
     cache = django_cache
     monkeypatch.setattr("api.controllers.search_controller.cache", cache)
 
-    enabled_provider = "enabled_provider"
-    cache_value = [enabled_provider]
+    enabled_source = "enabled_source"
+    cache_value = [enabled_source]
     cache.set(
-        key=FILTERED_PROVIDERS_CACHE_KEY,
-        version=FILTERED_PROVIDERS_CACHE_VERSION,
+        key=ENABLED_SOURCES_CACHE_KEY,
+        version=ENABLED_SOURCES_CACHE_VERSION,
         value=cache_value,
         timeout=1,
     )
 
-    yield enabled_provider
+    yield enabled_source
 
-    cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
+    cache.delete(ENABLED_SOURCES_CACHE_KEY, version=ENABLED_SOURCES_CACHE_VERSION)
 
 
 @mock.patch(
@@ -47,7 +47,7 @@ def test_related_media(
     wrapped_related_results,
     image_media_type_config,
     settings,
-    enabled_providers_cache,
+    enabled_sources_cache,
 ):
     image = ImageFactory.create()
 
@@ -83,7 +83,7 @@ def test_related_media(
         "query": {
             "bool": {
                 "filter": [
-                    {"terms": {"provider": [enabled_providers_cache]}},
+                    {"terms": {"source": [enabled_sources_cache]}},
                 ],
                 "must_not": [
                     {"term": {"mature": True}},

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -1,7 +1,7 @@
-import datetime
 import random
 import re
 from collections.abc import Callable
+from datetime import datetime, timezone
 from enum import Enum, auto
 from unittest import mock
 from unittest.mock import patch
@@ -855,7 +855,7 @@ def test_get_filtered_providers_query_returns_available_providers(
     else:
         for i in range(excluded_count):
             ContentProviderFactory.create(
-                created_on=datetime.datetime.now(),
+                created_on=datetime.now(tz=timezone.utc),
                 provider_identifier=f"provider{i + 1}",
                 provider_name=f"Provider {i + 1}",
                 filter_content=False,

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -840,7 +840,7 @@ def test_excessive_recursion_in_post_process(
     "excluded_count, result",
     [(2, Terms(provider=["provider1", "provider2"])), (0, None)],
 )
-def test_get_excluded_providers_query_returns_excluded(
+def test_get_filtered_providers_query_returns_available_providers(
     excluded_count, result, is_cache_reachable, cache_name, request
 ):
     cache = request.getfixturevalue(cache_name)
@@ -858,11 +858,11 @@ def test_get_excluded_providers_query_returns_excluded(
                 created_on=datetime.datetime.now(),
                 provider_identifier=f"provider{i + 1}",
                 provider_name=f"Provider {i + 1}",
-                filter_content=True,
+                filter_content=False,
             )
 
     with capture_logs() as cap_logs:
-        assert search_controller.get_excluded_providers_query() == result
+        assert search_controller.get_filtered_providers_query() == result
 
     if not is_cache_reachable:
         messages = [record["event"] for record in cap_logs]

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -16,7 +16,7 @@ from structlog.testing import capture_logs
 
 from api.controllers import search_controller
 from api.controllers.elasticsearch import helpers as es_helpers
-from api.controllers.search_controller import FILTERED_PROVIDERS_CACHE_KEY
+from api.controllers.search_controller import ENABLED_SOURCES_CACHE_KEY
 from api.utils import tallies
 from api.utils.dead_link_mask import get_query_hash, save_query_mask
 from api.utils.search_context import SearchContext
@@ -838,39 +838,39 @@ def test_excessive_recursion_in_post_process(
 @cache_availability_params
 @pytest.mark.parametrize(
     "excluded_count, result",
-    [(2, Terms(provider=["provider1", "provider2"])), (0, None)],
+    [(2, Terms(source=["source1", "source2"])), (0, None)],
 )
-def test_get_enabled_providers_query_returns_available_providers(
+def test_get_enabled_sources_query_returns_available_sources(
     excluded_count, result, is_cache_reachable, cache_name, request
 ):
     cache = request.getfixturevalue(cache_name)
 
     if is_cache_reachable:
         cache.set(
-            key=FILTERED_PROVIDERS_CACHE_KEY,
+            key=ENABLED_SOURCES_CACHE_KEY,
             version=2,
             timeout=30,
-            value=[f"provider{i + 1}" for i in range(excluded_count)],
+            value=[f"source{i + 1}" for i in range(excluded_count)],
         )
     else:
         for i in range(excluded_count):
             ContentProviderFactory.create(
                 created_on=datetime.now(tz=timezone.utc),
-                provider_identifier=f"provider{i + 1}",
-                provider_name=f"Provider {i + 1}",
+                provider_identifier=f"source{i + 1}",
+                provider_name=f"Source {i + 1}",
                 filter_content=False,
             )
 
     with capture_logs() as cap_logs:
-        assert search_controller.get_enabled_providers_query() == result
+        assert search_controller.get_enabled_sources_query() == result
 
     if not is_cache_reachable:
         messages = [record["event"] for record in cap_logs]
         assert all(
             message in messages
             for message in [
-                "Redis connect failed, cannot get cached filtered providers.",
-                "Redis connect failed, cannot cache filtered providers.",
+                "Redis connect failed, cannot get cached enabled sources.",
+                "Redis connect failed, cannot cache enabled sources.",
             ]
         )
 

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -840,7 +840,7 @@ def test_excessive_recursion_in_post_process(
     "excluded_count, result",
     [(2, Terms(provider=["provider1", "provider2"])), (0, None)],
 )
-def test_get_filtered_providers_query_returns_available_providers(
+def test_get_enabled_providers_query_returns_available_providers(
     excluded_count, result, is_cache_reachable, cache_name, request
 ):
     cache = request.getfixturevalue(cache_name)
@@ -862,7 +862,7 @@ def test_get_filtered_providers_query_returns_available_providers(
             )
 
     with capture_logs() as cap_logs:
-        assert search_controller.get_filtered_providers_query() == result
+        assert search_controller.get_enabled_providers_query() == result
 
     if not is_cache_reachable:
         messages = [record["event"] for record in cap_logs]

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -837,11 +837,11 @@ def test_excessive_recursion_in_post_process(
 @pytest.mark.django_db
 @cache_availability_params
 @pytest.mark.parametrize(
-    "excluded_count, result",
+    "enabled_count, result",
     [(2, Terms(source=["source1", "source2"])), (0, None)],
 )
 def test_get_enabled_sources_query_returns_available_sources(
-    excluded_count, result, is_cache_reachable, cache_name, request
+    enabled_count, result, is_cache_reachable, cache_name, request
 ):
     cache = request.getfixturevalue(cache_name)
 
@@ -850,10 +850,10 @@ def test_get_enabled_sources_query_returns_available_sources(
             key=ENABLED_SOURCES_CACHE_KEY,
             version=2,
             timeout=30,
-            value=[f"source{i + 1}" for i in range(excluded_count)],
+            value=[f"source{i + 1}" for i in range(enabled_count)],
         )
     else:
-        for i in range(excluded_count):
+        for i in range(enabled_count):
             ContentProviderFactory.create(
                 created_on=datetime.now(tz=timezone.utc),
                 provider_identifier=f"source{i + 1}",

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -5,8 +5,8 @@ from api.constants.parameters import COLLECTION, TAG
 from api.controllers import search_controller
 from api.controllers.search_controller import (
     DEFAULT_SQS_FLAGS,
-    FILTERED_PROVIDERS_CACHE_KEY,
-    FILTERED_PROVIDERS_CACHE_VERSION,
+    ENABLED_SOURCES_CACHE_KEY,
+    ENABLED_SOURCES_CACHE_VERSION,
 )
 
 
@@ -14,22 +14,22 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def enabled_providers_cache(django_cache, monkeypatch):
+def enabled_sources_cache(django_cache, monkeypatch):
     cache = django_cache
     monkeypatch.setattr("api.controllers.search_controller.cache", cache)
 
-    enabled_provider = "enabled_provider"
-    cache_value = [enabled_provider]
+    enabled_source = "enabled_source"
+    cache_value = [enabled_source]
     cache.set(
-        key=FILTERED_PROVIDERS_CACHE_KEY,
-        version=FILTERED_PROVIDERS_CACHE_VERSION,
+        key=ENABLED_SOURCES_CACHE_KEY,
+        version=ENABLED_SOURCES_CACHE_VERSION,
         value=cache_value,
         timeout=1,
     )
 
-    yield enabled_provider
+    yield enabled_source
 
-    cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
+    cache.delete(ENABLED_SOURCES_CACHE_KEY, version=ENABLED_SOURCES_CACHE_VERSION)
 
 
 def test_create_search_query_empty(media_type_config):
@@ -268,9 +268,9 @@ def test_create_search_query_q_search_license_license_type_creates_2_terms_filte
     }
 
 
-def test_create_search_query_empty_with_dynamically_enabled_providers(
+def test_create_search_query_empty_with_dynamically_enabled_sources(
     image_media_type_config,
-    enabled_providers_cache,
+    enabled_sources_cache,
 ):
     serializer = image_media_type_config.search_request_serializer(
         data={}, context={"media_type": image_media_type_config.media_type}
@@ -286,7 +286,7 @@ def test_create_search_query_empty_with_dynamically_enabled_providers(
         ],
         "must": [{"match_all": {}}],
         "filter": [
-            {"terms": {"provider": [enabled_providers_cache]}},
+            {"terms": {"source": [enabled_sources_cache]}},
         ],
         "should": [
             {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}

--- a/api/test/unit/controllers/test_search_controller_search_query.py
+++ b/api/test/unit/controllers/test_search_controller_search_query.py
@@ -14,12 +14,12 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def excluded_providers_cache(django_cache, monkeypatch):
+def filtered_providers_cache(django_cache, monkeypatch):
     cache = django_cache
     monkeypatch.setattr("api.controllers.search_controller.cache", cache)
 
-    excluded_provider = "excluded_provider"
-    cache_value = [excluded_provider]
+    filtered_provider = "filtered_provider"
+    cache_value = [filtered_provider]
     cache.set(
         key=FILTERED_PROVIDERS_CACHE_KEY,
         version=FILTERED_PROVIDERS_CACHE_VERSION,
@@ -27,41 +27,9 @@ def excluded_providers_cache(django_cache, monkeypatch):
         timeout=1,
     )
 
-    yield excluded_provider
+    yield filtered_provider
 
     cache.delete(FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION)
-
-
-def test_create_search_query_empty(media_type_config):
-    serializer = media_type_config.search_request_serializer(
-        data={}, context={"media_type": "image"}
-    )
-    serializer.is_valid(raise_exception=True)
-    search_query = search_controller.build_search_query(serializer)
-    actual_query_clauses = search_query.to_dict()["bool"]
-
-    assert actual_query_clauses == {
-        "must_not": [{"term": {"mature": True}}],
-        "must": [{"match_all": {}}],
-        "should": [
-            {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}
-        ],
-    }
-
-
-def test_create_search_query_empty_no_ranking(media_type_config, settings):
-    settings.USE_RANK_FEATURES = False
-    serializer = media_type_config.search_request_serializer(
-        data={}, context={"media_type": media_type_config.media_type}
-    )
-    serializer.is_valid(raise_exception=True)
-    search_query = search_controller.build_search_query(serializer)
-    actual_query_clauses = search_query.to_dict()["bool"]
-
-    assert actual_query_clauses == {
-        "must_not": [{"term": {"mature": True}}],
-        "must": [{"match_all": {}}],
-    }
 
 
 def test_create_search_query_q_search_no_filters(media_type_config):
@@ -261,16 +229,15 @@ def test_create_search_query_q_search_license_license_type_creates_2_terms_filte
 
     assert actual_query_clauses == {
         "must_not": [{"term": {"mature": True}}],
-        "must": [{"match_all": {}}],
         "should": [
             {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}},
         ],
     }
 
 
-def test_create_search_query_empty_with_dynamically_excluded_providers(
+def test_create_search_query_empty_with_dynamically_filtered_providers(
     image_media_type_config,
-    excluded_providers_cache,
+    filtered_providers_cache,
 ):
     serializer = image_media_type_config.search_request_serializer(
         data={}, context={"media_type": image_media_type_config.media_type}
@@ -283,9 +250,10 @@ def test_create_search_query_empty_with_dynamically_excluded_providers(
     assert actual_query_clauses == {
         "must_not": [
             {"term": {"mature": True}},
-            {"terms": {"provider": [excluded_providers_cache]}},
         ],
-        "must": [{"match_all": {}}],
+        "must": [
+            {"terms": {"provider": [filtered_providers_cache]}},
+        ],
         "should": [
             {"rank_feature": {"boost": 10000, "field": "standardized_popularity"}}
         ],


### PR DESCRIPTION
## Fixes

Fixes #4076 by @obulat 

## Description

This PR proposes an alternative solution to the one proposed in the issue: The search controller should limit the results queried to those associated with existing and not hidden providers. IMO, this is a simpler approach that takes advantage of the existing code structure. It fits the "filtered provider" concept in the sense that it queries for valid providers instead of skipping the "excluded." What I don't know is if we want to update the value of the `FILTERED_PROVIDERS_CACHE_VERSION` variable in this case.

## Testing Instructions

1. Spin up the API, `just a`, and go to http://localhost:50280/v1/images/ to confirm the search is working with the usual providers
2. Hide one of the image providers via Django admin, e.g. StockSnap.
3. Confirm the results for the hidden provider are not returned http://localhost:50280/v1/images/
4. Show the results of StockSnap again and delete the `ContentProvider` entry for Flickr.
5. Confirm the results for the deleted provider are not returned http://localhost:50280/v1/images/

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (only applicable for catalog PRs).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1
Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129
Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.
Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or
(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or
(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.
(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>