### PR TITLE
Fix Science Museum index out of range error

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -243,7 +243,7 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         # some items do not return license anywhere, but in the UI
         # they look like CC
         rights = image_data.get("legal", {}).get("rights")
-        if isinstance(rights, list):
+        if rights and isinstance(rights, list):
             license_name = rights[0].get("licence")
             if not license_name:
                 return None


### PR DESCRIPTION
## Fixes

Fixes production error. Blocking on Science Museum full run, needed to enable the provider in production.

## Description

(Hopefully last) small fix for Science Museum to try to get a complete dagrun. Handles case where the record data contains no licensing information.

## Testing Instructions

Run the Science Museum DAG with:

```
"initial_query_params":{
  "date[from]":1915,
  "date[to]":1925,
  "has_image":1,
  "image_license":"CC",
  "page[number]":11,
  "page[size]":100
}
```

This should error immediately on `main` but pass on this branch.


Note that if you want to test the full DAG you need to have the admin variable `SKIPPED_INGESTION_ERRORS` configured with this value:

```
{
    "science_museum_workflow": [
        {
            "issue": "https://github.com/WordPress/openverse/issues/4013",
            "predicate": "Service unavailable for url"
        }
    ]
}
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (only applicable for catalog PRs).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1
Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129
Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.
Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or
(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or
(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.
(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>