### PR TITLE
Update Science museum urls

### DIFF
--- a/catalog/dags/maintenance/update_science_museum_urls.py
+++ b/catalog/dags/maintenance/update_science_museum_urls.py
@@ -1,0 +1,164 @@
+"""
+# Update Science Museum URLs
+
+One-time maintenance DAG to update Science Museum records to have valid URLs. See https://github.com/WordPress/openverse/issues/4261.
+
+For each Science Museum record, this DAG:
+
+* updates the url to the new format, excluding `/images/` in the path if it exists
+* validates whether the url . If not, the record ID is added to an `invalid_science_musem_ids` table.
+
+Once complete, we can use the `invalid_science_museum_ids` to identify records to delete. They are not automatically deleted by this DAG, in order to give us an opportunity to first see how many there are.
+"""
+
+import logging
+from datetime import timedelta
+from textwrap import dedent
+
+from airflow.decorators import dag, task
+from airflow.exceptions import AirflowSkipException
+from airflow.models.abstractoperator import AbstractOperator
+from airflow.models.param import Param
+
+from common import slack
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
+from common.sql import RETURN_ROW_COUNT, PostgresHook
+from common.urls import rewrite_redirected_url
+
+
+logger = logging.getLogger(__name__)
+
+
+DAG_ID = "update_science_museum_urls"
+INVALID_IDS_TABLE = "science_museum_invalid_ids"
+
+UPDATE_URLS_QUERY = dedent(
+    """
+    UPDATE image
+    SET url=REPLACE(url, '/images', '')
+    WHERE provider='sciencemuseum' AND url ILIKE '%/images/%';
+    """
+)
+CREATE_TABLE_QUERY = dedent(
+    f"""
+    CREATE TABLE IF NOT EXISTS {INVALID_IDS_TABLE}
+    (identifier uuid);
+    """
+)
+
+
+@task
+def run_sql(
+    sql: str,
+    handler: callable = None,
+    postgres_conn_id: str = POSTGRES_CONN_ID,
+    task: AbstractOperator = None,
+):
+    postgres = PostgresHook(
+        postgres_conn_id=postgres_conn_id,
+        default_statement_timeout=PostgresHook.get_execution_timeout(task),
+    )
+
+    return postgres.run(sql, handler=handler)
+
+
+@task
+def get_batches(
+    batch_size: int,
+    postgres_conn_id: str = POSTGRES_CONN_ID,
+    task: AbstractOperator = None,
+):
+    postgres = PostgresHook(
+        postgres_conn_id=postgres_conn_id,
+        default_statement_timeout=PostgresHook.get_execution_timeout(task),
+    )
+    records = postgres.get_records(
+        "SELECT identifier, url FROM image where provider='sciencemuseum';"
+    )
+
+    return [records[i : i + batch_size] for i in range(0, len(records), batch_size)]
+
+
+@task
+def process_batch(records):
+    invalid_ids = []
+    for identifier, url in records:
+        # Failed to reach URL
+        if rewrite_redirected_url(url) is None:
+            invalid_ids.append(identifier)
+
+    return invalid_ids
+
+
+@task
+def record_invalid_ids(invalid_ids):
+    # Chain together
+    ids_to_record = sum(invalid_ids, [])
+
+    if not ids_to_record:
+        raise AirflowSkipException("No invalid urls found!")
+
+    values = ", ".join([f"('{id}')" for id in ids_to_record])
+    query = dedent(
+        f"""
+        INSERT INTO {INVALID_IDS_TABLE} (identifier)
+        VALUES {values}
+        """
+    )
+
+    return run_sql.function(sql=query, handler=RETURN_ROW_COUNT)
+
+
+@task
+def notify_slack(invalid_count: int):
+    slack.send_message(
+        f"Detected {invalid_count} invalid Science Museum urls.", dag_id=DAG_ID
+    )
+
+
+@dag(
+    dag_id=DAG_ID,
+    schedule=None,
+    catchup=False,
+    tags=["maintenance"],
+    doc_md=__doc__,
+    default_args={
+        **DAG_DEFAULT_ARGS,
+        "retries": 0,
+        "execution_timeout": timedelta(days=2),
+    },
+    render_template_as_native_obj=True,
+    params={
+        "batch_size": Param(
+            default=1_000,
+            type="integer",
+            description="The number of records to update per batch.",
+        ),
+    },
+)
+def update_science_museum_urls():
+    # Update all URLs to have the correct format
+    update = run_sql.override(task_id="update_url_format")(sql=UPDATE_URLS_QUERY)
+
+    # Create table to track ids of records that still have an
+    # invalid/unreachable url
+    create_table = run_sql.override(task_id="create_invalid_id_table")(
+        sql=CREATE_TABLE_QUERY
+    )
+
+    # Split records into batches
+    batches = get_batches(batch_size="{{ params.batch_size }}")
+
+    # Verify each record's url
+    process = process_batch.expand(records=batches)
+
+    # Record the identifiers of records with invalid urls
+    record = record_invalid_ids(process)
+
+    # Report the number of invalid records to Slack
+    notify = notify_slack(record)
+
+    update >> create_table >> process >> record >> notify
+
+
+update_science_museum_urls()

--- a/catalog/dags/maintenance/update_science_museum_urls.py
+++ b/catalog/dags/maintenance/update_science_museum_urls.py
@@ -80,7 +80,7 @@ def get_batches(
     return [records[i : i + batch_size] for i in range(0, len(records), batch_size)]
 
 
-@task
+@task(max_active_tis_per_dagrun=3)
 def process_batch(records):
     invalid_ids = []
     for identifier, url in records:
@@ -131,7 +131,7 @@ def notify_slack(invalid_count: int):
     render_template_as_native_obj=True,
     params={
         "batch_size": Param(
-            default=1_000,
+            default=250,
             type="integer",
             description="The number of records to update per batch.",
         ),

--- a/catalog/dags/maintenance/update_science_museum_urls.py
+++ b/catalog/dags/maintenance/update_science_museum_urls.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = "update_science_museum_urls"
 INVALID_IDS_TABLE = "science_museum_invalid_ids"
+IDS_TO_UPDATE_TABLE = "temp_science_museum_rows_to_validate"
 
 UPDATE_URLS_QUERY = dedent(
     """
@@ -44,6 +45,22 @@ CREATE_TABLE_QUERY = dedent(
     f"""
     CREATE TABLE IF NOT EXISTS {INVALID_IDS_TABLE}
     (identifier uuid);
+    """
+)
+CREATE_TEMP_TABLE_QUERY = dedent(
+    f"""
+    CREATE TABLE {IDS_TO_UPDATE_TABLE} AS
+    SELECT ROW_NUMBER() OVER() row_id, identifier, url
+    FROM image
+    WHERE provider='sciencemuseum';
+    """
+)
+DROP_TEMP_TABLE_QUERY = f"DROP TABLE {IDS_TO_UPDATE_TABLE};"
+GET_BATCH_QUERY = dedent(
+    """
+    SELECT identifier, url
+    FROM {table_name}
+    WHERE row_id > {start} AND row_id <= {end};
     """
 )
 
@@ -65,24 +82,31 @@ def run_sql(
 
 @task
 def get_batches(
+    total_count: int,
     batch_size: int,
+):
+    return [
+        {"start": i, "end": i + batch_size} for i in range(0, total_count, batch_size)
+    ]
+
+
+@task(max_active_tis_per_dagrun=3)
+def process_batch(
+    start: int,
+    end: int,
     postgres_conn_id: str = POSTGRES_CONN_ID,
     task: AbstractOperator = None,
 ):
+    invalid_ids = []
+
     postgres = PostgresHook(
         postgres_conn_id=postgres_conn_id,
         default_statement_timeout=PostgresHook.get_execution_timeout(task),
     )
     records = postgres.get_records(
-        "SELECT identifier, url FROM image where provider='sciencemuseum';"
+        GET_BATCH_QUERY.format(table_name=IDS_TO_UPDATE_TABLE, start=start, end=end)
     )
 
-    return [records[i : i + batch_size] for i in range(0, len(records), batch_size)]
-
-
-@task(max_active_tis_per_dagrun=3)
-def process_batch(records):
-    invalid_ids = []
     for identifier, url in records:
         # Failed to reach URL
         if rewrite_redirected_url(url) is None:
@@ -147,19 +171,33 @@ def update_science_museum_urls():
         sql=CREATE_TABLE_QUERY
     )
 
+    # Temp table used to store the information that needs to be
+    # validated.
+    create_temp_table = run_sql.override(task_id="create_temp_table")(
+        sql=CREATE_TEMP_TABLE_QUERY, handler=RETURN_ROW_COUNT
+    )
+
     # Split records into batches
-    batches = get_batches(batch_size="{{ params.batch_size }}")
+    batches = get_batches(
+        total_count=create_temp_table, batch_size="{{ params.batch_size }}"
+    )
 
     # Verify each record's url
-    process = process_batch.expand(records=batches)
+    process = process_batch.expand_kwargs(batches)
 
     # Record the identifiers of records with invalid urls
     record = record_invalid_ids(process)
+
+    # Drop the temp table.
+    drop_temp_table = run_sql.override(task_id="drop_temp_table")(
+        sql=DROP_TEMP_TABLE_QUERY
+    )
 
     # Report the number of invalid records to Slack
     notify_slack(record)
 
     update >> create_table >> process
+    record >> drop_temp_table
 
 
 update_science_museum_urls()

--- a/catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -17,6 +17,7 @@ from datetime import date
 from common import slack
 from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
+from common.urls import rewrite_redirected_url
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
@@ -166,9 +167,13 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
     def check_url(url: str | None) -> str | None:
         if not url:
             return None
-        if url.startswith("http"):
-            return url
-        return f"https://coimages.sciencemuseumgroup.org.uk/{url}"
+
+        # Will return None if url 403s
+        return rewrite_redirected_url(
+            url
+            if url.startswith("http")
+            else f"https://coimages.sciencemuseumgroup.org.uk/{url}"
+        )
 
     @staticmethod
     def _get_dimensions(image_data: dict) -> tuple[int | None, int | None]:

--- a/catalog/tests/dags/providers/provider_api_scripts/test_science_museum.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_science_museum.py
@@ -166,7 +166,7 @@ def test_get_record_data_success(object_data):
     expected_image_data = {
         "foreign_identifier": "i458349",
         "foreign_landing_url": "https://collection.sciencemuseumgroup.org.uk/objects/co84905/small-votive-organ-of-unknown-type-votive-viscera",
-        "url": "https://coimages.sciencemuseumgroup.org.uk/458/349/large_a659676__0001_.jpg",
+        "url": "https://coimages.sciencemuseumgroup.org.uk/458/349/large_a659676__0001_.jpg/",
         "height": 1150,
         "width": 1536,
         "filetype": "jpeg",
@@ -216,7 +216,7 @@ def test_image_info_large():
     )
     expected_image = (
         "https://coimages.sciencemuseumgroup.org.uk/3/563/"
-        "large_1999_0299_0001__0002_.jpg"
+        "large_1999_0299_0001__0002_.jpg/"
     )
     expected_height = 1022
     expected_width = 1536
@@ -238,7 +238,7 @@ def test_image_info_medium():
 
     expected_image = (
         "https://coimages.sciencemuseumgroup.org.uk/3/563/"
-        "medium_1999_0299_0001__0002_.jpg"
+        "medium_1999_0299_0001__0002_.jpg/"
     )
     expected_height = 576
     expected_width = 866
@@ -267,7 +267,7 @@ def test_check_relative_url():
     actual_url = sm.check_url(rel_url)
     expected_url = (
         "https://coimages.sciencemuseumgroup.org.uk/3/563/"
-        "large_thumbnail_1999_0299_0001__0002_.jpg"
+        "large_thumbnail_1999_0299_0001__0002_.jpg/"
     )
 
     assert actual_url == expected_url
@@ -276,7 +276,7 @@ def test_check_relative_url():
 def test_check_complete_url():
     url = (
         "https://coimages.sciencemuseumgroup.org.uk/3/563/"
-        "large_thumbnail_1999_0299_0001__0002_.jpg"
+        "large_thumbnail_1999_0299_0001__0002_.jpg/"
     )
     actual_url = sm.check_url(url)
     expected_url = url

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -72,6 +72,7 @@ The following are DAGs grouped by their primary tag:
 | [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow) | `@monthly`        |
 | [`pr_review_reminders`](#pr_review_reminders)                               | `0 0 * * 1-5`     |
 | [`rotate_db_snapshots`](#rotate_db_snapshots)                               | `0 0 * * 6`       |
+| [`update_science_museum_urls`](#update_science_museum_urls)                 | `None`            |
 
 ### Oauth
 
@@ -170,6 +171,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`smk_workflow`](#smk_workflow)
 1.  [`staging_database_restore`](#staging_database_restore)
 1.  [`stocksnap_workflow`](#stocksnap_workflow)
+1.  [`update_science_museum_urls`](#update_science_museum_urls)
 1.  [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)
 1.  [`wikimedia_reingestion_workflow`](#wikimedia_commons_workflow)
 1.  [`wordpress_workflow`](#wordpress_workflow)
@@ -1052,6 +1054,26 @@ Output: TSV file containing the image, the respective meta-data.
 Notes: <https://stocksnap.io/api/load-photos/date/desc/1>
 <https://stocksnap.io/faq> All images are licensed under CC0. No rate limits or
 authorization required. API is undocumented.
+
+----
+
+### `update_science_museum_urls`
+
+#### Update Science Museum URLs
+
+One-time maintenance DAG to update Science Museum records to have valid URLs.
+See https://github.com/WordPress/openverse/issues/4261.
+
+For each Science Museum record, this DAG:
+
+- updates the url to the new format, excluding `/images/` in the path if it
+  exists
+- validates whether the url . If not, the record ID is added to an
+  `invalid_science_musem_ids` table.
+
+Once complete, we can use the `invalid_science_museum_ids` to identify records
+to delete. They are not automatically deleted by this DAG, in order to give us
+an opportunity to first see how many there are.
 
 ----
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -26,9 +26,10 @@ The following are DAGs grouped by their primary tag:
 
 ### Data Normalization
 
-| DAG ID                                | Schedule Interval |
-| ------------------------------------- | ----------------- |
-| [`add_license_url`](#add_license_url) | `None`            |
+| DAG ID                                                      | Schedule Interval |
+| ----------------------------------------------------------- | ----------------- |
+| [`add_license_url`](#add_license_url)                       | `None`            |
+| [`update_science_museum_urls`](#update_science_museum_urls) | `None`            |
 
 ### Data Refresh
 
@@ -72,7 +73,6 @@ The following are DAGs grouped by their primary tag:
 | [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow) | `@monthly`        |
 | [`pr_review_reminders`](#pr_review_reminders)                               | `0 0 * * 1-5`     |
 | [`rotate_db_snapshots`](#rotate_db_snapshots)                               | `0 0 * * 6`       |
-| [`update_science_museum_urls`](#update_science_museum_urls)                 | `None`            |
 
 ### Oauth
 
@@ -1068,10 +1068,10 @@ For each Science Museum record, this DAG:
 
 - updates the url to the new format, excluding `/images/` in the path if it
   exists
-- validates whether the url . If not, the record ID is added to an
+- validates whether the url is reachable. If not, the record ID is added to an
   `invalid_science_musem_ids` table.
 
-Once complete, we can use the `invalid_science_museum_ids` to identify records
+Once complete, we can use the `science_museum_invalid_ids` to identify records
 to delete. They are not automatically deleted by this DAG, in order to give us
 an opportunity to first see how many there are.
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4261 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Hopefully this should be the final change needed to get Science Museum back in shape after the API updates in #4105.

The problem is that even though we're now formatting URLs properly:
* We have about 20k records that are not being reingested (possibly because we have to skip some batches due to an error with the provider API), and whose URLs are therefore not reformatted
* Even when the URLs _are_ reformatted, some portion of those continue to 403

We don't want to ingest records with broken links. So this PR does two things:

* Updates the Science Museum DAG to discard records whose URL cannot be reached
* Adds a one-time maintenance DAG which will be used to update and validate all of our existing records, including ones that are not being picked up by ingestion

<img width="1159" alt="Screenshot 2024-05-09 at 12 11 36 PM" src="https://github.com/WordPress/openverse/assets/63313398/eb7a4d7f-a8ea-482e-aa2b-04fc71c5c286">


This DAG will go back and correctly format all existing urls, and then check to see if the url is reachable. Since I don't know how many records will turn out to be unreachable, I have not opted to make the DAG automatically delete these records, just record their identifiers in a new table. Once the DAG runs, we'll be able to see how many are invalid and either investigate further or manually delete them using the recorded ids.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the Science Museum DAG and ensure that it still works. Let it ingest a few hundred records and then mark it as a success.

To test the maintenance DAG we will need to make sure we have at least one record which is invalid. You can do this manually by running `just catalog/pgcli` and then:

```sql
-- Update a record's URL to a url that is incorrectly formatted (contains '/images/'), AND
-- is known to 403 even when formatted correctly.
UPDATE image
SET url='https://coimages.sciencemuseumgroup.org.uk/images/206/868/large_cd0568_011_091005_2009_43_2_NEC_mobile_phone.jpg'
WHERE identifier IN (
   SELECT identifier
   FROM image
   WHERE provider='sciencemuseum'
   LIMIT 1
);
```

Then run the `update_science_museum_urls` DAG and verify that everything passes and one record id is added to the `science_museum_invalid_ids` table.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
