### PR TITLE
Tag API images with PDM content hash

### DIFF
--- a/api/compose.yml
+++ b/api/compose.yml
@@ -17,7 +17,7 @@ services:
         - SEMANTIC_VERSION=${SEMANTIC_VERSION:-v1.0.0}
         - API_PY_VERSION
         - PDM_INSTALL_ARGS=--dev
-    image: openverse-api
+    image: openverse-api:${API_PDM_HASH:-latest}
     volumes:
       - .:/api:z
       - ../packages/python:/packages/python:z

--- a/api/justfile
+++ b/api/justfile
@@ -16,8 +16,13 @@ NO_COLOR := "\\033[0m"
 
 # These commands use standard GNU tools instead of `pdm` because we do not
 # require PDM on the host machine for API development.
+export API_PDM_HASH := `grep 'content_hash' pdm.lock | awk -F'[:"]' '{print $3}'`
 export API_PY_VERSION := `grep 'requires-python' pyproject.toml | awk -F'"' '{print $2}' | sed 's/^==//g; s/\.\*$//g'`
 export PGCLI_VERSION := `grep -A 1 'name = "pgcli"' pdm.lock | grep 'version' | awk -F'"' '{print $2}'`
+
+# Print the PDM content hash as a unique identifier for the current set of packages
+@pdm-hash:
+    echo $API_PDM_HASH
 
 # Print the Python version specified in `pyproject.toml`
 @py-version:

--- a/justfile
+++ b/justfile
@@ -136,6 +136,7 @@ EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 export CATALOG_PY_VERSION := `just catalog/py-version`
 export CATALOG_AIRFLOW_VERSION := `just catalog/airflow-version`
 export API_PY_VERSION := `just api/py-version`
+export API_PDM_HASH := `just api/pdm-hash`
 export INGESTION_PY_VERSION := `just ingestion_server/py-version`
 export FRONTEND_NODE_VERSION := `just frontend/node-version`
 export FRONTEND_PNPM_VERSION := `just frontend/pnpm-version`


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR extracts the content hash from the PDM lockfile and uses that to tag the API image during development so that the image is automatically rebuilt on `just api/up` if the packages have changed.

This means that you will no longer receive messages like in the API container logs:

```
ModuleNotFoundError: No module named 'xyz'
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Check out the PR.
1. Build the `web` image: `just dc build web`.
2. See the tagged image: `docker image ls`.
3. Add a PDM package: `cd api && pdm add cowsay`.
4. Bring up the `web` service: `just api/up`.
5. You should see that it's building the image again because the packages have changed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
