### PR TITLE
Rough draft of contributor help script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !.pnpmfile.cjs
 !pnpm-lock.yaml
 !tsconfig.base.json
+!get-started.sh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,3 +46,4 @@ README.md                   @WordPress/openverse-maintainers
 docker-compose.yml          @WordPress/openverse-maintainers
 env.template                @WordPress/openverse-maintainers
 justfile                    @WordPress/openverse-maintainers
+get-started.sh              @WordPress/openverse-maintainers

--- a/Dockerfile.get-started-test
+++ b/Dockerfile.get-started-test
@@ -1,0 +1,7 @@
+FROM debian
+
+WORKDIR /app
+
+COPY get-started.sh /app/get-started.sh
+
+CMD ["/app/get-started.sh"]

--- a/Dockerfile.get-started-test
+++ b/Dockerfile.get-started-test
@@ -1,7 +1,57 @@
-FROM debian
+# Use arch because all these dependencies are available as easy-to-install packages in
+# the default repositories. For testing purposes, it's the easiest way to go and least fussy
+# installation methods.
+FROM archlinux as no-deps
+
+RUN pacman -Syu --noconfirm which
 
 WORKDIR /app
 
 COPY get-started.sh /app/get-started.sh
 
 CMD ["/app/get-started.sh"]
+
+FROM no-deps as with-python
+
+RUN pacman -Syu --noconfirm python
+
+FROM no-deps as with-just
+
+RUN pacman -Syu --noconfirm just
+
+FROM no-deps as with-docker
+
+RUN pacman -Syu --noconfirm docker
+
+FROM with-docker as with-docker-compose
+
+RUN pacman -Syu --noconfirm docker-compose
+
+FROM with-docker as with-docker-buildx
+
+RUN pacman -Syu --noconfirm docker-buildx
+
+FROM no-deps as with-node
+
+# Includes corepack
+RUN pacman -Syu --noconfirm nodejs
+
+FROM with-node as no-corepack
+
+RUN rm /usr/bin/corepack
+
+FROM no-deps as with-pnpm-direct
+
+# pnpm package also installs python via its dependency on the git package
+# pnpm -> git -> python
+RUN pacman -Syu --noconfirm pnpm \
+  && rm /usr/bin/python /usr/bin/python3 /usr/bin/python3.12
+
+FROM no-deps as with-everything
+
+RUN pacman -Syu --noconfirm \
+  nodejs \
+  python \
+  docker \
+  docker-compose \
+  just

--- a/api/manage.py
+++ b/api/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 
 import asyncio

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -38,7 +38,7 @@ venv:
 
 # Check that the active Python version matches the required Python version
 check-py-version:
-    #!/usr/bin/env python
+    #!/usr/bin/env python3
     import os
     import sys
     current = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/documentation/general/general_setup.md
+++ b/documentation/general/general_setup.md
@@ -55,6 +55,26 @@ required.
 The following setup steps are needed to set up a local copy of Openverse and do
 not prepare you to contribute code to the project.
 
+### Get started help script
+
+````{tip}
+If you have at least `git` installed, you can clone the repository, then run
+the `get-started.sh` script:
+
+```shell
+git clone https://github.com/WordPress/openverse
+
+cd openverse
+./get-started.sh
+```
+
+The `get-started.sh` script will check for each of the required development
+dependencies and suggest installation methods appropriate for your system.
+
+You may also refer to the individual sections below for each of the required
+tools.
+````
+
 ### Git
 
 Openverse is Git-tracked. To clone Openverse locally, you will need to install

--- a/get-started.sh
+++ b/get-started.sh
@@ -1,0 +1,108 @@
+#! /usr/bin/env sh
+
+cat <<'EOF'
+Welcome to...
+
+   ____
+  / __ \
+ | |  | |_ __   ___ _ ____   _____ _ __ ___  ___
+ | |  | | '_ \ / _ \ '_ \ \ / / _ \ '__/ __|/ _ \
+ | |__| | |_) |  __/ | | \ V /  __/ |  \__ \  __/
+  \____/| .__/ \___|_| |_|\_/ \___|_|  |___/\___|
+        | |
+        |_|
+
+This script will check your local development environment for the tools required to work on Openverse.
+
+If anything is missing, it will let you know, and provide a suggestion for where to find it.
+EOF
+
+missing_deps=0
+
+case $(uname -o) in
+GNU/Linux*)
+  py_install_url="https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python"
+  just_install_suggestion="
+    Try installing 'just' using your OS's package manager: https://github.com/casey/just?tab=readme-ov-file#packages
+
+    For debian or debian-derived systems (like Ubuntu) that do not have makedeb configured,
+    'just' also provides pre-built binaries. However, you'll need to manually keep them updated:
+
+    https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries
+    "
+  ;;
+
+Darwin)
+  py_install_url="https://docs.python.org/3/using/mac.html#getting-and-installing-python"
+  just_install_suggestion="
+    'just' is available through homebrew: https://formulae.brew.sh/formula/just
+    "
+  ;;
+
+*)
+  echo "Openverse development is only supported on Linux and macOS. Windows users must use WSL to run the Openverse development environment."
+  exit 1
+  ;;
+
+esac
+
+for python_binary in python python3; do
+  if which "$python_binary"; then
+    python_version=$("$python_binary" -c "import sys; print(sys.version_info > (3, 11, 0))")
+    if [ "$python_version" = "True" ]; then
+      has_python=1
+      break
+    fi
+  fi
+done
+
+if [ "$has_python" != "1" ]; then
+  missing_deps=1
+
+  echo "
+  Python 3.11 or later could not be found on your system. Please update or install Python according to the instructions from the Python Foundation:
+  $py_install_url
+  "
+fi
+
+if ! which just; then
+  missing_deps=1
+  echo "The 'just' command runner could not be found on your system.$just_install_suggestion"
+fi
+
+if ! which docker; then
+  missing_deps=1
+  echo "
+  Docker is missing from your system. Install it and Docker compose using Docker's instructions.
+
+  Docker engine: https://docs.docker.com/engine/install/
+  Docker compose: https://docs.docker.com/compose/install/
+
+  Podman is not currently supported for Openverse development.
+  "
+else
+  if ! docker compose 2>/dev/null 1>/dev/null; then
+    missing_deps=1
+    echo "
+    Docker compose is missing from your system. Install it using Docker's instructions:
+
+    https://docs.docker.com/compose/install/
+    "
+  fi
+fi
+
+if ! which pnpm; then
+  if which corepack; then
+    echo "Enabling corepack for pnpm"
+    corepack enable pnpm
+  else
+    missing_deps=1
+    echo "
+    pnpm is missing from your system, and corepack was unavailable to automatically install it using standard Node.js tooling.
+
+    Install it using pnpm's installation instructions: https://pnpm.io/installation#on-posix-systems
+    "
+  fi
+fi
+
+exit "$missing_deps"

--- a/get-started.sh
+++ b/get-started.sh
@@ -19,33 +19,50 @@ EOF
 
 missing_deps=0
 
+linux_just_install_suggestion=$(
+  cat <<-'EOF'
+Try installing 'just' using your OS's package manager: https://github.com/casey/just?tab=readme-ov-file#packages
+
+For debian or debian-derived systems (like Ubuntu) that do not have makedeb configured,
+'just' also provides pre-built binaries. However, you'll need to manually keep them updated:
+
+https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries
+
+Alternatively, you may prefer using the `just-install` NPM package, endorsed by the `just` project:
+
+https://github.com/brombal/just-install#readme
+EOF
+)
+
+macos_just_install_suggestion="
+'just' is available through homebrew: https://formulae.brew.sh/formula/just
+"
+
+py_install_suggestion="
+====== Python language ======
+
+Python 3.11 or later could not be found on your system. Please update or install Python according to the instructions from the Python Foundation:
+"
+
 case $(uname -o) in
 GNU/Linux*)
-  py_install_url="https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python"
-  just_install_suggestion="
-    Try installing 'just' using your OS's package manager: https://github.com/casey/just?tab=readme-ov-file#packages
-
-    For debian or debian-derived systems (like Ubuntu) that do not have makedeb configured,
-    'just' also provides pre-built binaries. However, you'll need to manually keep them updated:
-
-    https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries
-    "
+  py_install_suggestion="$py_install_suggestion\nhttps://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python"
+  just_install_suggestion="$linux_just_install_suggestion"
   ;;
 
 Darwin)
-  py_install_url="https://docs.python.org/3/using/mac.html#getting-and-installing-python"
-  just_install_suggestion="
-    'just' is available through homebrew: https://formulae.brew.sh/formula/just
-    "
+  py_install_suggestion="$py_install_suggestion\nhttps://docs.python.org/3/using/mac.html#getting-and-installing-python"
+  just_install_suggestion="$macos_just_install_suggestion"
   ;;
 
 *)
-  echo "Openverse development is only supported on Linux and macOS. Windows users must use WSL to run the Openverse development environment."
+  printf "Openverse development is only supported on Linux and macOS. Windows users must use WSL to run the Openverse development environment."
   exit 1
   ;;
 
 esac
 
+has_python=0
 for python_binary in python python3; do
   if which "$python_binary"; then
     python_version=$("$python_binary" -c "import sys; print(sys.version_info > (3, 11, 0))")
@@ -59,37 +76,57 @@ done
 if [ "$has_python" != "1" ]; then
   missing_deps=1
 
-  echo "
-  Python 3.11 or later could not be found on your system. Please update or install Python according to the instructions from the Python Foundation:
-  $py_install_url
-  "
+  printf "\n%s\n" "$py_install_suggestion"
 fi
 
 if ! which just; then
   missing_deps=1
+  printf "\n\n====== 'just' command runner ======\n"
   echo "The 'just' command runner could not be found on your system.$just_install_suggestion"
 fi
 
+docker_install_suggestion="
+
+====== Docker container runtime ======
+
+Docker is missing from your system. Install it and Docker compose using Docker's instructions.
+
+Docker engine: https://docs.docker.com/engine/install/
+Docker compose: https://docs.docker.com/compose/install/
+
+Podman is not currently supported for Openverse development.
+"
+
+compose_install_suggestion="
+
+====== Docker compose plugin ======
+
+Docker compose is missing from your system. Install it using Docker's instructions:
+
+https://docs.docker.com/compose/install/
+"
+
 if ! which docker; then
   missing_deps=1
-  echo "
-  Docker is missing from your system. Install it and Docker compose using Docker's instructions.
-
-  Docker engine: https://docs.docker.com/engine/install/
-  Docker compose: https://docs.docker.com/compose/install/
-
-  Podman is not currently supported for Openverse development.
-  "
+  echo "$docker_install_suggestion"
 else
   if ! docker compose 2>/dev/null 1>/dev/null; then
     missing_deps=1
-    echo "
-    Docker compose is missing from your system. Install it using Docker's instructions:
-
-    https://docs.docker.com/compose/install/
-    "
+    echo "$compose_install_suggestion"
   fi
 fi
+
+pnpm_install_suggestion="
+====== pnpm Node.js package manager ======
+
+pnpm is missing from your system, and corepack was unavailable to automatically install it using standard Node.js tooling.
+
+For ease of use, Corepack is highly recommended and is the most flexible approach to Node.js package manager installation.
+
+Refer to Corepack's documentation for installation instructions: https://github.com/nodejs/corepack?tab=readme-ov-file#how-to-install
+
+Alternatively, to install pnpm directly, refer to pnpm's installation instructions: https://pnpm.io/installation#on-posix-systems
+"
 
 if ! which pnpm; then
   if which corepack; then
@@ -97,11 +134,7 @@ if ! which pnpm; then
     corepack enable pnpm
   else
     missing_deps=1
-    echo "
-    pnpm is missing from your system, and corepack was unavailable to automatically install it using standard Node.js tooling.
-
-    Install it using pnpm's installation instructions: https://pnpm.io/installation#on-posix-systems
-    "
+    echo "$pnpm_install_suggestion"
   fi
 fi
 

--- a/justfile
+++ b/justfile
@@ -283,3 +283,8 @@ f:
 # alias for `pnpm --filter {package} run {script}`
 p package script +args="":
     pnpm --filter {{ package }} run {{ script }} {{ args }}
+
+
+test-get-started stage:
+    docker build -t get-started-test:{{ stage }} -f Dockerfile.get-started-test --target {{ stage }} .
+    docker run get-started-test:{{ stage }}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4137 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a new script `get-started.sh` for contributors to run. The script checks for dependencies on their system and gives suggestions for how to install them.

I've gone with a basic approach here, and we can expand or change references however we see fit. One thing I've noticed is that the installation suggestions naturally overlap with the documentation we have in the getting started page. Is there a reasonable way to merge these? Should we go "all in" on the script? Or should the script refer to the documentation pages instead of putting the suggestions in-line? The latter is probably the clearest and easiest way to remove the duplication. What do y'all think?

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I've added a temporary Dockerfile and just recipe to make testing the different scenarios as easy as possible.

Run `just test-get-started <target>` with each of the targets defined in `Dockerfile.get-started-test`:

- no-deps
- with-python
- with-just
- with-docker
- with-docker-compose
- with-node
- with-pnpm-direct
- with-everything

I'll remove the Dockerfile and the just recipe before merging.

<details>
<summary>Output when there's nothing missing</summary>

```
Welcome to...                                                                                                                                      

   ____
  / __ \
 | |  | |_ __   ___ _ ____   _____ _ __ ___  ___
 | |  | | '_ \ / _ \ '_ \ \ / / _ \ '__/ __|/ _ \
 | |__| | |_) |  __/ | | \ V /  __/ |  \__ \  __/
  \____/| .__/ \___|_| |_|\_/ \___|_|  |___/\___|
        | |
        |_|

This script will check your local development environment for the tools required to work on Openverse.

If anything is missing, it will let you know, and provide a suggestion for where to find it.


Enabling corepack in the repository for pnpm!

Congrats! Your system appears to be all set up for Openverse development!

Try running 'just install' followed by 'just up' and then 'just init'.

Further setup instructions can be found in the quick start guide.
The guide also includes instructions for setting up individual parts of the Openverse stack.

https://docs.openverse.org/general/quickstart.html
```
</details>

<details>
<summary>Output when everything is missing</summary>

```
Welcome to...

   ____
  / __ \
 | |  | |_ __   ___ _ ____   _____ _ __ ___  ___
 | |  | | '_ \ / _ \ '_ \ \ / / _ \ '__/ __|/ _ \
 | |__| | |_) |  __/ | | \ V /  __/ |  \__ \  __/
  \____/| .__/ \___|_| |_|\_/ \___|_|  |___/\___|
        | |
        |_|

This script will check your local development environment for the tools required to work on Openverse.

If anything is missing, it will let you know, and provide a suggestion for where to find it.



====== Python language ======

Python 3.11 or later could not be found on your system.
Please update or install Python according to the instructions from the Python Foundation:

https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python


====== 'just' command runner ======
The 'just' command runner could not be found on your system.
Try installing 'just' using your OS's package manager: https://github.com/casey/just?tab=readme-ov-file#packages

For debian or debian-derived systems (like Ubuntu) that do not have makedeb configured,
'just' also provides pre-built binaries. However, you'll need to manually keep them updated:

https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries

Alternatively, you may prefer using the 'just-install' NPM package, endorsed by the 'just' project:

https://github.com/brombal/just-install#readme


====== Docker container runtime ======

Docker is missing from your system. Install it and Docker compose using Docker's instructions.

Docker engine: https://docs.docker.com/engine/install/
Docker compose: https://docs.docker.com/compose/install/

Podman is not currently supported for Openverse development.


====== pnpm Node.js package manager ======

pnpm is missing from your system, and corepack was unavailable to automatically install it using standard Node.js tooling.

For ease of use, Corepack is highly recommended and is the most flexible approach to Node.js package manager installation.

Refer to Corepack's documentation for installation instructions: https://github.com/nodejs/corepack?tab=readme-ov-file#how-to-install

Alternatively, to install pnpm directly, refer to pnpm's installation instructions: https://pnpm.io/installation#on-posix-systems


I detected the following missing dependencies:
- pnpm package manager
- Docker container runtime
- Just command runner
- Python 3.11 or greater
```
</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
