### PR TITLE
Initialize feature flag state on the server

### DIFF
--- a/frontend/src/pages/preferences.vue
+++ b/frontend/src/pages/preferences.vue
@@ -8,8 +8,8 @@
     it doesn't count as a user preference.
     -->
     <div
-      v-for="(group, groupIndex) in featureData.groups"
-      :key="groupIndex"
+      v-for="group in featureGroups"
+      :key="group.title"
       class="not-prose border-b border-dark-charcoal-20 py-6 last-of-type:border-b-0"
     >
       <h2 class="label-bold mb-2">
@@ -22,52 +22,52 @@
       </p>
       <ul>
         <li
-          v-for="(name, featureIndex) in group.features"
-          :key="featureIndex"
+          v-for="flag in group.features"
+          :key="flag.name"
           class="mb-4 last:mb-0"
         >
           <VCheckbox
-            v-if="isFlagName(name) && isSwitchable(name)"
-            :id="name"
+            v-if="flag.status === SWITCHABLE"
+            :id="flag.name"
             class="flex-row items-center"
-            :checked="isOn(name)"
+            :checked="flag.state === ON"
             is-switch
             @change="handleChange"
-            >{{ $t(`prefPage.features.${name}`) }}</VCheckbox
+            >{{ $t(`prefPage.features.${flag.name}`) }}</VCheckbox
           >
         </li>
       </ul>
     </div>
 
     <div
-      v-for="isFlagSwitchable in [false, true]"
-      :key="`${isFlagSwitchable}`"
+      v-for="isSwitchable in [false, true]"
+      :key="`${isSwitchable}`"
       class="not-prose border-b border-dark-charcoal-20 py-6 last-of-type:border-b-0"
     >
       <h2 class="label-bold mb-2">
-        {{ $t(`prefPage.${isFlagSwitchable ? "s" : "nonS"}witchable.title`) }}
+        {{ $t(`prefPage.${isSwitchable ? "s" : "nonS"}witchable.title`) }}
       </h2>
       <p class="label-regular mb-4">
-        {{ $t(`prefPage.${isFlagSwitchable ? "s" : "nonS"}witchable.desc`) }}
+        {{ $t(`prefPage.${isSwitchable ? "s" : "nonS"}witchable.desc`) }}
       </p>
       <ul>
         <li
-          v-for="[name, feature] in getFlagsBySwitchable(isFlagSwitchable)"
-          :key="name"
+          v-for="flag in flagsBySwitchable[`${isSwitchable}`]"
+          :key="flag.name"
           class="mb-4 flex flex-row items-center last:mb-0"
         >
           <VCheckbox
-            :id="name"
+            :id="flag.name"
             class="flex-row items-center"
-            :checked="isOn(name)"
-            :disabled="!isFlagSwitchable"
+            :checked="flag.state === ON"
+            :disabled="flag.status !== SWITCHABLE"
             is-switch
             @change="handleChange"
           >
             <div>
-              <strong>{{ name }}</strong>
+              <strong>{{ flag.name }}</strong>
               <br />
-              {{ feature.description }}
+              {{ flag.description }}
             </div>
           </VCheckbox>
         </li>
@@ -83,9 +83,7 @@
 import { computed } from "vue"
 import { defineComponent } from "@nuxtjs/composition-api"
 
-import featureData from "~~/feat/feature-flags.json"
-
-import { useFeatureFlagStore, isFlagName } from "~/stores/feature-flag"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
 import { SWITCHABLE, ON, OFF, FEATURE_STATES } from "~/constants/feature-flag"
 
 import VContentPage from "~/components/VContentPage.vue"
@@ -115,37 +113,19 @@ export default defineComponent({
       name: string
       checked?: boolean
     }) => {
-      if (!isFlagName(name)) {
-        throw new Error(
-          `Cannot change the state of flag ${name}: it does not exist.`
-        )
-      }
       featureFlagStore.toggleFeature(name, checked ? ON : OFF)
     }
 
-    const isOn = (name: string) => {
-      if (!isFlagName(name)) {
-        throw new Error(
-          `Cannot check the state of flag ${name}: it does not exist.`
-        )
+    const flagsBySwitchable = computed(() => {
+      return {
+        true: featureFlagStore.getFlagsBySwitchable(true),
+        false: featureFlagStore.getFlagsBySwitchable(false),
       }
-      return featureFlagStore.isOn(name)
-    }
+    })
 
-    const isSwitchable = (name: string) => {
-      if (!isFlagName(name)) {
-        throw new Error(
-          `Cannot check the switchability of flag ${name}: it does not exist.`
-        )
-      }
-      return featureFlagStore.isSwitchable(name)
-    }
-
-    const getFlagsBySwitchable = (switchable: boolean) => {
-      return Object.entries(flags.value).filter(
-        ([name]) => isSwitchable(name) === switchable
-      )
-    }
+    const featureGroups = computed(() => {
+      return featureFlagStore.getFeatureGroups()
+    })
 
     return {
       ON,
@@ -154,14 +134,11 @@ export default defineComponent({
       FEATURE_STATES,
 
       flags,
-      isOn,
-      isSwitchable,
 
       handleChange,
-      isFlagName,
 
-      featureData,
-      getFlagsBySwitchable,
+      flagsBySwitchable,
+      featureGroups,
     }
   },
 })

--- a/frontend/src/types/feature-flag.ts
+++ b/frontend/src/types/feature-flag.ts
@@ -1,3 +1,5 @@
+import featureData from "~~/feat/feature-flags.json"
+
 import type {
   FeatureState,
   FlagStatus,
@@ -5,15 +7,30 @@ import type {
 } from "~/constants/feature-flag"
 import type { DeployEnv } from "~/constants/deploy-env"
 
-export interface FeatureFlag {
-  status: FlagStatus | Record<DeployEnv, FlagStatus>
+export type FlagName = keyof (typeof featureData)["features"]
+
+export type FlagStatusRecord = string | Partial<Record<DeployEnv, string>>
+/**
+ * The record of a feature flag from the json file.
+ */
+export interface FeatureFlagRecord {
+  status: FlagStatusRecord
   description?: string
   data?: unknown
 
   defaultState?: FeatureState
-  preferredState?: FeatureState // only set for switchable flag with known preference
 
   supportsQuery?: boolean // default: true
 
   storage: Storage
+}
+
+/**
+ * The feature flag with the status resolved based on the current environment.
+ */
+export type FeatureFlag = Omit<FeatureFlagRecord, "status"> & {
+  name: keyof (typeof featureData)["features"]
+  status: FlagStatus
+  state: FeatureState
+  preferredState: FeatureState | undefined
 }

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -4,10 +4,8 @@ import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 
 import featureData from "~~/feat/feature-flags.json"
 
-import { _getFlagStatus, type FlagName } from "~/stores/feature-flag"
-import type { FeatureFlag } from "~/types/feature-flag"
-
-const deployEnv = "staging" as const
+import { getFlagStatus } from "~/stores/feature-flag"
+import type { FeatureFlag, FlagName } from "~/types/feature-flag"
 
 const getFeatureCookies = async (page: Page, cookieName: string) => {
   const cookies = await page.context().cookies()
@@ -30,7 +28,7 @@ const getFeaturesToTest = () => {
   } as const
   for (const [name, state] of Object.entries(testableFeatures)) {
     const flag = featureData.features[name as FlagName] as FeatureFlag
-    if (_getFlagStatus(flag, deployEnv) !== "switchable") {
+    if (getFlagStatus(flag) !== "switchable") {
       throw new Error(`Feature ${name} is not switchable`)
     }
     if (flag.defaultState !== state) {

--- a/frontend/test/unit/specs/stores/feature-flag-store.spec.js
+++ b/frontend/test/unit/specs/stores/feature-flag-store.spec.js
@@ -51,8 +51,14 @@ jest.mock(
 )
 
 describe("Feature flag store", () => {
+  let initialEnv
   beforeEach(() => {
     setActivePinia(createPinia())
+    initialEnv = process.env.DEPLOYMENT_ENV
+  })
+
+  afterEach(() => {
+    process.env.DEPLOYMENT_ENV = initialEnv
   })
 
   it("initialises state from JSON", () => {
@@ -145,7 +151,7 @@ describe("Feature flag store", () => {
   `(
     "returns $featureState for $environment",
     ({ environment, featureState }) => {
-      const initialValue = process.env.DEPLOYMENT_ENV
+      // The value is cleaned up in afterEach
       process.env.DEPLOYMENT_ENV = environment
       const featureFlagStore = useFeatureFlagStore()
 
@@ -155,7 +161,6 @@ describe("Feature flag store", () => {
       expect(featureFlagStore.isOn("feat_env_specific")).toEqual(
         featureState === "on"
       )
-      process.env.DEPLOYMENT_ENV = initialValue
     }
   )
 
@@ -167,13 +172,12 @@ describe("Feature flag store", () => {
   `(
     "handles fallback for missing $environment",
     ({ environment, flagStatus }) => {
-      const initialValue = process.env.DEPLOYMENT_ENV
+      // The value is cleaned up in afterEach
       process.env.DEPLOYMENT_ENV = environment
       const actualStatus = getFlagStatus({
         status: { staging: "switchable" },
       })
       expect(actualStatus).toEqual(flagStatus)
-      process.env.DEPLOYMENT_ENV = initialValue
     }
   )
 

--- a/frontend/test/unit/specs/stores/search-store.spec.js
+++ b/frontend/test/unit/specs/stores/search-store.spec.js
@@ -491,6 +491,8 @@ describe("Search Store", () => {
     `(
       "changing searchType from $searchType clears all but $expectedFilterCount $nextSearchType filters",
       async ({ searchType, nextSearchType, expectedFilterCount }) => {
+        // We need to switch on the additional_search_types feature flag
+        // to be able to switch to video.
         const featureFlagStore = useFeatureFlagStore()
         featureFlagStore.toggleFeature("additional_search_types", "on")
 

--- a/frontend/test/unit/specs/stores/search-store.spec.js
+++ b/frontend/test/unit/specs/stores/search-store.spec.js
@@ -491,11 +491,11 @@ describe("Search Store", () => {
     `(
       "changing searchType from $searchType clears all but $expectedFilterCount $nextSearchType filters",
       async ({ searchType, nextSearchType, expectedFilterCount }) => {
-        const searchStore = useSearchStore()
-        searchStore.setSearchType(searchType)
-
         const featureFlagStore = useFeatureFlagStore()
         featureFlagStore.toggleFeature("additional_search_types", "on")
+
+        const searchStore = useSearchStore()
+        searchStore.setSearchType(searchType)
 
         // Set all filters to checked
         for (let ft in searchStore.filters) {


### PR DESCRIPTION
## Fixes
Fixes #4223 by @obulat

## Description

This PR sets the flag states on the server init based on the `DEPLOYMENT_ENV` env variable, instead of checking the state every time we access the flag.

The filtering of flags by switchable or by feature groups was moved to the store, too, to simplify the component code.

## Testing instructions

The CI checks preferences and sensitive toggle, so the CI passing is a good indicator.
Go to `/preferences` and see that the features are displayed correctly and can be toggled.