### PR TITLE
Fix the aria label for search result grid

### DIFF
--- a/frontend/src/components/VSearchResultsGrid/VSearchResults.vue
+++ b/frontend/src/components/VSearchResultsGrid/VSearchResults.vue
@@ -102,7 +102,7 @@ export default defineComponent({
 
     const collectionLabel = computed(() => {
       return i18n
-        .t(`browsePage.aria.results.${props.results.type}`, {
+        .t(`browsePage.aria.resultsLabel.${props.results.type}`, {
           query: props.searchTerm,
         })
         .toString()

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -685,6 +685,11 @@
       creator: "search by creator",
       imageTitle: "Image: {title}",
       audioTitle: "Audio track: {title}",
+      /**
+       * These strings are used as aria-label of the list of the search results.
+       * The number of results is given in `results.mediaType`, so is not
+       * needed here.
+       */
       resultsLabel: {
         all: "All results for {query}",
         image: "Image results for {query}",

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -685,6 +685,11 @@
       creator: "search by creator",
       imageTitle: "Image: {title}",
       audioTitle: "Audio track: {title}",
+      resultsLabel: {
+        all: "All results for {query}",
+        image: "Image results for {query}",
+        audio: "Audio tracks for {query}",
+      },
       results: {
         /**
          * "imageResults" and "audioResults" are interpolated from the strings under


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4300 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the new result aria-labels for all/image/audio results. Since we show the result count in the page title, we don't need to add the result count to the grid label. 

The results grid (images/audio track boxes grid) should have a screen-reader label: "All/image/audio results for <query>".

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app locally using `just frontend/run dev:only`
Go to http://localhost:8443/search/image?q=cat)
Turn on the screen reader and navigate to the search results content list.
You should hear "Entering image results for cat content list" (on a Mac VoiceOver).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
