### PR TITLE
Fix Slack message formatting for ES health alert

### DIFF
--- a/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
+++ b/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
@@ -63,9 +63,9 @@ def _format_response_body(response_body: dict) -> str:
 
 def _compose_red_status(env: Environment, response_body: dict) -> str:
     message = f"""
-    Elasticsearch {env} cluster status is **red**.
+    Elasticsearch {env} cluster status is *red*.
 
-    This is a critical status change, **investigate ASAP**.
+    This is a critical status change, *investigate ASAP*.
 
     {_format_response_body(response_body)}
     """
@@ -78,13 +78,13 @@ def _compose_unexpected_node_count(env: Environment, response_body: dict) -> str
     master_node_count = node_count - data_node_count
 
     message = f"""
-    Elasticsearch {env} cluster node count is **{node_count}**.
+    Elasticsearch {env} cluster node count is *{node_count}*.
     Expected {EXPECTED_NODE_COUNT} total nodes.
 
-    Master nodes: **{master_node_count}** of expected {EXPECTED_MASTER_NODE_COUNT}
-    Data nodes: **{data_node_count}** of expected {EXPECTED_DATA_NODE_COUNT}
+    Master nodes: *{master_node_count}* of expected {EXPECTED_MASTER_NODE_COUNT}
+    Data nodes: *{data_node_count}* of expected {EXPECTED_DATA_NODE_COUNT}
 
-    This is a critical status change, **investigate ASAP**.
+    This is a critical status change, *investigate ASAP*.
     If this is expected (e.g., during controlled node or cluster changes), acknowledge immediately with explanation.
 
     {_format_response_body(response_body)}
@@ -95,7 +95,7 @@ def _compose_unexpected_node_count(env: Environment, response_body: dict) -> str
 
 def _compose_yellow_cluster_health(env: Environment, response_body: dict) -> str:
     message = f"""
-    Elasticsearch {env} cluster health is **yellow**.
+    Elasticsearch {env} cluster health is *yellow*.
 
     This does not mean something is necessarily wrong, but if this is not expected (e.g., data refresh) then investigate cluster health now.
 

--- a/catalog/tests/dags/elasticsearch_cluster/test_healthcheck_dag.py
+++ b/catalog/tests/dags/elasticsearch_cluster/test_healthcheck_dag.py
@@ -33,10 +33,10 @@ def _make_response_body(**kwargs):
 def _missing_node_keys(master_nodes: int, data_nodes: int):
     total_nodes = master_nodes + data_nodes
     return (
-        f"Elasticsearch {_TEST_ENV} cluster node count is **{total_nodes}**",
+        f"Elasticsearch {_TEST_ENV} cluster node count is *{total_nodes}*",
         "Expected 6 total nodes.",
-        f"Master nodes: **{master_nodes}** of expected 3",
-        f"Data nodes: **{data_nodes}** of expected 3",
+        f"Master nodes: *{master_nodes}* of expected 3",
+        f"Data nodes: *{data_nodes}* of expected 3",
     )
 
 
@@ -45,7 +45,7 @@ def _missing_node_keys(master_nodes: int, data_nodes: int):
     (
         pytest.param(
             "alert",
-            (f"Elasticsearch {_TEST_ENV} cluster status is **red**",),
+            (f"Elasticsearch {_TEST_ENV} cluster status is *red*",),
             _make_response_body(status="red"),
             id="red-status",
         ),
@@ -81,7 +81,7 @@ def _missing_node_keys(master_nodes: int, data_nodes: int):
         ),
         pytest.param(
             "notification",
-            (f"Elasticsearch {_TEST_ENV} cluster health is **yellow**.",),
+            (f"Elasticsearch {_TEST_ENV} cluster health is *yellow*.",),
             _make_response_body(
                 status="yellow",
             ),
@@ -127,4 +127,4 @@ def test_production_compose_notification_data_refresh_not_running():
     )
 
     assert message_type == "notification"
-    assert "Elasticsearch production cluster health is **yellow**." in message
+    assert "Elasticsearch production cluster health is *yellow*." in message


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Small issue I noticed while we've been receiving ES health Slack alerts:

![image](https://github.com/WordPress/openverse/assets/10214785/b858c04a-3996-47fc-ac61-1f4a825bc9a6)

Since Slack forming isn't actually markdown, the double asterisk `**` was showing up as unformatted when the message should have had bold text. This PR corrects the instances of `**` to use a single `*` instead which will bold the message in Slack.

![image](https://github.com/WordPress/openverse/assets/10214785/d22ff9fa-ecb3-44b3-abd2-4528d826f94e)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass.

You can also observe this locally by running the following (as a maintainer):

1. `just c i` (to start the catalog & ingestion server resources)
2. `j run webserver variables set SLACK_MESSAGE_OVERRIDE true` (to enable sending the message to Slack)
3. Enable the `staging_elasticsearch_cluster_healthcheck` DAG

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
