### PR TITLE
Prevent exposing Django Admin features referencing media tables in prod

### DIFF
--- a/api/api/admin/__init__.py
+++ b/api/api/admin/__init__.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group, User
@@ -55,8 +56,9 @@ for klass in [
     admin.site.register(klass, MediaSubreportAdmin)
 
 # Temporary addition of model admin for decisions while this view gets built
-admin.site.register(ImageDecision, admin.ModelAdmin)
-admin.site.register(AudioDecision, admin.ModelAdmin)
+if settings.ENVIRONMENT != "production":
+    admin.site.register(ImageDecision, admin.ModelAdmin)
+    admin.site.register(AudioDecision, admin.ModelAdmin)
 
 
 @admin.register(ContentProvider)

--- a/api/test/unit/admin/test_media_report.py
+++ b/api/test/unit/admin/test_media_report.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+from api.admin.media_report import _production_deferred
+
+
+@pytest.mark.parametrize(
+    "values, environment, expected",
+    [
+        ([1, 2, 3], "local", (1, 2, 3)),
+        ([1, 2, 3], "production", ()),
+        ([], "local", ()),
+        ([], "production", ()),
+    ],
+)
+def test_production_deferred(values, environment, expected):
+    with mock.patch("api.admin.media_report.settings") as mock_settings:
+        mock_settings.ENVIRONMENT = environment
+        actual = _production_deferred(*values)
+    assert actual == expected


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4344 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the Django Admin registrations for various media report related views in order to prevent exposing access to the primary media tables in production. Queries that are made to these tables are often naive and, for such a large table, cause significant issues. However, they're extremely useful to have when running the application locally in order to easily create/reference media while we build out the content safety reporting features.

This will necessarily reduce our available features in production, but because of the nature of the failure which caused this, we couldn't have used those features anyway!


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass. You can also verify this locally by:

1. `just api/init`
1. Visit http://localhost:50280/admin/ and observe that `Image Decision` shows up in the list of available models for site administration
1. Add `ENVIRONMENT=production` and `DJANGO_SECRET_KEY=blahblahblah` to `api/.env`
1. Run `just down && just a` to restart the API stack
1. Visit http://localhost:50280/admin/ and observe that the decision views are no longer present


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
