### PR TITLE
Update bucket names to use openverse-catalog and remove openverse-storage

### DIFF
--- a/catalog/env.template
+++ b/catalog/env.template
@@ -103,7 +103,7 @@ AWS_ACCESS_KEY=test_key
 AWS_SECRET_KEY=test_secret
 AWS_DEFAULT_REGION=us-east-1
 # General bucket used for TSV->DB ingestion and logging
-OPENVERSE_BUCKET=openverse-storage
+OPENVERSE_BUCKET=openverse-catalog
 # Seconds to wait before poking for availability of the data refresh pool when running a data_refresh
 # DAG. Used to shorten the time for testing purposes.
 DATA_REFRESH_POKE_INTERVAL=5

--- a/docker/minio/env.template
+++ b/docker/minio/env.template
@@ -5,4 +5,4 @@ MINIO_ROOT_USER=test_key
 MINIO_ROOT_PASSWORD=test_secret
 
 # Comma separated list of buckets to create on startup
-BUCKETS_TO_CREATE=openverse-catalog,openverse-storage,openverse-airflow-logs
+BUCKETS_TO_CREATE=openverse-catalog,openverse-airflow-logs


### PR DESCRIPTION
### Internal Improvement
Internal Improvement for #4355

### Description
This pull request updates the bucket names in the `env.template` files to use `openverse-catalog` and removes the creation of the `openverse-storage` bucket. This change ensures consistency between local and production environments as discussed in issue #4355.

### Checklist
- [x] My pull request has a descriptive title (not a vague title like "Update index.md").
- [x] My pull request targets the default branch of the repository (main) or a parent feature branch.
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made.
- [ ] I added or updated documentation.
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (just `catalog/generate-docs` for catalog PRs) or the media properties generator (just `catalog/generate-docs media-props` for the catalog or just `api/generate-docs` for the API) where applicable.
