### PR TITLE
Fix frontend to include languages that do not have iso-639-1 codes

### DIFF
--- a/frontend/src/locales/scripts/create-wp-locale-list.js
+++ b/frontend/src/locales/scripts/create-wp-locale-list.js
@@ -7,7 +7,6 @@ This script extracts data for locales available in GlotPress and translate.wp.or
 const fs = require("fs")
 
 const axios = require("./axios")
-
 const { addFetchedTranslationStatus } = require("./get-translations-status")
 
 const base_url =
@@ -34,6 +33,8 @@ const createPropertyRePatterns = ({
     "english_name",
     "native_name",
     "lang_code_iso_639_1", // used for HTML lang attribute
+    "lang_code_iso_639_2", // used for HTML lang attribute, fallback from previous
+    "lang_code_iso_639_3", // used for HTML lang attribute, fallback from previous
     "slug", // unique identifier used by Nuxt i18n
     "text_direction",
   ],
@@ -49,12 +50,14 @@ function parseLocaleData(rawData) {
   const wpLocalePattern = /wp_locale *= *'(.*)';/
   const propertyRePatterns = createPropertyRePatterns()
   const wpLocaleMatch = rawData.match(wpLocalePattern)
+
   // ugly check to exclude English from the locales list,
   // so we don't overwrite `en.json` later. See `get-translations.js`
   // to check how `en.json` file is created.
   if (wpLocaleMatch && wpLocaleMatch[1] !== "en_US") {
     const wpLocale = wpLocaleMatch[1]
     const data = {}
+
     Object.keys(propertyRePatterns).forEach((key) => {
       const pattern = propertyRePatterns[key]
       const value = rawData.match(pattern)
@@ -66,6 +69,7 @@ function parseLocaleData(rawData) {
         data[camelCasedPropName] = value[1]
       }
     })
+
     return [wpLocale, data]
   }
 }

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -29,6 +29,9 @@ const getValidatedLocales = async () => {
     code: locale.slug,
     dir: locale.textDirection || "ltr",
     file: `${locale.slug}.json`,
+    // Check for a language in all three versions of the ISO 639 spec,
+    // defaulting to the v1 two-character codes before checking for the
+    // three-character codes in the v2 and v3 specs.
     iso:
       locale.langCodeIso_639_1 ??
       locale.langCodeIso_639_2 ??

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -29,7 +29,11 @@ const getValidatedLocales = async () => {
     code: locale.slug,
     dir: locale.textDirection || "ltr",
     file: `${locale.slug}.json`,
-    iso: locale.langCodeIso_639_1 ?? undefined,
+    iso:
+      locale.langCodeIso_639_1 ??
+      locale.langCodeIso_639_2 ??
+      locale.langCodeIso_639_3 ??
+      undefined,
 
     /* Custom fields */
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

As discovered by a contributor in [this issue](https://github.com/WordPress/openverse/pull/4224#issuecomment-2119152158), our translations of the Saraiki language were not appearing in production. I realized that the language was being filtered out of our valid translations because it does not have a `langCodeIso_639_1` property in our code. This is because the language is part of the https://en.wikipedia.org/wiki/ISO_639-3 standard, which is essentially v3 of the list of international language codes, and our code was only including languages present in v1. 

Saraiki appears to be the only language impacted by this change

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just frontend/run i18n` and `just frontend/run dev` locally and observe that the `/skr` path now works. You could also count and confirm that the locale chooser now has 61 languages instead of the 60 in production, with running something like `[...document.querySelectorAll('.language option')].length` in your browser's console. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
