### PR TITLE
Enable soft-locking functionality for media reports to assist simultaneous moderators

### DIFF
--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -314,14 +314,9 @@ class MediaReportAdmin(admin.ModelAdmin):
         obj = self.get_object(request, object_id)
         if obj and obj.media_obj:
             additional_data = self._get_media_obj_data(obj)
-            extra_context = {**extra_context, **additional_data}
+            extra_context |= additional_data
 
-        return super().change_view(
-            request,
-            object_id,
-            form_url,
-            extra_context=extra_context,
-        )
+        return super().change_view(request, object_id, form_url, extra_context)
 
     def changelist_view(self, request, extra_context=None):
         valid_locks = self.lock_manager.prune()

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -280,11 +280,16 @@ class MediaReportAdmin(admin.ModelAdmin):
 
     def soft_lock_view(self, request, object_id):
         """
-        Add soft-locks for the current user and object ID.
+        Soft-lock the provided report to the current user.
 
-        This view is called from the frontend when a user loads the
-        change page. It is also called when the page visibility is
-        restored.
+        This view is polled from the frontend when a user has the report
+        change page open. Not polling this endpoint will automatically
+        release the lock when it expires.
+
+        The endpoint returns the lock expiration timestamp.
+
+        :param request: the incoming request to soft-lock the report
+        :param object_id: the ID of the report to soft-lock
         """
 
         expiration = self.lock_manager.add_locks(request.user.get_username(), object_id)

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -140,14 +140,7 @@ class MediaListAdmin(admin.ModelAdmin):
 class MediaReportAdmin(admin.ModelAdmin):
     change_list_template = "admin/api/media_report/change_list.html"
     change_form_template = "admin/api/media_report/change_form.html"
-    list_display = (
-        "id",
-        "reason",
-        "is_pending",
-        "description",
-        "created_at",
-        "url",
-    )
+    list_display = ("id", "reason", "is_pending", "description", "created_at", "url")
     list_filter = (
         ("decision", admin.EmptyFieldListFilter),  # ~status, i.e. pending or moderated
         "reason",

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -298,7 +298,8 @@ class MediaReportAdmin(admin.ModelAdmin):
         mods -= {request.user.get_username()}
         if len(mods):
             messages.warning(
-                request, f"Other moderator(s) looking at this report: {', '.join(mods)}"
+                request,
+                f"Other moderator(s) looking at this report: {', '.join(mods)}.",
             )
 
         extra_context = extra_context or {}

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -309,8 +309,11 @@ class MediaReportAdmin(admin.ModelAdmin):
         restored.
         """
 
-        self.lock_manager.add_locks(request.user.get_username(), object_id)
-        return JsonResponse({"status": "OK"})
+        expiration = self.lock_manager.add_locks(request.user.get_username(), object_id)
+        return JsonResponse(
+            data={"expiration": expiration},
+            status=503 if expiration == 0 else 200,
+        )
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         mods = self.lock_manager.moderator_set(object_id)

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -138,8 +138,17 @@ class MediaListAdmin(admin.ModelAdmin):
 
 
 class MediaReportAdmin(admin.ModelAdmin):
+    change_list_template = "admin/api/media_report/change_list.html"
     change_form_template = "admin/api/media_report/change_form.html"
-    list_display = ("id", "reason", "is_pending", "description", "created_at", "url")
+    list_display = (
+        "id",
+        "reason",
+        "is_pending",
+        "description",
+        "created_at",
+        "url",
+        "get_is_soft_locked",
+    )
     list_filter = (
         ("decision", admin.EmptyFieldListFilter),  # ~status, i.e. pending or moderated
         "reason",
@@ -150,6 +159,20 @@ class MediaReportAdmin(admin.ModelAdmin):
     autocomplete_fields = _production_deferred("media_obj")
     actions = None
     media_type = None
+
+    @admin.display(boolean=True, description="Soft locked")
+    def get_is_soft_locked(self, obj):
+        """
+        Get whether this particular report is soft-locked.
+
+        This field is hidden from the rendered table, but the alt-text
+        the field helps to highlight the soft-locked rows.
+
+        :param obj: the report object
+        :return bool: whether the report is soft-locked
+        """
+
+        return len(self.lock_manager.moderator_set(obj.id)) != 0
 
     def __init__(self, *args, **kwargs):
         self.lock_manager = LockManager(self.media_type)

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -2,7 +2,7 @@ from functools import update_wrapper
 from typing import Sequence
 
 from django.conf import settings
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.views.main import ChangeList
 from django.db.models import Count, F, Min
 from django.http import JsonResponse
@@ -329,6 +329,13 @@ class MediaReportAdmin(admin.ModelAdmin):
         return JsonResponse({"status": "OK"})
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
+        mods = self.lock_manager.moderator_set(object_id)
+        mods -= {request.user.get_username()}
+        if len(mods):
+            messages.warning(
+                request, f"Other moderator(s) looking at this report: {', '.join(mods)}"
+            )
+
         extra_context = extra_context or {}
         extra_context["media_type"] = self.media_type
 

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -193,18 +193,14 @@ class MediaReportAdmin(admin.ModelAdmin):
         info = self.opts.app_label, self.opts.model_name
 
         urls = super().get_urls()
-        urls[-1:-1] = [
+        urls.insert(
+            -1,
             path(
                 "<path:object_id>/lock/",
                 wrap(self.soft_lock_view),
                 name="{:s}_{:s}_lock".format(*info),
             ),
-            path(
-                "<path:object_id>/unlock/",
-                wrap(self.soft_unlock_view),
-                name="{:s}_{:s}_unlock".format(*info),
-            ),
-        ]
+        )
         return urls
 
     def get_fieldsets(self, request, obj=None):
@@ -314,18 +310,6 @@ class MediaReportAdmin(admin.ModelAdmin):
         """
 
         self.lock_manager.add_locks(request.user.get_username(), object_id)
-        return JsonResponse({"status": "OK"})
-
-    def soft_unlock_view(self, request, object_id):
-        """
-        Remove soft-locks for the current user and object ID.
-
-        This view is called from the frontend when the change page
-        visibility is lost, including the case where the user unloads
-        the page.
-        """
-
-        self.lock_manager.remove_locks(request.user.get_username(), object_id)
         return JsonResponse({"status": "OK"})
 
     def change_view(self, request, object_id, form_url="", extra_context=None):

--- a/api/api/apps.py
+++ b/api/api/apps.py
@@ -3,4 +3,5 @@ from django.apps import AppConfig
 
 class ApiConfig(AppConfig):
     name = "api"
+    verbose_name = "API"
     default_auto_field = "django.db.models.AutoField"

--- a/api/api/models/moderation.py
+++ b/api/api/models/moderation.py
@@ -1,5 +1,7 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -36,3 +38,17 @@ def create_or_update_user_profile(sender, instance, created, **kwargs):
     if created:
         UserPreferences.objects.create(user=instance)
     instance.userpreferences.save()
+
+
+def get_moderators() -> models.QuerySet:
+    """
+    Get all users who either are members of the "Content Moderators"
+    group or have superuser privileges.
+
+    :return: a ``QuerySet`` of ``User``s who can perform moderation
+    """
+
+    User = get_user_model()
+    return User.objects.filter(
+        Q(groups__name="Content Moderators") | Q(is_superuser=True)
+    )

--- a/api/api/templates/admin/api/media_report/change_form.html
+++ b/api/api/templates/admin/api/media_report/change_form.html
@@ -147,4 +147,42 @@
     img.src = url;
   }
 </script>
+
+<script>
+  // This script tag manages the soft-locking mechanism for the report.
+
+  function toggleLock(url) {
+    // Toggle the soft-lock for the current user-report pair.
+    fetch(url, {
+      method: 'POST',
+      keepalive: true,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+      },
+    })
+      .then(res => console.log(res))
+      .catch(err => console.error(err));
+  }
+
+  function softLock() {
+    toggleLock('{% url "admin:api_"|add:media_type|add:"report_lock" object_id=object_id %}')
+  }
+
+  function softUnlock() {
+    toggleLock('{% url "admin:api_"|add:media_type|add:"report_unlock" object_id=object_id %}')
+  }
+
+  // On first load, set the soft-lock.
+  document.addEventListener("DOMContentLoaded", softLock)
+  // Subsequent visibility changes (including unload and other ways to
+  // close the page) will toggle the soft-lock.
+  document.addEventListener("visibilitychange", function() {
+    if (document.visibilityState === 'visible') {
+      softLock()
+    } else {
+      softUnlock()
+    }
+  })
+</script>
 {% endblock %}

--- a/api/api/templates/admin/api/media_report/change_form.html
+++ b/api/api/templates/admin/api/media_report/change_form.html
@@ -151,38 +151,26 @@
 <script>
   // This script tag manages the soft-locking mechanism for the report.
 
-  function toggleLock(url) {
-    // Toggle the soft-lock for the current user-report pair.
-    fetch(url, {
+  function softLock() {
+    fetch('{% url "admin:api_"|add:media_type|add:"report_lock" object_id=object_id %}', {
       method: 'POST',
-      keepalive: true,
+      keepalive: true, // This makes the request equivalent to a beacon.
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
       },
     })
-      .then(res => console.log(res))
-      .catch(err => console.error(err));
   }
 
-  function softLock() {
-    toggleLock('{% url "admin:api_"|add:media_type|add:"report_lock" object_id=object_id %}')
+  /**
+   * Activate the soft-lock and set an loop to keep it alive. Ensure
+   * that the loop interval is smaller than the TTL of the soft-lock.
+   */
+  function loadHandler() {
+    softLock()
+    setInterval(softLock, 5000)
   }
 
-  function softUnlock() {
-    toggleLock('{% url "admin:api_"|add:media_type|add:"report_unlock" object_id=object_id %}')
-  }
-
-  // On first load, set the soft-lock.
-  document.addEventListener("DOMContentLoaded", softLock)
-  // Subsequent visibility changes (including unload and other ways to
-  // close the page) will toggle the soft-lock.
-  document.addEventListener("visibilitychange", function() {
-    if (document.visibilityState === 'visible') {
-      softLock()
-    } else {
-      softUnlock()
-    }
-  })
+  document.addEventListener("DOMContentLoaded", loadHandler)
 </script>
 {% endblock %}

--- a/api/api/templates/admin/api/media_report/change_list.html
+++ b/api/api/templates/admin/api/media_report/change_list.html
@@ -4,11 +4,7 @@
 {% block extrastyle %}
 {{ block.super }}
 <style>
-  th.column-get_is_soft_locked,td.field-get_is_soft_locked {
-    display: none;
-  }
-
-  tr:has(td.field-get_is_soft_locked>img[alt="True"]) {
+  tr.is-soft-locked {
     background-color: var(--message-warning-bg);
   }
 </style>
@@ -20,4 +16,14 @@
   Reports that are being moderated by another user are highlighted in yellow.
 </p>
 {{ block.super }}
+{% endblock %}
+
+{% block content %}
+{{ block.super }}
+<script>
+  const reports = {{ locked_reports }};
+  for (let report of reports) {
+    document.querySelector(`tr:has(a[href*="/${report}/"])`).classList.add('is-soft-locked')
+  }
+</script>
 {% endblock %}

--- a/api/api/templates/admin/api/media_report/change_list.html
+++ b/api/api/templates/admin/api/media_report/change_list.html
@@ -1,0 +1,23 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  th.column-get_is_soft_locked,td.field-get_is_soft_locked {
+    display: none;
+  }
+
+  tr:has(td.field-get_is_soft_locked>img[alt="True"]) {
+    background-color: var(--message-warning-bg);
+  }
+</style>
+{% endblock %}
+
+{% block result_list %}
+<p>
+  <strong>Note:</strong>
+  Reports that are being moderated by another user are highlighted in yellow.
+</p>
+{{ block.super }}
+{% endblock %}

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -9,6 +9,7 @@ from api.models.moderation import get_moderators
 
 
 LOCK_PREFIX = "moderation_lock"
+TTL = 10  # seconds
 
 logger = structlog.get_logger(__name__)
 
@@ -61,7 +62,7 @@ class LockManager:
             return
 
         object = f"{self.media_type}:{object_id}"
-        expiration = int(time.time()) + 5 * 60  # 5 minutes from now
+        expiration = int(time.time()) + TTL
 
         logger.info("Adding lock", object=object, user=username, expiration=expiration)
         self.redis.zadd(f"{LOCK_PREFIX}:{username}", {object: expiration})

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -1,8 +1,9 @@
 import time
 
+import django_redis
 import structlog
-from django_redis import get_redis_connection
 from redis import Redis
+from redis.exceptions import ConnectionError
 
 
 REPORT_LOCK_PREFIX = "soft_lock_report"
@@ -10,25 +11,31 @@ MODERATOR_LOCK_PREFIX = "soft_lock_moderator"
 PREFIXES = [REPORT_LOCK_PREFIX, MODERATOR_LOCK_PREFIX]
 
 logger = structlog.get_logger(__name__)
-redis: Redis = get_redis_connection("default")
 
 
 class LockManager:
     def __init__(self, media_type):
         self.media_type = media_type
+        redis: Redis = django_redis.get_redis_connection("default")
+        try:
+            redis.ping()
+            self.redis = redis
+        except ConnectionError:
+            logger.error("Redis connection failed")
+            self.redis = None
 
     def prune(self):
         """Delete all expired locks."""
 
         def _prune(pattern: str):
             now = int(time.time())
-            pipeline = redis.pipeline()
-            for key in redis.keys(pattern):
-                for value, score in redis.zrange(key, 0, -1, withscores=True):
+            pipe = self.redis.pipeline()
+            for key in self.redis.keys(pattern):
+                for value, score in self.redis.zrange(key, 0, -1, withscores=True):
                     if score <= now:
                         logger.info("Deleting expired lock", key=key, value=value)
-                        pipeline.zrem(key, value)
-            pipeline.execute()
+                        pipe.zrem(key, value)
+            pipe.execute()
 
         for prefix in PREFIXES:
             _prune(f"{prefix}:*")
@@ -41,10 +48,13 @@ class LockManager:
         :param object_id: the ID of the report being viewed
         """
 
+        if not self.redis:
+            return
+
         object = f"{self.media_type}:{object_id}"
         expiration = int(time.time()) + 5 * 60  # 5 minutes from now
 
-        pipe = redis.pipeline()
+        pipe = self.redis.pipeline()
         logger.info("Adding lock", object=object, user=username, expiration=expiration)
         pipe.zadd(f"{REPORT_LOCK_PREFIX}:{object}", {username: expiration})
         pipe.zadd(f"{MODERATOR_LOCK_PREFIX}:{username}", {object: expiration})
@@ -58,9 +68,12 @@ class LockManager:
         :param object_id: the ID of the report being viewed
         """
 
+        if not self.redis:
+            return
+
         object = f"{self.media_type}:{object_id}"
 
-        pipe = redis.pipeline()
+        pipe = self.redis.pipeline()
         logger.info("Removing lock", object=object, user=username)
         pipe.zrem(f"{REPORT_LOCK_PREFIX}:{object}", username)
         pipe.zrem(f"{MODERATOR_LOCK_PREFIX}:{username}", object)
@@ -74,12 +87,15 @@ class LockManager:
         :return: the list of moderators on a particular item
         """
 
+        if not self.redis:
+            return set()
+
         self.prune()
 
         object = f"{self.media_type}:{object_id}"
         mods = set(
             item.decode("utf-8")
-            for item in redis.zrange(
+            for item in self.redis.zrange(
                 f"{REPORT_LOCK_PREFIX}:{object}",
                 start=0,
                 end=-1,

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -103,3 +103,20 @@ class LockManager:
         )
         logger.info("Retrieved moderators", object=object, mods=mods)
         return mods
+
+    def score(self, username, object_id) -> int:
+        """
+        Get the score of a particular moderator on a particular item.
+
+        :param username: the username of the moderator viewing a report
+        :param object_id: the ID of the report being viewed
+        :return: the score of a particular moderator on a particular item
+        """
+
+        if not self.redis:
+            return 0
+
+        object = f"{self.media_type}:{object_id}"
+        score = self.redis.zscore(f"{REPORT_LOCK_PREFIX}:{object}", username)
+        logger.info("Retrieved score", object=object, user=username, score=score)
+        return score

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -1,0 +1,89 @@
+import time
+
+import structlog
+from django_redis import get_redis_connection
+from redis import Redis
+
+
+REPORT_LOCK_PREFIX = "soft_lock_report"
+MODERATOR_LOCK_PREFIX = "soft_lock_moderator"
+PREFIXES = [REPORT_LOCK_PREFIX, MODERATOR_LOCK_PREFIX]
+
+logger = structlog.get_logger(__name__)
+redis: Redis = get_redis_connection("default")
+
+
+class LockManager:
+    def __init__(self, media_type):
+        self.media_type = media_type
+
+    def prune(self):
+        """Delete all expired locks."""
+
+        def _prune(pattern: str):
+            now = int(time.time())
+            pipeline = redis.pipeline()
+            for key in redis.keys(pattern):
+                for value, score in redis.zrange(key, 0, -1, withscores=True):
+                    if score <= now:
+                        logger.info("Deleting expired lock", key=key, value=value)
+                        pipeline.zrem(key, value)
+            pipeline.execute()
+
+        for prefix in PREFIXES:
+            _prune(f"{prefix}:*")
+
+    def add_locks(self, username, object_id):
+        """
+        Add soft-locks for a given username and report pair.
+
+        :param username: the username of the moderator viewing a report
+        :param object_id: the ID of the report being viewed
+        """
+
+        object = f"{self.media_type}:{object_id}"
+        expiration = int(time.time()) + 5 * 60  # 5 minutes from now
+
+        pipe = redis.pipeline()
+        logger.info("Adding lock", object=object, user=username, expiration=expiration)
+        pipe.zadd(f"{REPORT_LOCK_PREFIX}:{object}", {username: expiration})
+        pipe.zadd(f"{MODERATOR_LOCK_PREFIX}:{username}", {object: expiration})
+        pipe.execute()
+
+    def remove_locks(self, username, object_id):
+        """
+        Remove soft-locks for a given username and report pair.
+
+        :param username: the username of the moderator viewing a report
+        :param object_id: the ID of the report being viewed
+        """
+
+        object = f"{self.media_type}:{object_id}"
+
+        pipe = redis.pipeline()
+        logger.info("Removing lock", object=object, user=username)
+        pipe.zrem(f"{REPORT_LOCK_PREFIX}:{object}", username)
+        pipe.zrem(f"{MODERATOR_LOCK_PREFIX}:{username}", object)
+        pipe.execute()
+
+    def moderator_set(self, object_id) -> set[str]:
+        """
+        Get the list of moderators on a particular item.
+
+        :param object_id: the ID of the report being viewed
+        :return: the list of moderators on a particular item
+        """
+
+        self.prune()
+
+        object = f"{self.media_type}:{object_id}"
+        mods = set(
+            item.decode("utf-8")
+            for item in redis.zrange(
+                f"{REPORT_LOCK_PREFIX}:{object}",
+                start=0,
+                end=-1,
+            )
+        )
+        logger.info("Retrieved moderators", object=object, mods=mods)
+        return mods

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -1,8 +1,9 @@
+import functools
 import time
+from typing import Callable
 
 import django_redis
 import structlog
-from redis import Redis
 from redis.exceptions import ConnectionError
 
 from api.models.moderation import get_moderators
@@ -14,17 +15,25 @@ TTL = 10  # seconds
 logger = structlog.get_logger(__name__)
 
 
+def handle_redis_exception(ret_val=None):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except ConnectionError:
+                return ret_val() if isinstance(ret_val, Callable) else ret_val
+
+        return wrapper
+
+    return decorator
+
+
 class LockManager:
     def __init__(self, media_type):
         self.media_type = media_type
-        redis: Redis = django_redis.get_redis_connection("default")
-        try:
-            redis.ping()
-            self.redis = redis
-        except ConnectionError:
-            logger.error("Redis connection failed")
-            self.redis = None
 
+    @handle_redis_exception(ret_val=dict)
     def prune(self) -> dict[str, set[str]]:
         """
         Delete all expired locks and get a mapping of usernames to
@@ -33,13 +42,14 @@ class LockManager:
         :return: a mapping of moderators to reports they are viewing
         """
 
+        redis = django_redis.get_redis_connection("default")
         valid_locks = {}
 
         now = int(time.time())
-        pipe = self.redis.pipeline()
+        pipe = redis.pipeline()
         for username in get_moderators().values_list("username", flat=True):
             key = f"{LOCK_PREFIX}:{username}"
-            for value, score in self.redis.zrange(key, 0, -1, withscores=True):
+            for value, score in redis.zrange(key, 0, -1, withscores=True):
                 if score <= now:
                     logger.info("Deleting expired lock", key=key, value=value)
                     pipe.zrem(key, value)
@@ -50,6 +60,7 @@ class LockManager:
 
         return valid_locks
 
+    @handle_redis_exception()
     def add_locks(self, username, object_id):
         """
         Add a soft-lock for a given report to the given moderator.
@@ -58,15 +69,15 @@ class LockManager:
         :param object_id: the ID of the report being viewed
         """
 
-        if not self.redis:
-            return
+        redis = django_redis.get_redis_connection("default")
 
         object = f"{self.media_type}:{object_id}"
         expiration = int(time.time()) + TTL
 
         logger.info("Adding lock", object=object, user=username, expiration=expiration)
-        self.redis.zadd(f"{LOCK_PREFIX}:{username}", {object: expiration})
+        redis.zadd(f"{LOCK_PREFIX}:{username}", {object: expiration})
 
+    @handle_redis_exception()
     def remove_locks(self, username, object_id):
         """
         Remove the soft-lock for a given report from the given moderator.
@@ -75,13 +86,12 @@ class LockManager:
         :param object_id: the ID of the report not being viewed
         """
 
-        if not self.redis:
-            return
+        redis = django_redis.get_redis_connection("default")
 
         object = f"{self.media_type}:{object_id}"
 
         logger.info("Removing lock", object=object, user=username)
-        self.redis.zrem(f"{LOCK_PREFIX}:{username}", object)
+        redis.zrem(f"{LOCK_PREFIX}:{username}", object)
 
     def moderator_set(self, object_id) -> set[str]:
         """
@@ -91,9 +101,6 @@ class LockManager:
         :return: the list of moderators on a particular item
         """
 
-        if not self.redis:
-            return set()
-
         valid_locks = self.prune()
 
         object = f"{self.media_type}:{object_id}"
@@ -101,6 +108,7 @@ class LockManager:
         logger.info("Retrieved moderators", object=object, mods=mods)
         return mods
 
+    @handle_redis_exception()
     def score(self, username, object_id) -> int:
         """
         Get the score of a particular moderator on a particular item.
@@ -110,10 +118,9 @@ class LockManager:
         :return: the score of a particular moderator on a particular item
         """
 
-        if not self.redis:
-            return 0
+        redis = django_redis.get_redis_connection("default")
 
         object = f"{self.media_type}:{object_id}"
-        score = self.redis.zscore(f"{LOCK_PREFIX}:{username}", object)
+        score = redis.zscore(f"{LOCK_PREFIX}:{username}", object)
         logger.info("Retrieved score", object=object, user=username, score=score)
         return score

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -57,7 +57,7 @@ class LockManager:
         return valid_locks
 
     @handle_redis_exception
-    def add_locks(self, username, object_id):
+    def add_locks(self, username, object_id) -> int:
         """
         Add a soft-lock for a given report to the given moderator.
 
@@ -68,10 +68,11 @@ class LockManager:
         redis = django_redis.get_redis_connection("default")
 
         object = f"{self.media_type}:{object_id}"
-        expiration = int(time.time()) + TTL
 
+        expiration = int(time.time()) + TTL
         logger.info("Adding lock", object=object, user=username, expiration=expiration)
         redis.zadd(f"{LOCK_PREFIX}:{username}", {object: expiration})
+        return expiration
 
     @handle_redis_exception
     def remove_locks(self, username, object_id):

--- a/api/test/unit/utils/test_moderation_lock.py
+++ b/api/test/unit/utils/test_moderation_lock.py
@@ -54,7 +54,7 @@ def test_lock_manager_handles_missing_redis(is_cache_reachable, cache_name, requ
         assert lm.moderator_set(10) == {"one"}
         assert lm.score("one", 10) is not None
     else:
-        assert lm.prune() == dict()
+        assert lm.prune() is None
         assert lm.moderator_set(10) == set()
         assert lm.score("one", 10) is None
 

--- a/api/test/unit/utils/test_moderation_lock.py
+++ b/api/test/unit/utils/test_moderation_lock.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+
+import pytest
+from freezegun import freeze_time
+from redis import Redis
+
+from api.utils.moderation_lock import LockManager
+
+
+@pytest.mark.parametrize(
+    "is_cache_reachable, cache_name",
+    [(True, "redis"), (False, "unreachable_redis")],
+)
+def test_lock_manager_handles_missing_redis(is_cache_reachable, cache_name, request):
+    request.getfixturevalue(cache_name)
+
+    lm = LockManager("media_type")
+    lm.add_locks("test", 10)
+
+    if is_cache_reachable:
+        assert isinstance(lm.redis, Redis)
+        assert lm.moderator_set(10) == {"test"}
+    else:
+        assert lm.redis is None
+        assert lm.moderator_set(10) == set()
+
+
+def test_lock_manager_adds_and_removes_locks():
+    lm = LockManager("media_type")
+
+    lm.add_locks("one", 10)
+    assert lm.moderator_set(10) == {"one"}
+    lm.add_locks("two", 10)
+    assert lm.moderator_set(10) == {"one", "two"}
+    lm.remove_locks("two", 10)
+    assert lm.moderator_set(10) == {"one"}
+
+
+def test_relocking_updates_score(redis):
+    lm = LockManager("media_type")
+    now = datetime.now()
+
+    with freeze_time(now):
+        lm.add_locks("one", 10)
+        init_score = lm.score("one", 10)
+
+    with freeze_time(now + timedelta(minutes=2)):
+        lm.add_locks("one", 10)
+        updated_score = lm.score("one", 10)
+
+    assert updated_score == init_score + 120
+
+
+def test_lock_manager_prunes_after_timeout():
+    lm = LockManager("media_type")
+    now = datetime.now()
+
+    with freeze_time(now):
+        lm.add_locks("test", 10)
+
+    with freeze_time(now + timedelta(minutes=2)):
+        lm.prune()
+        assert lm.moderator_set(10) == {"test"}
+
+    with freeze_time(now + timedelta(minutes=6)):
+        lm.prune()
+        assert lm.moderator_set(10) == set()

--- a/api/test/unit/utils/test_moderation_lock.py
+++ b/api/test/unit/utils/test_moderation_lock.py
@@ -47,16 +47,18 @@ def test_lock_manager_handles_missing_redis(is_cache_reachable, cache_name, requ
     request.getfixturevalue(cache_name)
 
     lm = LockManager("media_type")
-    lm.add_locks("one", 10)
+    expiration = lm.add_locks("one", 10)
 
     if is_cache_reachable:
+        assert expiration is not None
         assert lm.prune() == {"one": {"media_type:10"}}
         assert lm.moderator_set(10) == {"one"}
-        assert lm.score("one", 10) is not None
+        assert lm.score("one", 10) == expiration
     else:
+        assert expiration is None
         assert lm.prune() is None
         assert lm.moderator_set(10) == set()
-        assert lm.score("one", 10) is None
+        assert lm.score("one", 10) == expiration
 
 
 def test_lock_manager_adds_and_removes_locks():

--- a/api/test/unit/utils/test_moderation_lock.py
+++ b/api/test/unit/utils/test_moderation_lock.py
@@ -1,10 +1,43 @@
 from datetime import datetime, timedelta
 
+from django.contrib.auth.models import Group, Permission
+
 import pytest
 from freezegun import freeze_time
 from redis import Redis
 
 from api.utils.moderation_lock import LockManager
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mod_group():
+    perms_to_add = ["view", "add", "change"]
+    models_to_affect = [
+        "audio report",
+        "image report",
+        "sensitive audio",
+        "sensitive image",
+    ]
+
+    mod_group, created = Group.objects.get_or_create(name="Content Moderators")
+    if created:
+        for model in models_to_affect:
+            for perm in perms_to_add:
+                name = f"Can {perm} {model}"
+                model_add_perm = Permission.objects.get(name=name)
+                mod_group.permissions.add(model_add_perm)
+    mod_group.save()
+    return mod_group
+
+
+@pytest.fixture(autouse=True)
+def moderators(django_user_model, mod_group):
+    for username in ["one", "two"]:
+        user = django_user_model.objects.create(username=username, password=username)
+        mod_group.user_set.add(user)
 
 
 @pytest.mark.parametrize(
@@ -15,11 +48,11 @@ def test_lock_manager_handles_missing_redis(is_cache_reachable, cache_name, requ
     request.getfixturevalue(cache_name)
 
     lm = LockManager("media_type")
-    lm.add_locks("test", 10)
+    lm.add_locks("one", 10)
 
     if is_cache_reachable:
         assert isinstance(lm.redis, Redis)
-        assert lm.moderator_set(10) == {"test"}
+        assert lm.moderator_set(10) == {"one"}
     else:
         assert lm.redis is None
         assert lm.moderator_set(10) == set()
@@ -56,11 +89,11 @@ def test_lock_manager_prunes_after_timeout():
     now = datetime.now()
 
     with freeze_time(now):
-        lm.add_locks("test", 10)
+        lm.add_locks("one", 10)
 
     with freeze_time(now + timedelta(minutes=2)):
         lm.prune()
-        assert lm.moderator_set(10) == {"test"}
+        assert lm.moderator_set(10) == {"one"}
 
     with freeze_time(now + timedelta(minutes=6)):
         lm.prune()


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3639 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
1. creates a lock manager to keep lock management utilities separate from the admin
2. highlights reports that are under an active soft-lock in the list view
3. softly locks and unlocks works, using two new admin endpoints at `/lock` and `/unlock`, in response to events (including but not limited to loading the change page, switching between tabs or closing the browser)
4. shows a message to any subsequent moderator when they open a work that's soft-locked by someone else
5. times-out soft-locks after 5 minutes (this functionality may be redundant, even harmful, considering point 3 above)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This is best tested using two browsers, or two profiles in separate windows of the same browser, or one regular and one incognito session in the same profile of the same browser.

1. In client A, login with admin creds `deploy` and `deploy`.
2. In client B, login with moderator creds `moderator` and `deploy`. (This was weird when I first learned about it, I expected the password to be the same as the username.)

### Test list highlights

...continued

3. In both clients open the list view. You should see no highlighted rows.
4. In client A, click on a report ID and open the change page.
5. Refresh client B to see that row highlighted in yellow.
6. In client A, click on multiple report IDs and open them in separate tabs.
7. Refresh client B to see all those rows highlighted in yellow.

### Test other moderator message

...continued

8. In client B, click on the report ID in the highlighted row and open the change page. You should see a message that "deploy" is also looking at the same report.
9. Refresh client A. You should see a message that "moderator" is also looking at the same report.

### Test page visibility changes

...continued

10. Close client A to a different tab.
11. Refresh client B, the message about the another moderator should disappear within 10 seconds.
12. Reopen client A to the report tab.
13. Refresh client B, the message should reappear immediately.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
