### PR TITLE
Always assume special urgency for contributor PR pings

### DIFF
--- a/catalog/dags/common/github.py
+++ b/catalog/dags/common/github.py
@@ -107,3 +107,9 @@ class GitHubAPI:
             f"repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
             json={"inputs": inputs or {}, "ref": ref},
         )
+
+    def get_team_members(self, team: str, owner: str = "WordPress"):
+        return self._make_request(
+            "GET",
+            f"orgs/{owner}/teams/{team}/members",
+        )

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
@@ -18,6 +18,7 @@ REPOSITORIES = [
 ]
 MAINTAINER_TEAM = "openverse-maintainers"
 OPENVERSE_BOT = "openverse-bot"
+NON_MAINTAINER_IGNORATIONS = {OPENVERSE_BOT, "renovate", "dependabot[bot]"}
 
 
 class Urgency:
@@ -70,10 +71,8 @@ def get_maintainers(github_pat: str) -> set[str]:
     gh = GitHubAPI(github_pat)
     maintainer_info = gh.get_team_members(MAINTAINER_TEAM)
     maintainers = {
-        member["login"]
-        for member in maintainer_info
-        if member["login"] != OPENVERSE_BOT
-    }
+        member["login"] for member in maintainer_info
+    } ^ NON_MAINTAINER_IGNORATIONS
     return maintainers
 
 

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
@@ -72,7 +72,7 @@ def get_maintainers(github_pat: str) -> set[str]:
     maintainer_info = gh.get_team_members(MAINTAINER_TEAM)
     maintainers = {
         member["login"] for member in maintainer_info
-    } ^ NON_MAINTAINER_IGNORATIONS
+    } | NON_MAINTAINER_IGNORATIONS
     return maintainers
 
 

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
@@ -18,7 +18,7 @@ REPOSITORIES = [
 ]
 MAINTAINER_TEAM = "openverse-maintainers"
 OPENVERSE_BOT = "openverse-bot"
-NON_MAINTAINER_IGNORATIONS = {OPENVERSE_BOT, "renovate", "dependabot[bot]"}
+BOT_ACCOUNTS = {OPENVERSE_BOT, "renovate", "dependabot[bot]"}
 
 
 class Urgency:
@@ -70,9 +70,7 @@ class ReviewDelta:
 def get_maintainers(github_pat: str) -> set[str]:
     gh = GitHubAPI(github_pat)
     maintainer_info = gh.get_team_members(MAINTAINER_TEAM)
-    maintainers = {
-        member["login"] for member in maintainer_info
-    } | NON_MAINTAINER_IGNORATIONS
+    maintainers = {member["login"] for member in maintainer_info} | BOT_ACCOUNTS
     return maintainers
 
 

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders.py
@@ -72,7 +72,7 @@ def get_maintainers(github_pat: str) -> set[str]:
     maintainers = {
         member["login"]
         for member in maintainer_info
-        if member["login"] != "openverse-bot"
+        if member["login"] != OPENVERSE_BOT
     }
     return maintainers
 

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
@@ -32,6 +32,7 @@ from maintenance.pr_review_reminders import pr_review_reminders
 
 DAG_ID = "pr_review_reminders"
 MAX_ACTIVE_TASKS = 1
+DEFERRED_GITHUB_PAT = "{{ var.value.get('GITHUB_API_KEY', 'not_set') }}"
 
 dag = DAG(
     dag_id=DAG_ID,
@@ -54,11 +55,13 @@ dag = DAG(
 )
 
 with dag:
+    pr_review_reminders.get_maintainers(DEFERRED_GITHUB_PAT)
+
     PythonOperator(
         task_id="pr_review_reminder_operator",
         python_callable=pr_review_reminders.post_reminders,
         op_kwargs={
-            "github_pat": "{{ var.value.get('GITHUB_API_KEY', 'not_set') }}",
+            "github_pat": DEFERRED_GITHUB_PAT,
             "dry_run": "{{ var.json.get('PR_REVIEW_REMINDER_DRY_RUN', "
             "var.value.ENVIRONMENT != 'production') }}",
         },

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
@@ -10,8 +10,13 @@ This DAG runs daily and pings on the following schedule based on priority label:
 | --- | --- |
 | critical | 1 day |
 | high | >2 days |
+| contributor | >3 days |
 | medium | >4 days |
 | low | >7 days |
+
+Special consideration is made for non-maintainer PRs so that we ensure contributors
+are responded to in a timely manner
+[per this documentation](https://docs.openverse.org/general/contribution/good_first_and_help_wanted_issues.html#timing-and-process).
 
 The DAG does not ping on Saturday and Sunday and accounts for weekend days
 when determining how much time has passed since the review.

--- a/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
+++ b/catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
@@ -24,7 +24,6 @@ is unavailable for the time period during which the PR should be reviewed.
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
-from airflow.operators.python import PythonOperator
 
 from common.constants import DAG_DEFAULT_ARGS
 from maintenance.pr_review_reminders import pr_review_reminders
@@ -55,14 +54,10 @@ dag = DAG(
 )
 
 with dag:
-    pr_review_reminders.get_maintainers(DEFERRED_GITHUB_PAT)
-
-    PythonOperator(
-        task_id="pr_review_reminder_operator",
-        python_callable=pr_review_reminders.post_reminders,
-        op_kwargs={
-            "github_pat": DEFERRED_GITHUB_PAT,
-            "dry_run": "{{ var.json.get('PR_REVIEW_REMINDER_DRY_RUN', "
-            "var.value.ENVIRONMENT != 'production') }}",
-        },
+    maintainers = pr_review_reminders.get_maintainers(DEFERRED_GITHUB_PAT)
+    pr_review_reminders.post_reminders(
+        maintainers,
+        github_pat=DEFERRED_GITHUB_PAT,
+        dry_run="{{ var.json.get('PR_REVIEW_REMINDER_DRY_RUN', "
+        "var.value.ENVIRONMENT != 'production') }}",
     )

--- a/catalog/tests/dags/maintenance/test_pr_review_reminders.py
+++ b/catalog/tests/dags/maintenance/test_pr_review_reminders.py
@@ -242,6 +242,14 @@ parametrize_possible_pingable_events = pytest.mark.parametrize(
 
 
 @parametrize_urgency
+def test_urgency_respects_contributors(urgency):
+    pull = make_pull(urgency, old=False)
+    # Don't pass maintainers in so any author is considered a "contributor"
+    actual = Urgency.for_pr(pull, set())
+    assert actual == Urgency.CONTRIBUTOR
+
+
+@parametrize_urgency
 @parametrize_possible_pingable_events
 def test_pings_past_due(github, urgency, events):
     past_due_pull = make_pull(urgency, old=True)

--- a/catalog/tests/dags/maintenance/test_pr_review_reminders.py
+++ b/catalog/tests/dags/maintenance/test_pr_review_reminders.py
@@ -44,6 +44,8 @@ LAST_WEDNESDAY = MONDAY - timedelta(days=5)
 LAST_TUESDAY = MONDAY - timedelta(days=6)
 LAST_MONDAY = MONDAY - timedelta(days=7)
 
+MAINTAINERS = {"helpful-contributor"}
+
 
 @pytest.mark.parametrize(
     "today, against, expected_days",
@@ -269,7 +271,7 @@ def test_pings_past_due(github, urgency, events):
         make_non_urgent_reviewable_events(events)
     )
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] in github["posted_comments"]
     assert not_due_pull["number"] not in github["posted_comments"]
@@ -311,7 +313,7 @@ def test_does_not_reping_past_due_if_reminder_is_current(github, urgency, events
         make_non_urgent_reviewable_events(events)
     )
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] not in github["posted_comments"]
     assert not_due_pull["number"] not in github["posted_comments"]
@@ -347,7 +349,7 @@ def test_does_reping_past_due_if_reminder_is_outdated(github, urgency, events):
         make_non_urgent_reviewable_events(events)
     )
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] in github["posted_comments"]
     assert not_due_pull["number"] not in github["posted_comments"]
@@ -400,7 +402,7 @@ def test_does_ping_if_pr_has_less_than_min_required_approvals(
     github["pull_reviews"][past_due_pull["number"]] = reviews
     github["events"][past_due_pull["number"]] = make_urgent_events(urgency, events)
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] in github["posted_comments"]
 
@@ -438,7 +440,7 @@ def test_does_not_ping_if_pr_has_min_required_approvals(
     ] * min_required_approvals
     github["events"][past_due_pull["number"]] = make_urgent_events(urgency, events)
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] not in github["posted_comments"]
 
@@ -466,7 +468,7 @@ def test_does_not_ping_if_no_reviewers(github, urgency, events):
     for pr in [past_due_pull, not_due_pull]:
         _setup_branch_protection(github, pr)
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] not in github["posted_comments"]
     assert not_due_pull["number"] not in github["posted_comments"]
@@ -545,7 +547,7 @@ def test_ignores_created_at_and_pings_if_urgent_ready_for_review_event_exists(
 
     _setup_branch_protection(github, pull)
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert pull["number"] in github["posted_comments"]
 
@@ -579,6 +581,6 @@ def test_falls_back_to_main_on_multiple_branch_levels(
         Urgency.LOW, ["review_requested"]
     )
 
-    post_reminders("not_set", dry_run=False)
+    post_reminders.function(MAINTAINERS, "not_set", dry_run=False)
 
     assert past_due_pull["number"] not in github["posted_comments"]

--- a/catalog/tests/factories/github/team.json
+++ b/catalog/tests/factories/github/team.json
@@ -1,0 +1,22 @@
+[
+  {
+    "login": "helpful-contributor",
+    "id": 0,
+    "node_id": "MDQ6VXNlcjg5NTgxO222",
+    "avatar_url": "https://avatars.githubusercontent.com/u/0?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/helpful-contributor",
+    "html_url": "https://github.com/helpful-contributor",
+    "followers_url": "https://api.github.com/users/helpful-contributor/followers",
+    "following_url": "https://api.github.com/users/helpful-contributor/following{/other_user}",
+    "gists_url": "https://api.github.com/users/helpful-contributor/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/helpful-contributor/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/helpful-contributor/subscriptions",
+    "organizations_url": "https://api.github.com/users/helpful-contributor/orgs",
+    "repos_url": "https://api.github.com/users/helpful-contributor/repos",
+    "events_url": "https://api.github.com/users/helpful-contributor/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/helpful-contributor/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+]

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -860,12 +860,17 @@ have not yet approved the PR or explicitly requested changes.
 
 This DAG runs daily and pings on the following schedule based on priority label:
 
-| priority | days    |
-| -------- | ------- |
-| critical | 1 day   |
-| high     | >2 days |
-| medium   | >4 days |
-| low      | >7 days |
+| priority    | days    |
+| ----------- | ------- |
+| critical    | 1 day   |
+| high        | >2 days |
+| contributor | >3 days |
+| medium      | >4 days |
+| low         | >7 days |
+
+Special consideration is made for non-maintainer PRs so that we ensure
+contributors are responded to in a timely manner
+[per this documentation](https://docs.openverse.org/general/contribution/good_first_and_help_wanted_issues.html#timing-and-process).
 
 The DAG does not ping on Saturday and Sunday and accounts for weekend days when
 determining how much time has passed since the review.


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4327 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the PR reminder review DAG to use a special urgency level, `contributor` (3 business days), for any pull request that isn't opened by one of the `WordPress/openverse-maintainers` users (or a few other bot accounts). I modified the DAG workflow to use the TaskFlow API syntax, and updated tests accordingly as well.

3 days was chosen for this level based on the linked issue and this documentation: https://docs.openverse.org/general/contribution/good_first_and_help_wanted_issues.html#timing-and-process

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The new tests should pass and make sense. We don't have any PRs open right now that qualify for this new ping criteria, but if you have a copy of the GitHub PAT we use, you can test that the DAG still runs as expected with the new dependency.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
