### PR TITLE
Make media items the centre for all moderation activity

### DIFF
--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -47,10 +47,8 @@ def register(site):
     ]:
         site.register(klass, MediaSubreportAdmin)
 
-    # Temporary addition of model admin for decisions while this view gets built
-    if settings.ENVIRONMENT != "production":
-        site.register(ImageDecision, admin.ModelAdmin)
-        site.register(AudioDecision, admin.ModelAdmin)
+    site.register(ImageDecision, ImageDecisionAdmin)
+    site.register(AudioDecision, AudioDecisionAdmin)
 
 
 class MultipleValueField(forms.MultipleChoiceField):
@@ -570,6 +568,11 @@ class MediaReportAdmin(admin.ModelAdmin):
         )
 
 
+class MediaDecisionAdmin(admin.ModelAdmin):
+    media_type = None
+    through_model = None
+
+
 class ImageReportAdmin(MediaReportAdmin):
     media_type = "image"
 
@@ -584,6 +587,16 @@ class ImageListViewAdmin(MediaListAdmin):
 
 class AudioListViewAdmin(MediaListAdmin):
     media_type = "audio"
+
+
+class ImageDecisionAdmin(MediaDecisionAdmin):
+    media_type = "image"
+    through_model = ImageDecisionThrough
+
+
+class AudioDecisionAdmin(MediaDecisionAdmin):
+    media_type = "audio"
+    through_model = AudioDecisionThrough
 
 
 class MediaSubreportAdmin(admin.ModelAdmin):

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -390,7 +390,7 @@ class MediaListAdmin(admin.ModelAdmin):
                     decision=decision.id,
                     action=action,
                     notes=notes,
-                    moderator=moderator.username,
+                    moderator=moderator.get_username(),
                 )
 
                 through = through_class.objects.create(

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -425,6 +425,9 @@ class MediaListAdmin(admin.ModelAdmin):
     # Overrides #
     #############
 
+    # TODO: This construct breaks down if a decision is associated with
+    #   a media item that does not have any reports. Such an item cannot
+    #   be reached at the URL ``admin/api/{media_type}/{id}/change/``.
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         # Return all available image if this is for an autocomplete request

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -14,7 +14,6 @@ from django.utils.safestring import mark_safe
 import structlog
 from elasticsearch import NotFoundError
 from elasticsearch_dsl import Search
-from openverse_attribution.license import License
 
 from api.models import (
     PENDING,
@@ -455,131 +454,65 @@ class MediaListAdmin(admin.ModelAdmin):
 
 
 class MediaReportAdmin(admin.ModelAdmin):
-    change_form_template = "admin/api/media_report/change_form.html"
-    list_display = ("id", "reason", "is_pending", "description", "created_at", "url")
-    list_filter = (
-        ("decision", admin.EmptyFieldListFilter),  # ~status, i.e. pending or moderated
-        "reason",
-    )
-    list_display_links = ("id",)
-    list_select_related = ("media_obj",)
-    search_fields = _production_deferred("description", "media_obj__identifier")
-    autocomplete_fields = _production_deferred("media_obj")
-    actions = None
     media_type = None
 
-    def get_fieldsets(self, request, obj=None):
-        if obj is None:
-            return [
-                (
-                    "Report details",
-                    {"fields": ["status", "decision", "reason", "description"]},
-                ),
-                ("Media details", {"fields": ["media_obj"]}),
-            ]
-        return [
-            (
-                "Report details",
-                {
-                    "fields": [
-                        "created_at",
-                        "status",
-                        "decision",
-                        "reason",
-                        "description",
-                        "has_sensitive_text",
-                    ],
-                },
-            ),
-        ]
+    @admin.display(description="Is pending?", boolean=True)
+    def is_pending(self, obj):
+        """Shadow the ``is_pending`` property but render as icon in Django admin."""
+        return obj.is_pending
 
-    def get_exclude(self, request, obj=None):
-        # ``identifier`` cannot be edited on an existing report.
-        if request.path.endswith("/change/"):
-            return ["media_obj"]
+    #############
+    # List view #
+    #############
+
+    list_display = (
+        "id",
+        "created_at",
+        "reason",
+        "description",
+        "is_pending",
+        "media_id",  # used because ``media_obj`` does not render a link
+    )
+    list_filter = (
+        "reason",
+        ("decision", admin.EmptyFieldListFilter),  # ~is_pending
+    )
+    list_select_related = ("media_obj",)
+    search_fields = ("description", *_production_deferred("media_obj__identifier"))
+
+    @admin.display(description="Media obj")
+    def media_id(self, obj):
+        path = reverse(f"admin:api_{self.media_type}_change", args=(obj.media_obj.id,))
+        return format_html(f'<a href="{path}">{obj.media_obj}</a>')
+
+    ###############
+    # Change view #
+    ###############
+
+    autocomplete_fields = ("decision", *_production_deferred("media_obj"))
+    raw_id_fields = _non_production_deferred("media_obj")
+    actions = None
 
     def get_readonly_fields(self, request, obj=None):
-        if obj is None:
-            return []
-        readonly_fields = [
+        if obj is None:  # Create form
+            return ()
+        # These fields only make sense after a report has been created.
+        # Hence they are only shown in the change form.
+        return (
             "created_at",
-            "reason",
-            "description",
-            "has_sensitive_text",
-            "media_obj_id",
-        ]
-        # ``status`` cannot be changed on a finalised report.
-        if obj.status != PENDING:
-            readonly_fields.append("status")
-        return readonly_fields
-
-    @admin.display(description="Has sensitive text")
-    def has_sensitive_text(self, obj):
-        """
-        Return `True` if the item cannot be found in the filtered index - which means the item
-        was filtered out due to text sensitivity.
-        """
-        if not self.media_type or not obj:
-            return None
-
-        filtered_index = f"{settings.MEDIA_INDEX_MAPPING[self.media_type]}-filtered"
-        try:
-            search = (
-                Search(index=filtered_index)
-                .query("term", identifier=obj.media_obj.identifier)
-                .execute()
-            )
-            if search.hits:
-                return False
-        except NotFoundError:
-            logger.error(f"Could not resolve index {filtered_index}")
-            return None
-        return True
-
-    def get_other_reports(self, obj):
-        if not self.media_type or not obj:
-            return []
-
-        reports = (
-            self.model.objects.filter(media_obj__identifier=obj.media_obj.identifier)
-            .exclude(id=obj.id)
-            .order_by("created_at")
+            "is_pending",
+            "media_obj",
         )
-        return reports
 
-    def _get_media_obj_data(self, obj):
-        tags_by_provider = {}
-        if obj.media_obj.tags:
-            for tag in obj.media_obj.tags:
-                tags_by_provider.setdefault(tag["provider"], []).append(tag["name"])
-        additional_data = {
-            "other_reports": self.get_other_reports(obj),
-            "media_obj": obj.media_obj,
-            "license": License(
-                obj.media_obj.license,
-                obj.media_obj.license_version,
-            ).full_name,
-            "tags": tags_by_provider,
-            "description": obj.media_obj.meta_data.get("description", ""),
-        }
-        logger.info(f"Additional data: {additional_data}")
-        return additional_data
-
-    def change_view(self, request, object_id, form_url="", extra_context=None):
-        extra_context = extra_context or {}
-        extra_context["media_type"] = self.media_type
-
-        obj = self.get_object(request, object_id)
-        if obj and obj.media_obj:
-            additional_data = self._get_media_obj_data(obj)
-            extra_context = {**extra_context, **additional_data}
-
-        return super().change_view(
-            request,
-            object_id,
-            form_url,
-            extra_context=extra_context,
-        )
+    def get_exclude(self, request, obj=None):
+        if obj is None:  # Create form
+            # The decision will be linked to the report after it has
+            # been created, not during.
+            return ("decision",)
+        else:  # Change form
+            # In the change form, we do not want to allow the media
+            # object to be changed.
+            return ("media_obj",)
 
 
 class MediaDecisionAdmin(admin.ModelAdmin):

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -281,6 +281,7 @@ class MediaListAdmin(admin.ModelAdmin):
     change_form_template = "admin/api/media/change_form.html"
     readonly_fields = (
         "attribution",
+        "license_url",
         "has_sensitive_text",
     )
 

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -204,7 +204,6 @@ class MediaListAdmin(admin.ModelAdmin):
         "pending_reports_links",
     )
     list_filter = (PendingRecordCountFilter,)
-    # Disable link display for images
     list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
     sortable_by = ()  # Ordering is defined in ``get_queryset``.

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -108,7 +108,7 @@ class MediaListAdmin(admin.ModelAdmin):
     )
     list_filter = (PendingRecordCountFilter,)
     # Disable link display for images
-    list_display_links = None
+    list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
     media_type = None
     # Ordering is not set here, see get_queryset

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -222,6 +222,24 @@ class MediaListAdmin(admin.ModelAdmin):
 
         return mark_safe(", ".join(data))
 
+    ###############
+    # Change view #
+    ###############
+
+    change_form_template = "admin/api/media/change_form.html"
+    readonly_fields = ("attribution",)
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+
+        extra_context["media_type"] = self.media_type
+
+        media_obj = self.get_object(request, object_id)
+        if media_obj:
+            extra_context["media_obj"] = media_obj
+
+        return super().change_view(request, object_id, form_url, extra_context)
+
     #############
     # Lock view #
     #############

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -277,9 +277,9 @@ class MediaListAdmin(admin.ModelAdmin):
         valid_locks = self.lock_manager.prune()
         locked_media = list(
             int(item.replace(f"{self.media_type}:", ""))
-            for lock_set in valid_locks.values()
+            for moderator, lock_set in valid_locks.items()
             for item in lock_set
-            if self.media_type in item
+            if self.media_type in item and moderator != request.user.get_username()
         )
         extra_context["locked_media"] = locked_media
 

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -149,6 +149,10 @@ class PendingRecordCountFilter(admin.SimpleListFilter):
 
 
 class MediaListAdmin(admin.ModelAdmin):
+    #############
+    # List view #
+    #############
+
     list_display = (
         "identifier",
         "total_report_count",
@@ -183,6 +187,10 @@ class MediaListAdmin(admin.ModelAdmin):
             data.append(format_html('<a href="{}">Report {}</a>', url, report.id))
 
         return mark_safe(", ".join(data))
+
+    #############
+    # Overrides #
+    #############
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -333,6 +333,9 @@ class MediaListAdmin(admin.ModelAdmin):
         reports = manager.order_by("-created_at")
         extra_context["reports"] = reports
 
+        pending_report_count = reports.filter(decision_id=None).count()
+        extra_context["pending_report_count"] = pending_report_count
+
         extra_context["mod_form"] = MediaDecisionForm(media_type=self.media_type)
 
         return super().change_view(request, object_id, form_url, extra_context)

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -195,6 +195,7 @@ class MediaListAdmin(admin.ModelAdmin):
     # List view #
     #############
 
+    change_list_template = "admin/api/media/change_list.html"
     list_display = (
         "identifier",
         "total_report_count",
@@ -228,6 +229,21 @@ class MediaListAdmin(admin.ModelAdmin):
             data.append(format_html('<a href="{}">Report {}</a>', url, report.id))
 
         return mark_safe(", ".join(data))
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+
+        extra_context["media_type"] = self.media_type
+
+        valid_locks = self.lock_manager.prune()
+        locked_media = list(
+            int(item.replace(f"{self.media_type}:", ""))
+            for lock_set in valid_locks.values()
+            for item in lock_set
+        )
+        extra_context["locked_media"] = locked_media
+
+        return super().changelist_view(request, extra_context)
 
     ###############
     # Change view #

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -115,6 +115,20 @@ def _production_deferred(*values: str) -> Sequence[str]:
     return values
 
 
+def _non_production_deferred(*values: str) -> Sequence[str]:
+    """
+    Define a sequence in only the production environment.
+
+    The raw ID field is perfectly suited for massive tables, and so enabling
+    that in production will often prevent performance hits or outages. This will
+    return the input values only the environment is production, and in all other
+    cases it will return an empty sequence.
+    """
+    if settings.ENVIRONMENT != "production":
+        return ()
+    return values
+
+
 class PredeterminedOrderChangelist(ChangeList):
     """
     ChangeList class which does not apply any default ordering to the items.

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -246,6 +246,10 @@ class MediaListAdmin(admin.ModelAdmin):
             tags_by_provider.setdefault(tag["provider"], []).append(text)
         extra_context["tags"] = tags_by_provider
 
+        manager = getattr(media_obj, f"{self.media_type}decisionthrough_set")
+        decision_throughs = manager.order_by("decision__created_on")
+        extra_context["decision_throughs"] = decision_throughs
+
         return super().change_view(request, object_id, form_url, extra_context)
 
     #############

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -1,6 +1,7 @@
 from functools import update_wrapper
 from typing import Sequence
 
+from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.views.main import ChangeList
@@ -15,16 +16,16 @@ import structlog
 from elasticsearch import NotFoundError
 from elasticsearch_dsl import Search
 
+from api.constants.moderation import DecisionAction
 from api.models import (
-    PENDING,
     Audio,
-    AudioReport,
     AudioDecision,
     AudioDecisionThrough,
+    AudioReport,
     Image,
-    ImageReport,
     ImageDecision,
     ImageDecisionThrough,
+    ImageReport,
 )
 from api.models.media import AbstractDeletedMedia, AbstractSensitiveMedia
 from api.utils.moderation_lock import LockManager

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -238,6 +238,14 @@ class MediaListAdmin(admin.ModelAdmin):
         if media_obj:
             extra_context["media_obj"] = media_obj
 
+        tags_by_provider = {}
+        for tag in media_obj.tags:
+            text = tag["name"]
+            if acc := tag.get("accuracy"):
+                text = f"{text} ({acc})"
+            tags_by_provider.setdefault(tag["provider"], []).append(text)
+        extra_context["tags"] = tags_by_provider
+
         return super().change_view(request, object_id, form_url, extra_context)
 
     #############

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -461,7 +461,14 @@ class MediaReportAdmin(admin.ModelAdmin):
 
     @admin.display(description="Is pending?", boolean=True)
     def is_pending(self, obj):
-        """Shadow the ``is_pending`` property but render as icon in Django admin."""
+        """
+        Set an explicit display type for the ``is_pending`` property.
+
+        This is required so that the property, which otherwise renders
+        "True" or "False" strings, now renders as check/cross icons in
+        Django Admin.
+        """
+
         return obj.is_pending
 
     #############

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -23,6 +23,7 @@ from api.models import (
     ImageDecision,
 )
 from api.models.media import AbstractDeletedMedia, AbstractSensitiveMedia
+from api.utils.moderation_lock import LockManager
 
 
 logger = structlog.get_logger(__name__)
@@ -149,6 +150,13 @@ class PendingRecordCountFilter(admin.SimpleListFilter):
 
 
 class MediaListAdmin(admin.ModelAdmin):
+    media_type = None
+
+    def __init__(self, *args, **kwargs):
+        self.lock_manager = LockManager(self.media_type)
+
+        super().__init__(*args, **kwargs)
+
     #############
     # List view #
     #############
@@ -164,7 +172,6 @@ class MediaListAdmin(admin.ModelAdmin):
     # Disable link display for images
     list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
-    media_type = None
     # Ordering is not set here, see get_queryset
 
     def total_report_count(self, obj):

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -207,7 +207,7 @@ class MediaListAdmin(admin.ModelAdmin):
     # Disable link display for images
     list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
-    # Ordering is not set here, see get_queryset
+    sortable_by = ()  # Ordering is defined in ``get_queryset``.
 
     def total_report_count(self, obj):
         return obj.total_report_count

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -186,6 +186,11 @@ class MediaListAdmin(admin.ModelAdmin):
         # End of block lifted from Django source.
 
         urls = super().get_urls()
+
+        # Using slice assignment (docs:
+        # https://docs.python.org/3/tutorial/introduction.html#lists),
+        # insert custom URLs at the penultimate position so that they
+        # appear just before the catch-all view.
         urls[-1:-1] = [
             path(
                 "<path:object_id>/moderate/",

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -272,11 +272,12 @@ class MediaListAdmin(admin.ModelAdmin):
             extra_context["media_obj"] = media_obj
 
         tags_by_provider = {}
-        for tag in media_obj.tags:
-            text = tag["name"]
-            if acc := tag.get("accuracy"):
-                text = f"{text} ({acc})"
-            tags_by_provider.setdefault(tag["provider"], []).append(text)
+        if tags := media_obj.tags:
+            for tag in tags:
+                text = tag["name"]
+                if acc := tag.get("accuracy"):
+                    text = f"{text} ({acc})"
+                tags_by_provider.setdefault(tag["provider"], []).append(text)
         extra_context["tags"] = tags_by_provider
 
         manager = getattr(media_obj, f"{self.media_type}decisionthrough_set")

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -250,6 +250,12 @@ class MediaListAdmin(admin.ModelAdmin):
         decision_throughs = manager.order_by("decision__created_on")
         extra_context["decision_throughs"] = decision_throughs
 
+        manager = getattr(media_obj, f"{self.media_type}_report")
+        reports = manager.order_by("-created_at")
+        extra_context["reports"] = reports
+
+        extra_context["mod_form"] = MediaDecisionForm(media_type=self.media_type)
+
         return super().change_view(request, object_id, form_url, extra_context)
 
     #############

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -240,6 +240,7 @@ class MediaListAdmin(admin.ModelAdmin):
             int(item.replace(f"{self.media_type}:", ""))
             for lock_set in valid_locks.values()
             for item in lock_set
+            if self.media_type in item
         )
         extra_context["locked_media"] = locked_media
 

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -368,7 +368,7 @@ class MediaListAdmin(admin.ModelAdmin):
     def moderate_view(self, request, object_id):
         """
         Create a decision for the media object and associate selected
-        reports complaining about the media with this decision.
+        reports referencing the media with this decision.
         """
 
         if request.method == "POST":

--- a/api/api/models/__init__.py
+++ b/api/api/models/__init__.py
@@ -2,15 +2,23 @@ from api.models.base import OpenLedgerModel  # isort:skip
 from api.models.audio import (
     AltAudioFile,
     Audio,
+    AudioDecision,
+    AudioDecisionThrough,
     AudioList,
     AudioReport,
     AudioSet,
     DeletedAudio,
     SensitiveAudio,
-    AudioDecision,
-    AudioDecisionThrough,
 )
-from api.models.image import DeletedImage, Image, ImageList, ImageReport, SensitiveImage, ImageDecision, ImageDecisionThrough
+from api.models.image import (
+    DeletedImage,
+    Image,
+    ImageDecision,
+    ImageDecisionThrough,
+    ImageList,
+    ImageReport,
+    SensitiveImage,
+)
 from api.models.media import (
     DEINDEXED,
     DMCA,

--- a/api/api/models/__init__.py
+++ b/api/api/models/__init__.py
@@ -8,8 +8,9 @@ from api.models.audio import (
     DeletedAudio,
     SensitiveAudio,
     AudioDecision,
+    AudioDecisionThrough,
 )
-from api.models.image import DeletedImage, Image, ImageList, ImageReport, SensitiveImage, ImageDecision
+from api.models.image import DeletedImage, Image, ImageList, ImageReport, SensitiveImage, ImageDecision, ImageDecisionThrough
 from api.models.media import (
     DEINDEXED,
     DMCA,

--- a/api/api/models/__init__.py
+++ b/api/api/models/__init__.py
@@ -7,8 +7,9 @@ from api.models.audio import (
     AudioSet,
     DeletedAudio,
     SensitiveAudio,
+    AudioDecision,
 )
-from api.models.image import DeletedImage, Image, ImageList, ImageReport, SensitiveImage
+from api.models.image import DeletedImage, Image, ImageList, ImageReport, SensitiveImage, ImageDecision
 from api.models.media import (
     DEINDEXED,
     DMCA,

--- a/api/api/models/audio.py
+++ b/api/api/models/audio.py
@@ -251,6 +251,13 @@ class Audio(AudioFileMixin, AbstractMedia):
     class Meta(AbstractMedia.Meta):
         db_table = "audio"
 
+    def get_absolute_url(self):
+        """Enable the "View on site" link in the Django Admin."""
+
+        from django.urls import reverse
+
+        return reverse("image-detail", args=[str(self.identifier)])
+
 
 class DeletedAudio(AbstractDeletedMedia):
     """

--- a/api/api/models/audio.py
+++ b/api/api/models/audio.py
@@ -256,7 +256,7 @@ class Audio(AudioFileMixin, AbstractMedia):
 
         from django.urls import reverse
 
-        return reverse("image-detail", args=[str(self.identifier)])
+        return reverse("audio-detail", args=[str(self.identifier)])
 
 
 class DeletedAudio(AbstractDeletedMedia):

--- a/api/api/models/image.py
+++ b/api/api/models/image.py
@@ -54,6 +54,13 @@ class Image(ImageFileMixin, AbstractMedia):
     class Meta(AbstractMedia.Meta):
         db_table = "image"
 
+    def get_absolute_url(self):
+        """Enable the "View on site" link in the Django Admin."""
+
+        from django.urls import reverse
+
+        return reverse("image-detail", args=[str(self.identifier)])
+
     @property
     def sensitive(self) -> bool:
         return hasattr(self, "sensitive_image")

--- a/api/api/models/moderation.py
+++ b/api/api/models/moderation.py
@@ -1,5 +1,7 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -36,3 +38,17 @@ def create_or_update_user_profile(sender, instance, created, **kwargs):
     if created:
         UserPreferences.objects.create(user=instance)
     instance.userpreferences.save()
+
+
+def get_moderators() -> models.QuerySet:
+    """
+    Get all users who either are members of the "Content Moderators"
+    group or have superuser privileges.
+
+    :return: a ``QuerySet`` of ``User``s who can perform moderation
+    """
+
+    User = get_user_model()
+    return User.objects.filter(
+        Q(groups__name="Content Moderators") | Q(is_superuser=True)
+    )

--- a/api/api/models/moderation.py
+++ b/api/api/models/moderation.py
@@ -11,7 +11,7 @@ class UserPreferences(models.Model):
     preferences = models.JSONField(default=dict)
 
     def __str__(self):
-        return f"{self.user.username}'s preferences"
+        return f"{self.user.get_username()}'s preferences"
 
     @property
     def moderator(self):

--- a/api/api/templates/admin/api/components/media_additional.html
+++ b/api/api/templates/admin/api/components/media_additional.html
@@ -1,0 +1,69 @@
+{% comment %}
+Props:
+- media_type
+- media_obj
+- tags
+{% endcomment %}
+
+<fieldset class="module aligned">
+  <h2>Additional information</h2>
+
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        <label>Preview</label>
+        {% if media_type == 'image' %}
+        <div class="overflow-hidden">
+          <img
+            src="{% url media_type|add:'-thumb' identifier=media_obj.identifier %}"
+            alt="Media Image"
+            class="transition-filter blur-60px"
+            height="300"
+            onclick="toggleBlur(this)"
+            onerror="this.onerror=null;this.src='{{ media_obj.url }}';">
+        </div>
+        <style>
+          .overflow-hidden { overflow: hidden; }
+          .transition-filter { transition: filter 0.3s; }
+          .blur-60px { filter: blur(60px); }
+        </style>
+        <script>
+          function toggleBlur(img) {
+            img.classList.toggle('blur-60px');
+          }
+        </script>
+
+        {% elif media_type == 'audio' %}
+        <audio controls>
+          <source src="{{ media_obj.url }}">
+          Your browser does not support the audio element.
+        </audio>
+        {% endif %}
+      </div>
+      <div class="help">
+        {% if media_type == 'image' %}
+        <div>Click to show/hide content.</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        <label>Tags</label>
+        <div>
+          <dl class="pl-0">
+            {% for provider, provider_tags in tags.items %}
+            <dt>{{ provider }}:</dt>
+            <dd>{{ provider_tags|join:', ' }}</dd>
+            {% endfor %}
+          </dl>
+          <style>
+            dl.pl-0 { padding-left: 0; }
+          </style>
+        </div>
+      </div>
+    </div>
+  </div>
+</fieldset>

--- a/api/api/templates/admin/api/components/media_additional.html
+++ b/api/api/templates/admin/api/components/media_additional.html
@@ -11,7 +11,7 @@ Props:
   <div class="form-row field-height">
     <div>
       <div class="flex-container">
-        <label>Preview</label>
+        <label>Preview:</label>
         {% if media_type == 'image' %}
         <div class="overflow-hidden">
           <img
@@ -51,7 +51,7 @@ Props:
   <div class="form-row field-height">
     <div>
       <div class="flex-container">
-        <label>Tags</label>
+        <label>Tags:</label>
         <div>
           <dl class="pl-0">
             {% for provider, provider_tags in tags.items %}

--- a/api/api/templates/admin/api/components/media_decisions.html
+++ b/api/api/templates/admin/api/components/media_decisions.html
@@ -30,7 +30,7 @@ Props:
           <a href="{% url 'admin:api_'|add:media_type|add:'decision_change' decision.id %}">{{ decision.id }}</a>
         </td>
         <td>{{ decision.created_on }}</td>
-        <td>{{ decision.moderator.username }}</td>
+        <td>{{ decision.moderator }}</td>
         <td>{{ decision.action }}</td>
         <td>{{ decision.notes }}</td>
         <td>

--- a/api/api/templates/admin/api/components/media_decisions.html
+++ b/api/api/templates/admin/api/components/media_decisions.html
@@ -1,0 +1,55 @@
+{% comment %}
+Props:
+- media_type
+- decision_throughs
+{% endcomment %}
+
+{% load get_attr %}
+
+<fieldset class="module">
+  <h2>Decisions</h2>
+
+  <table class="w-full">
+    <thead>
+      <tr>
+        <th class="hidden"></th>
+        <th>ID</th>
+        <th>Date</th>
+        <th>Moderator</th>
+        <th>Action</th>
+        <th>Notes</th>
+        <th>Reports</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for decision_through in decision_throughs %}
+      {% with decision_through.decision as decision %}
+      <tr>
+        <td class="hidden"><!-- Hidden inputs etc. --></td>
+        <td>
+          <a href="{% url 'admin:api_'|add:media_type|add:'decision_change' decision.id %}">{{ decision.id }}</a>
+        </td>
+        <td>{{ decision.created_on }}</td>
+        <td>{{ decision.moderator.username }}</td>
+        <td>{{ decision.action }}</td>
+        <td>{{ decision.notes }}</td>
+        <td>
+          {% with media_type|add:'report_set' as attr_name %}
+          {% with decision|get_attr:attr_name as reports %}
+          {% for report in reports.all %}
+            <a href="{% url 'admin:api_'|add:media_type|add:'report_change' report.id %}">{{ report.id }}</a> ({{report.reason}})<br/>
+          {% endfor %}
+          {% endwith %}
+          {% endwith %}
+        </td>
+      </tr>
+      {% endwith %}
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <style>
+    .hidden { display: none; }
+    .w-full { width: 100%; }
+  </style>
+</fieldset>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -1,0 +1,99 @@
+{% comment %}
+Props:
+- media_type
+- reports
+- mod_form
+{% endcomment %}
+
+<fieldset class="module aligned">
+  <h2>Reports</h2>
+
+  <p>
+    You can take a decision for the pending reports by selecting one
+    or more of them and creating a decision.
+  </p>
+  <table class="w-full">
+    <thead>
+      <tr>
+        <th class="hidden"></th>
+        <th>Select</th>
+        <th>ID</th>
+        <th>Date</th>
+        <th>Reason</th>
+        <th>Description</th>
+        <th>Is pending?</th>
+        <th>Decision</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for report in reports %}
+      <tr>
+        <td class="hidden"><!-- Hidden inputs etc. --></td>
+        <td>
+          {% if report.is_pending %}
+          <input
+            form="decision-create"
+            type="checkbox"
+            name="report_id"
+            value="{{ report.id }}"
+            class="action-select">
+          {% endif %}
+        </td>
+        <td>
+          <a href="{% url 'admin:api_'|add:media_type|add:'report_change' report.id %}">{{ report.id }}</a>
+        </td>
+        <td>{{ report.created_at }}</td>
+        <td>{{ report.reason }}</td>
+        <td>{{ report.description }}</td>
+        <td>
+          {% if report.is_pending %}
+          <img src="/static/admin/img/icon-yes.svg" alt="False">
+          {% else %}
+          <img src="/static/admin/img/icon-no.svg" alt="False">
+          {% endif %}
+        </td>
+        <td>
+          {% if report.decision %}
+          <a href="{% url 'admin:api_'|add:media_type|add:'decision_change' report.decision.id %}">{{ report.decision.id }}</a>
+          ({{ report.decision.action }})
+          {% else %}
+          -
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <style>
+    .hidden { display: none; }
+    .w-full { width: 100%; }
+  </style>
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        <label>Action</label>
+        <div>
+          {{ mod_form.action }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        <label>Notes</label>
+        <div>{{ mod_form.notes }}</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-10px">
+    <input form="decision-create" type="submit" value="Create decision">
+  </div>
+</fieldset>
+
+<style>
+  .p-10px { padding: 10px; }
+</style>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -39,8 +39,7 @@ Props:
             form="decision-create"
             type="checkbox"
             name="report_id"
-            value="{{ report.id }}"
-            class="action-select">
+            value="{{ report.id }}">
           {% endif %}
         </td>
         {% endif %}

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -78,29 +78,29 @@ Props:
   <div class="form-row field-height">
     <div>
       <div class="flex-container">
-        <label>Action</label>
-        <div>
-          {{ mod_form.action }}
-        </div>
+        {{ mod_form.action.label_tag }}
+        {{ mod_form.action }}
       </div>
+      <div class="help">{{ mod_form.action.help_text }}</div>
     </div>
   </div>
 
   <div class="form-row field-height">
     <div>
       <div class="flex-container">
-        <label>Notes</label>
-        <div>{{ mod_form.notes }}</div>
+        {{ mod_form.notes.label_tag }}
+        {{ mod_form.notes }}
       </div>
+      <div class="help">{{ mod_form.notes.help_text }}</div>
     </div>
   </div>
 
   <div class="p-10px">
     <input form="decision-create" type="submit" value="Create decision">
   </div>
+
+  <style>
+    .p-10px { padding: 10px; }
+  </style>
   {% endif %}
 </fieldset>
-
-<style>
-  .p-10px { padding: 10px; }
-</style>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -2,21 +2,24 @@
 Props:
 - media_type
 - reports
+- pending_report_count
 - mod_form
 {% endcomment %}
 
 <fieldset class="module aligned">
   <h2>Reports</h2>
 
+  {% if pending_report_count %}
   <p>
     You can take a decision for the pending reports by selecting one
     or more of them and creating a decision.
   </p>
+  {% endif %}
   <table class="w-full">
     <thead>
       <tr>
         <th class="hidden"></th>
-        <th>Select</th>
+        {% if pending_report_count %}<th>Select</th>{% endif %}
         <th>ID</th>
         <th>Date</th>
         <th>Reason</th>
@@ -29,6 +32,7 @@ Props:
       {% for report in reports %}
       <tr>
         <td class="hidden"><!-- Hidden inputs etc. --></td>
+        {% if pending_report_count %}
         <td>
           {% if report.is_pending %}
           <input
@@ -39,6 +43,7 @@ Props:
             class="action-select">
           {% endif %}
         </td>
+        {% endif %}
         <td>
           <a href="{% url 'admin:api_'|add:media_type|add:'report_change' report.id %}">{{ report.id }}</a>
         </td>
@@ -69,6 +74,7 @@ Props:
     .hidden { display: none; }
     .w-full { width: 100%; }
   </style>
+  {% if pending_report_count %}
   <div class="form-row field-height">
     <div>
       <div class="flex-container">
@@ -92,6 +98,7 @@ Props:
   <div class="p-10px">
     <input form="decision-create" type="submit" value="Create decision">
   </div>
+  {% endif %}
 </fieldset>
 
 <style>

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -1,0 +1,45 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}{{ block.super }}
+<!--
+  This script make links clickable. Since we've stored URLs in
+  `TextField`s, they are not rendered as links in the Django Admin UI.
+  This script identifies `<div>`s containing links and converts them to
+  `<a>` tags.
+-->
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    document.querySelectorAll("div.readonly").forEach(div => {
+      if (div.textContent.match(/https?:\/\/\S+/)) {
+        div.innerHTML = div.textContent.replace(/(https?:\/\/\S+)/g, '<a href="$1">$1</a>');
+      }
+    });
+  });
+</script>
+
+<!--
+  This script polls the soft-lock endpoint at intervals shorter than the
+  lock TTL to keep the lock alive.
+-->
+<script>
+  function softLock() {
+    fetch('{% url "admin:api_"|add:media_type|add:"_lock" object_id=object_id %}', {
+      method: "POST",
+      keepalive: true, // This makes the request equivalent to a beacon.
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": document.querySelector('[name="csrfmiddlewaretoken"]').value
+      },
+    })
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    softLock()
+    setInterval(softLock, 5000)
+  })
+</script>
+{% endblock %}
+
+{% block object-tools-items %}{{ block.super }}
+<li><a href="https://openverse.org/{{media_type}}/{{media_obj.identifier}}" class="viewsitelink">View on openverse.org</a></li>
+{% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -40,6 +40,13 @@
 </script>
 {% endblock %}
 
+{% block content %}{{ block.super }}
+<!-- Fields for this form are supplied separately in `media_reports.html`. -->
+<form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_moderate' object_id %}">
+  {% csrf_token %}
+</form>
+{% endblock %}
+
 {% block object-tools-items %}{{ block.super }}
 <li><a href="https://openverse.org/{{media_type}}/{{media_obj.identifier}}" class="viewsitelink">View on openverse.org</a></li>
 {% endblock %}
@@ -47,4 +54,5 @@
 {% block after_field_sets %}
 {% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
 {% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
+{% include 'admin/api/components/media_reports.html' with media_type=media_type reports=reports mod_form=mod_form only %}
 {% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -43,3 +43,7 @@
 {% block object-tools-items %}{{ block.super }}
 <li><a href="https://openverse.org/{{media_type}}/{{media_obj.identifier}}" class="viewsitelink">View on openverse.org</a></li>
 {% endblock %}
+
+{% block after_field_sets %}
+{% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
+{% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -46,4 +46,5 @@
 
 {% block after_field_sets %}
 {% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
+{% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
 {% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -42,9 +42,11 @@
 
 {% block content %}{{ block.super }}
 <!-- Fields for this form are supplied separately in `media_reports.html`. -->
+{% if pending_report_count %}
 <form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_moderate' object_id %}">
   {% csrf_token %}
 </form>
+{% endif %}
 {% endblock %}
 
 {% block object-tools-items %}{{ block.super }}
@@ -54,5 +56,5 @@
 {% block after_field_sets %}
 {% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
 {% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
-{% include 'admin/api/components/media_reports.html' with media_type=media_type reports=reports mod_form=mod_form only %}
+{% include 'admin/api/components/media_reports.html' with media_type=media_type reports=reports pending_report_count=pending_report_count mod_form=mod_form only %}
 {% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -55,6 +55,6 @@
 
 {% block after_field_sets %}
 {% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
-{% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
 {% include 'admin/api/components/media_reports.html' with media_type=media_type reports=reports pending_report_count=pending_report_count mod_form=mod_form only %}
+{% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
 {% endblock %}

--- a/api/api/templates/admin/api/media/change_list.html
+++ b/api/api/templates/admin/api/media/change_list.html
@@ -1,0 +1,28 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block extrahead %}{{ block.super }}
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const mediaItems = JSON.parse('{{ locked_media }}');
+    for (let mediaItem of mediaItems) {
+      console.log(`tr:has(a[href*="/{{ media_type }}/${mediaItem}/"])`);
+      document.querySelector(`tr:has(a[href*="/{{ media_type }}/${mediaItem}/"])`).classList.add('bg-warning');
+    }
+  });
+</script>
+{% endblock %}
+
+{% block extrastyle %}{{ block.super }}
+<style>
+  tr.bg-warning { background-color: var(--message-warning-bg); }
+</style>
+{% endblock %}
+
+{% block result_list %}
+<p>
+  <strong>Note:</strong>
+  Media items that are being moderated by another user are highlighted.
+</p>
+{{ block.super }}
+{% endblock %}

--- a/api/api/templates/admin/api/media/change_list.html
+++ b/api/api/templates/admin/api/media/change_list.html
@@ -2,6 +2,10 @@
 {% load i18n admin_urls static admin_list %}
 
 {% block extrahead %}{{ block.super }}
+<!--
+  This script highlights rows which are open in another moderator's
+   session using the warning color.
+-->
 <script>
   document.addEventListener("DOMContentLoaded", function() {
     const mediaItems = JSON.parse('{{ locked_media }}');

--- a/api/api/templatetags/get_attr.py
+++ b/api/api/templatetags/get_attr.py
@@ -1,0 +1,23 @@
+import re
+
+from django import template
+
+
+numeric_test = re.compile("^\d+$")
+register = template.Library()
+
+
+def get_attr(value, arg):
+    """Get an attribute of an object dynamically from a string name"""
+
+    if hasattr(value, str(arg)):
+        return getattr(value, arg)
+    elif hasattr(value, "has_key") and value.has_key(arg):
+        return value[arg]
+    elif numeric_test.match(str(arg)) and len(value) > int(arg):
+        return value[int(arg)]
+    else:
+        return None
+
+
+register.filter("get_attr", get_attr)

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -26,6 +26,12 @@ def handle_redis_exception(func):
 
 
 class LockManager:
+    """
+    Kudos to this Google Group discussion for the solution using a
+    ranked-set:
+    https://web.archive.org/web/20211205091916/https://groups.google.com/g/redis-db/c/rXXMCLNkNSs
+    """
+
     def __init__(self, media_type):
         self.media_type = media_type
 

--- a/api/api/utils/moderation_lock.py
+++ b/api/api/utils/moderation_lock.py
@@ -1,0 +1,123 @@
+import functools
+import time
+
+import django_redis
+import structlog
+from redis.exceptions import ConnectionError
+
+from api.models.moderation import get_moderators
+
+
+LOCK_PREFIX = "moderation_lock"
+TTL = 10  # seconds
+
+logger = structlog.get_logger(__name__)
+
+
+def handle_redis_exception(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ConnectionError:
+            return None
+
+    return wrapper
+
+
+class LockManager:
+    def __init__(self, media_type):
+        self.media_type = media_type
+
+    @handle_redis_exception
+    def prune(self) -> dict[str, set[str]]:
+        """
+        Delete all expired locks and get a mapping of usernames to
+        media items that have active locks.
+
+        :return: a mapping of moderators to media items they are viewing
+        """
+
+        redis = django_redis.get_redis_connection("default")
+        valid_locks = {}
+
+        now = int(time.time())
+        pipe = redis.pipeline()
+        for username in get_moderators().values_list("username", flat=True):
+            key = f"{LOCK_PREFIX}:{username}"
+            for value, score in redis.zrange(key, 0, -1, withscores=True):
+                if score <= now:
+                    logger.info("Deleting expired lock", key=key, value=value)
+                    pipe.zrem(key, value)
+                else:
+                    logger.info("Keeping valid lock", key=key, value=value)
+                    valid_locks.setdefault(username, set()).add(value.decode())
+        pipe.execute()
+
+        return valid_locks
+
+    @handle_redis_exception
+    def add_locks(self, username, object_id) -> int:
+        """
+        Add a soft-lock for a given media item to the given moderator.
+
+        :param username: the username of the moderator viewing a media item
+        :param object_id: the ID of the media item being viewed
+        """
+
+        redis = django_redis.get_redis_connection("default")
+
+        object = f"{self.media_type}:{object_id}"
+
+        expiration = int(time.time()) + TTL
+        logger.info("Adding lock", object=object, user=username, expiration=expiration)
+        redis.zadd(f"{LOCK_PREFIX}:{username}", {object: expiration})
+        return expiration
+
+    @handle_redis_exception
+    def remove_locks(self, username, object_id):
+        """
+        Remove the soft-lock for a given media item from the given moderator.
+
+        :param username: the username of the moderator not viewing a media item
+        :param object_id: the ID of the media item not being viewed
+        """
+
+        redis = django_redis.get_redis_connection("default")
+
+        object = f"{self.media_type}:{object_id}"
+
+        logger.info("Removing lock", object=object, user=username)
+        redis.zrem(f"{LOCK_PREFIX}:{username}", object)
+
+    def moderator_set(self, object_id) -> set[str]:
+        """
+        Get the list of moderators on a particular item.
+
+        :param object_id: the ID of the media item being viewed
+        :return: the list of moderators on a particular item
+        """
+
+        valid_locks = self.prune() or {}
+
+        object = f"{self.media_type}:{object_id}"
+        mods = {mod for mod, objects in valid_locks.items() if object in objects}
+        logger.info("Retrieved moderators", object=object, mods=mods)
+        return mods
+
+    @handle_redis_exception
+    def score(self, username, object_id) -> int:
+        """
+        Get the score of a particular moderator on a particular item.
+
+        :param username: the username of the moderator viewing a media item
+        :param object_id: the ID of the media item being viewed
+        :return: the score of a particular moderator on a particular item
+        """
+
+        redis = django_redis.get_redis_connection("default")
+
+        object = f"{self.media_type}:{object_id}"
+        score = redis.zscore(f"{LOCK_PREFIX}:{username}", object)
+        logger.info("Retrieved score", object=object, user=username, score=score)
+        return score

--- a/api/test/unit/admin/test_media_report.py
+++ b/api/test/unit/admin/test_media_report.py
@@ -2,20 +2,22 @@ from unittest import mock
 
 import pytest
 
-from api.admin.media_report import _production_deferred
+from api.admin.media_report import _non_production_deferred, _production_deferred
 
 
 @pytest.mark.parametrize(
-    "values, environment, expected",
+    "values, environment, prod_expected, non_prod_expected",
     [
-        ([1, 2, 3], "local", (1, 2, 3)),
-        ([1, 2, 3], "production", ()),
-        ([], "local", ()),
-        ([], "production", ()),
+        ([1, 2, 3], "local", (1, 2, 3), ()),
+        ([1, 2, 3], "production", (), (1, 2, 3)),
+        ([], "local", (), ()),
+        ([], "production", (), ()),
     ],
 )
-def test_production_deferred(values, environment, expected):
+def test_production_deferred(values, environment, prod_expected, non_prod_expected):
     with mock.patch("api.admin.media_report.settings") as mock_settings:
         mock_settings.ENVIRONMENT = environment
-        actual = _production_deferred(*values)
-    assert actual == expected
+        prod_deferred = _production_deferred(*values)
+        non_prod_deferred = _non_production_deferred(*values)
+    assert prod_deferred == prod_expected
+    assert non_prod_deferred == non_prod_expected

--- a/api/test/unit/utils/test_moderation_lock.py
+++ b/api/test/unit/utils/test_moderation_lock.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta
+
+from django.contrib.auth.models import Group
+
+import pytest
+from freezegun import freeze_time
+
+from api.utils.moderation_lock import TTL, LockManager
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def moderators(django_user_model):
+    for username in ["one", "two"]:
+        user = django_user_model.objects.create(username=username, password=username)
+        group, _ = Group.objects.get_or_create(name="Content Moderators")
+        group.user_set.add(user)
+
+
+@pytest.mark.parametrize(
+    "is_cache_reachable, cache_name",
+    [(True, "redis"), (False, "unreachable_redis")],
+)
+def test_lock_manager_handles_missing_redis(is_cache_reachable, cache_name, request):
+    request.getfixturevalue(cache_name)
+
+    lm = LockManager("media_type")
+    expiration = lm.add_locks("one", 10)
+
+    if is_cache_reachable:
+        assert expiration is not None
+        assert lm.prune() == {"one": {"media_type:10"}}
+        assert lm.moderator_set(10) == {"one"}
+        assert lm.score("one", 10) == expiration
+    else:
+        assert expiration is None
+        assert lm.prune() is None
+        assert lm.moderator_set(10) == set()
+        assert lm.score("one", 10) == expiration
+
+
+def test_lock_manager_adds_and_removes_locks():
+    lm = LockManager("media_type")
+
+    lm.add_locks("one", 10)
+    assert lm.moderator_set(10) == {"one"}
+    lm.add_locks("two", 10)
+    assert lm.moderator_set(10) == {"one", "two"}
+    lm.remove_locks("two", 10)
+    assert lm.moderator_set(10) == {"one"}
+
+
+def test_relocking_updates_score(redis):
+    lm = LockManager("media_type")
+    now = datetime.now()
+
+    with freeze_time(now):
+        lm.add_locks("one", 10)
+        init_score = lm.score("one", 10)
+
+    with freeze_time(now + timedelta(seconds=TTL / 2)):
+        lm.add_locks("one", 10)
+        updated_score = lm.score("one", 10)
+
+    assert updated_score == init_score + TTL / 2
+
+
+def test_lock_manager_prunes_after_timeout():
+    lm = LockManager("media_type")
+    now = datetime.now()
+
+    with freeze_time(now):
+        lm.add_locks("one", 10)
+
+    with freeze_time(now + timedelta(seconds=TTL - 1)):
+        assert lm.moderator_set(10) == {"one"}
+
+    with freeze_time(now + timedelta(seconds=TTL + 1)):
+        assert lm.moderator_set(10) == set()

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -81,15 +81,22 @@ for username in usernames:
 # Credit: https://stackoverflow.com/a/53733693
 echo "
 from django.contrib.auth.models import User, Group, Permission
-perms_to_add = ['view', 'add', 'change']
-models_to_affect = ['audio report', 'image report', 'sensitive audio', 'sensitive image']
+crud_perm_map = {'C': 'add', 'R': 'view', 'U': 'change'}
+model_perms_map = {
+  'image': 'R',
+  'audio': 'R',
+  'image report': 'CRU',
+  'audio report': 'CRU',
+  'sensitive image': 'CRU',
+  'sensitive audio': 'CRU',
+}
 
 mod_group, created = Group.objects.get_or_create(name='Content Moderators')
 if created:
   print('Setting up Content Moderators group')
-  for model in models_to_affect:
-    for perm in perms_to_add:
-      name = f'Can {perm} {model}'
+  for model, perms in model_perms_map.items():
+    for perm in perms:
+      name = f'Can {crud_perm_map[perm]} {model}'
       print(f'Adding permission to moderators group: {name}')
       model_add_perm = Permission.objects.get(name=name)
       mod_group.permissions.add(model_add_perm)

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -81,7 +81,7 @@ for username in usernames:
 # Credit: https://stackoverflow.com/a/53733693
 echo "
 from django.contrib.auth.models import User, Group, Permission
-crud_perm_map = {'C': 'add', 'R': 'view', 'U': 'change'}
+crud_perm_map = {'C': 'add', 'R': 'view', 'U': 'change', 'D': 'delete'}
 model_perms_map = {
   'image': 'R',
   'audio': 'R',
@@ -89,6 +89,10 @@ model_perms_map = {
   'audio report': 'CRU',
   'sensitive image': 'CRU',
   'sensitive audio': 'CRU',
+  'image decision': 'CRU',
+  'audio decision': 'CRU',
+  'image decision through': 'CRUD',
+  'audio decision through': 'CRUD',
 }
 
 mod_group, created = Group.objects.get_or_create(name='Content Moderators')


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3638 by @sarayourfriend 
Fixes #3639 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- makes it possible for moderators to view the media model list and change pages, in addition to accessing decision pages and making changes to decision-media relationships
- adds soft-locking and warning messages so that moderators can avoid potential conflicts
- makes the media model (and not the media-report model) the root of all moderation activity
- adds additional information to media model change page
- provides comprehensive history of pending/reviewed reports and past decisions for any media item
- adds actions for moderation into the media model change page

This PR also
- breaks admin templates into smaller, more-manageable components
- adheres more closely to Django idioms for site links in the admin
- refactors and organises code in the extremely large model-admin classes

Please note that this PR is intentionally allowed to deviate from some permissions and access controls. These permissions will be tightened in #3640.

## Testing Instructions

For the steps involving the Django admin, it is best to use two different profiles (or even browsers) so that you can see the admin from the perspective of a superuser ("deploy") and a moderator ("moderator").

### Preparing the data

1. Take down services (with volumes), bring up the API and initialise.
 
   ```bash
   just down -v
   just api/up
   just api/init
   ```

2. Get a few image and audio identifiers.

   ```bash
   curl --silent 'http://localhost:50280/v1/images/?page_size=3' | jq '.results[].id'
   curl --silent 'http://localhost:50280/v1/audio/?page_size=3' | jq '.results[].id'
   ```

3. File many different reports of many different reasons against these identifiers. You can use this cURL command as a reference.

   ```bash
   curl \
     -X POST \
     -H 'content-type: application/json' \
     -H 'accept: application/json, */*;q=0.5' \
     -d '{"reason":"<mature|dmca|other>","description":"<any random message of 20+ chars>"}' \
     http://localhost:50280/v1/<image|audio>/<identifier>/report/
   ```

### Testing

#### Access control

1. Open the Django Admin homepage at `/admin`.
2. Ensure that relevant models are visible. User "moderator" should see "Images" and "Audios" and some other selected models, whereas user "admin" should see all registered models.
3. Open a media item's detail page. User "moderator" should see most fields as read-only, whereas user "admin" should see editable fields. Both should be able to make a decision for pending reports (more info below).

#### Soft-locking

1. Open a media item's detail page from "moderator"'s session.
4. On the media list page in "admin"'s session, you should see that media item highlighted in the warning color.
5. If you visit the same media item's detail page in "admin"'s session, you will also see a warning message at the top stating that "moderator" is viewing this.
6. If you now refresh the media item's detail page in "moderator"'s session, you will see the same warning but referencing "admin" instead.
7. The soft-lock endpoint will be polled as long as the detail page is open. Close the detail page and the locks should be cleared in a few seconds.

#### Additional info

1. Open the media list view.
2. You should see the following additional information:
   - column "Has sensitive text?" showing whether the media item has sensitive text
4. Open a media item's detail page.
5. You should see the following additional information:
   - links to view the item on the API and Openverse.org in the top right corner
   - the attribution as a read-only field below the media item's fields
   - the license URL as a read-only field below the attribution
   - whether the media item has sensitive text as a read-only field below the license URL
   - a preview of the media item (which in the case of images, can be blurred and un-blurred by clicking the preview)
   - a view of the tags grouped by provider and showing accuracy (if known)
   - information about past decisions
   - information about reports (pending and reviewed)
     - controls to take a new decision for pending reports

#### Moderation actions

1. Open a media item's detail page.
2. Go to the report's list at the bottom of the page.
6. Select any number of pending reports.
7. Choose an action and enter moderation notes (optional).
8. Click on the "Create decision" button. The page will reload (the form submits to the `/moderate` endpoint which redirects back to `/change` endpoint).
9. Verify the results.
   - The new decision should appear under the decision section (with the selected reports shown in the last column).
   - The selected reports should no longer be pending (with the checkbox gone and the decision shown in the last column).

#### Production deferred

1. Go to the page to create a new report `/admin/api/imagereport/add/`. You should see an autocomplete field for "Media obj".
2. Similarly go to the page to create a new decision `/admin/api/audiodecision/add/`. You should see an inline tabular admin with autocomplete field for "Media obj".
3. Now switch your current `ENVIRONMENT` to "production". These fields should be replaced with `raw_id_fields` that should offer considerably better performance.

## Report admin pages (list, create, change)

1. The list of reports is shown in a table identical to that present inside the media item change page.
2. The page to change the report does not allow changing the "Media obj".
3. The page to create a new report hides away fields that do not make sense before and during filing of reports.

## Decision admin pages (list, create, change)

1. The list of decisions is shown in a table identical to that present inside the media item change page.
2. The page to change the decision freezes the set of media-decision-through models and does not allow changing them.
3. The page to create a new decision hides away fields that do not make sense before and during filing of report, and populates the moderator from `request.user` automatically.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
