### PR TITLE
Improve accessibility labels for filters tab and button

### DIFF
--- a/frontend/src/components/VHeader/VHeaderMobile/VFilterTab.vue
+++ b/frontend/src/components/VHeader/VHeaderMobile/VFilterTab.vue
@@ -1,14 +1,18 @@
 <template>
-  <VTab id="filters" size="medium" class="gap-x-2">
+  <VTab id="filters" size="medium" class="gap-x-2" :aria-label="ariaLabel">
     <VFilterIconOrCounter :applied-filter-count="appliedFilterCount" />
     <h2 class="label-regular">{{ $t("filters.title") }}</h2>
   </VTab>
 </template>
 <script lang="ts">
+import { computed, defineComponent } from "vue"
+
+import { useI18n } from "~/composables/use-i18n"
+
 import VFilterIconOrCounter from "~/components/VHeader/VFilterIconOrCounter.vue"
 import VTab from "~/components/VTabs/VTab.vue"
 
-export default {
+export default defineComponent({
   name: "VFilterTab",
   components: { VFilterIconOrCounter, VTab },
   props: {
@@ -17,5 +21,12 @@ export default {
       default: 0,
     },
   },
-}
+  setup(props) {
+    const i18n = useI18n()
+    const ariaLabel = computed(() =>
+      i18n.tc("header.filterButton.withCount", props.appliedFilterCount)
+    )
+    return { ariaLabel }
+  },
+})
 </script>

--- a/frontend/src/components/VHeader/VHeaderMobile/VFilterTab.vue
+++ b/frontend/src/components/VHeader/VHeaderMobile/VFilterTab.vue
@@ -1,18 +1,19 @@
 <template>
-  <VTab id="filters" size="medium" class="gap-x-2" :aria-label="ariaLabel">
+  <VTab
+    id="filters"
+    size="medium"
+    class="gap-x-2"
+    :aria-label="$tc('header.filterButton.withCount', appliedFilterCount)"
+  >
     <VFilterIconOrCounter :applied-filter-count="appliedFilterCount" />
     <h2 class="label-regular">{{ $t("filters.title") }}</h2>
   </VTab>
 </template>
 <script lang="ts">
-import { computed, defineComponent } from "vue"
-
-import { useI18n } from "~/composables/use-i18n"
-
 import VFilterIconOrCounter from "~/components/VHeader/VFilterIconOrCounter.vue"
 import VTab from "~/components/VTabs/VTab.vue"
 
-export default defineComponent({
+export default {
   name: "VFilterTab",
   components: { VFilterIconOrCounter, VTab },
   props: {
@@ -21,12 +22,5 @@ export default defineComponent({
       default: 0,
     },
   },
-  setup(props) {
-    const i18n = useI18n()
-    const ariaLabel = computed(() =>
-      i18n.tc("header.filterButton.withCount", props.appliedFilterCount)
-    )
-    return { ariaLabel }
-  },
-})
+}
 </script>

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -52,7 +52,7 @@
     loading: "Loading...",
     filterButton: {
       simple: "Filters",
-      withCount: "{count} Filter|{count} Filters",
+      withCount: "Filter ({count})|Filters ({count})",
     },
     seeResults: "See results",
     backButton: "Go back",

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -52,6 +52,7 @@
     loading: "Loading...",
     filterButton: {
       simple: "Filters",
+      /** Used as the accessible label for the button or tab that opens the filters sidebar. Count refers the number of filters the user has enabled, not the number of available filters */
       withCount: "Filters ({count})",
     },
     seeResults: "See results",

--- a/frontend/src/locales/scripts/en.json5
+++ b/frontend/src/locales/scripts/en.json5
@@ -52,7 +52,7 @@
     loading: "Loading...",
     filterButton: {
       simple: "Filters",
-      withCount: "Filter ({count})|Filters ({count})",
+      withCount: "Filters ({count})",
     },
     seeResults: "See results",
     backButton: "Go back",

--- a/frontend/test/locales/ar.json
+++ b/frontend/test/locales/ar.json
@@ -52,7 +52,7 @@
     "loading": "جار التحميل...",
     "filterButton": {
       "simple": "مرشحات",
-      "withCount": "{count} عامل التصفية | {count} عوامل التصفية"
+      "withCount": "({count}) مرشحات|({count}) مرشح"
     },
     "seeResults": "انظر النتائج",
     "backButton": "عُد",

--- a/frontend/test/locales/ar.json
+++ b/frontend/test/locales/ar.json
@@ -52,7 +52,7 @@
     "loading": "جار التحميل...",
     "filterButton": {
       "simple": "مرشحات",
-      "withCount": "({count}) مرشحات|({count}) مرشح"
+      "withCount": "({count}) مرشح"
     },
     "seeResults": "انظر النتائج",
     "backButton": "عُد",

--- a/frontend/test/playwright/utils/navigation.ts
+++ b/frontend/test/playwright/utils/navigation.ts
@@ -49,12 +49,11 @@ export const searchTypeNames = {
  */
 export const openContentSettingsTab = async (
   page: Page,
-  tab: "searchTypes" | "filters" = "searchTypes",
-  dir: LanguageDirection = "ltr"
+  tab: "searchTypes" | "filters" = "searchTypes"
 ) => {
-  const tabKey = tab === "searchTypes" ? "searchType.heading" : "filters.title"
+  const tabId = tab === "searchTypes" ? "content-settings" : "filters"
 
-  await page.getByRole("tab", { name: t(tabKey, dir) }).click()
+  await page.locator(`#tab-${tabId}`).click()
 }
 
 /**
@@ -105,7 +104,7 @@ export const setContentSwitcherState = async (
       await buttonLocator.isEnabled()
       await buttonLocator.click()
     }
-    return openContentSettingsTab(page, contentSwitcherKind, dir)
+    return openContentSettingsTab(page, contentSwitcherKind)
   } else if (isPressed) {
     await closeContentSettingsModal(page, dir)
   }

--- a/frontend/test/playwright/utils/navigation.ts
+++ b/frontend/test/playwright/utils/navigation.ts
@@ -49,11 +49,18 @@ export const searchTypeNames = {
  */
 export const openContentSettingsTab = async (
   page: Page,
-  tab: "searchTypes" | "filters" = "searchTypes"
+  tab: "searchTypes" | "filters" = "searchTypes",
+  dir: LanguageDirection = "ltr"
 ) => {
-  const tabId = tab === "searchTypes" ? "content-settings" : "filters"
+  // Use a hard-coded Regex to match the dynamic Filters tab name
+  const tabName =
+    tab === "searchTypes"
+      ? t("searchType.heading", dir)
+      : dir === "ltr"
+        ? /filter/i
+        : /مرش/
 
-  await page.locator(`#tab-${tabId}`).click()
+  await page.getByRole("tab", { name: tabName }).click()
 }
 
 /**
@@ -104,7 +111,7 @@ export const setContentSwitcherState = async (
       await buttonLocator.isEnabled()
       await buttonLocator.click()
     }
-    return openContentSettingsTab(page, contentSwitcherKind)
+    return openContentSettingsTab(page, contentSwitcherKind, dir)
   } else if (isPressed) {
     await closeContentSettingsModal(page, dir)
   }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #957 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a common `aria-label` to both the `VFilterTab` and `VFilterButton` (based on feedback provided in #957) which more appropriately conveys in text format what sighted users are expected to understand about the action component. The new label takes the form (in English) of `Filters ({number})`.

I've opted to reduce the set of changes to just this, since the testing translation changes were pretty unrelated and this makes the changeset much smaller.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Run the app locally using `just frontend/run dev`
2. Visit http://localhost:8443/search/?q=cats&license=pdm,cc0,by using a wide viewport
3. Right click on the filters button, and click "Inspect Accessibility Properties" (for firefox, not sure what this looks like in Chrome)
4. Verify that the text present for the button is `Filters (3)`
5. Change to a smaller viewport for mobile devices and reload the page
6. Open up the filters drawer with the button next to search
7. Right click on the filter tab and click "Inspect Accessibility Properties"
8. Verify that the text present for the button is `Filters (3)`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
