### PR TITLE
Revert "Change search query approach to include only available providers (#4238)"

### DIFF
--- a/api/api/controllers/elasticsearch/related.py
+++ b/api/api/controllers/elasticsearch/related.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl.response import Hit
 from api.controllers.elasticsearch.helpers import get_es_response, get_query_slice
 from api.controllers.search_controller import (
     _post_process_results,
-    get_enabled_sources_query,
+    get_excluded_providers_query,
 )
 
 
@@ -36,7 +36,7 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
     tags = getattr(item_hit, "tags", None)
     creator = getattr(item_hit, "creator", None)
 
-    related_query = {"filter": [], "must_not": [], "should": []}
+    related_query = {"must_not": [], "must": [], "should": []}
 
     if not title and not tags:
         if not creator:
@@ -55,8 +55,8 @@ def related_media(uuid: str, index: str, filter_dead: bool) -> list[Hit]:
             related_query["should"].append(Q("terms", tags__name__keyword=tags))
 
     # Exclude the dynamically disabled sources.
-    if enabled_sources_query := get_enabled_sources_query():
-        related_query["filter"].append(enabled_sources_query)
+    if excluded_providers_query := get_excluded_providers_query():
+        related_query["must_not"].append(excluded_providers_query)
     # Exclude the current item and mature content.
     related_query["must_not"].extend(
         [Q("term", mature=True), Q("term", identifier=uuid)]

--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -41,8 +41,12 @@ logger = structlog.get_logger(__name__)
 NESTING_THRESHOLD = config("POST_PROCESS_NESTING_THRESHOLD", cast=int, default=5)
 SOURCE_CACHE_TIMEOUT = 60 * 60 * 4  # 4 hours
 FILTER_CACHE_TIMEOUT = 30
-ENABLED_SOURCES_CACHE_KEY = "enabled_sources"
-ENABLED_SOURCES_CACHE_VERSION = 2
+FILTERED_PROVIDERS_CACHE_KEY = "filtered_providers"
+FILTERED_PROVIDERS_CACHE_VERSION = 2
+THUMBNAIL = "thumbnail"
+URL = "url"
+PROVIDER = "provider"
+QUERY_SPECIAL_CHARACTER_ERROR = "Unescaped special characters are not allowed."
 DEFAULT_BOOST = 10000
 DEFAULT_SEARCH_FIELDS = ["title", "description", "tags.name"]
 DEFAULT_SQS_FLAGS = "AND|NOT|PHRASE|WHITESPACE"
@@ -158,46 +162,42 @@ def _post_process_results(
     return results[:page_size]
 
 
-def get_enabled_sources_query() -> Q | None:
+def get_excluded_providers_query() -> Q | None:
     """
-    Get a query that only includes enabled sources.
-
-    To exclude a source, set ``filter_content`` to ``True`` in the
+    Hide data sources from the catalog dynamically.
+    To exclude a provider, set ``filter_content`` to ``True`` in the
     ``ContentProvider`` model in Django admin.
     The list of ``provider_identifier``s is cached in Redis with
-    `:ENABLED_SOURCES_CACHE_VERSION:ENABLED_SOURCES_CACHE_KEY` key.
+    `:FILTERED_PROVIDERS_CACHE_VERSION:FILTERED_PROVIDERS_CACHE_KEY` key.
     """
 
     try:
-        enabled_sources = cache.get(
-            key=ENABLED_SOURCES_CACHE_KEY, version=ENABLED_SOURCES_CACHE_VERSION
+        filtered_providers = cache.get(
+            key=FILTERED_PROVIDERS_CACHE_KEY, version=FILTERED_PROVIDERS_CACHE_VERSION
         )
     except ConnectionError:
-        logger.warning("Redis connect failed, cannot get cached enabled sources.")
-        enabled_sources = None
+        logger.warning("Redis connect failed, cannot get cached filtered providers.")
+        filtered_providers = None
 
-    if not enabled_sources:
-        # `ContentProvider` currently only handles _sources_, not providers.
-        # TODO: This is a legacy naming convention that should be updated.
-        # https://github.com/WordPress/openverse/issues/4346
-        enabled_sources = list(
-            models.ContentProvider.objects.filter(filter_content=False).values_list(
+    if not filtered_providers:
+        filtered_providers = list(
+            models.ContentProvider.objects.filter(filter_content=True).values_list(
                 "provider_identifier", flat=True
             )
         )
 
         try:
             cache.set(
-                key=ENABLED_SOURCES_CACHE_KEY,
-                version=ENABLED_SOURCES_CACHE_VERSION,
+                key=FILTERED_PROVIDERS_CACHE_KEY,
+                version=FILTERED_PROVIDERS_CACHE_VERSION,
                 timeout=FILTER_CACHE_TIMEOUT,
-                value=enabled_sources,
+                value=filtered_providers,
             )
         except ConnectionError:
-            logger.warning("Redis connect failed, cannot cache enabled sources.")
+            logger.warning("Redis connect failed, cannot cache filtered providers.")
 
-    if enabled_sources:
-        return Q("terms", source=enabled_sources)
+    if filtered_providers:
+        return Q("terms", provider=filtered_providers)
     return None
 
 
@@ -285,8 +285,8 @@ def build_search_query(
     if not search_params.validated_data["include_sensitive_results"]:
         search_queries["must_not"].append(Q("term", mature=True))
     # Exclude dynamically disabled sources (see Redis cache)
-    if enabled_sources_query := get_enabled_sources_query():
-        search_queries["filter"].append(enabled_sources_query)
+    if excluded_providers_query := get_excluded_providers_query():
+        search_queries["must_not"].append(excluded_providers_query)
 
     # Search either by generic multimatch or by "advanced search" with
     # individual field-level queries specified.
@@ -375,7 +375,6 @@ def build_collection_query(
     :return: the search client with the query applied.
     """
     search_query = {"filter": [], "must": [], "should": [], "must_not": []}
-
     # Apply the term filters. Each tuple pairs a filter's parameter name in the API
     # with its corresponding field in Elasticsearch. "None" means that the
     # names are identical.
@@ -396,8 +395,8 @@ def build_collection_query(
     if not include_sensitive_by_params:
         search_query["must_not"].append({"term": {"mature": True}})
 
-    if enabled_sources_query := get_enabled_sources_query():
-        search_query["filter"].append(enabled_sources_query)
+    if excluded_providers_query := get_excluded_providers_query():
+        search_query["must_not"].append(excluded_providers_query)
 
     return Q("bool", **search_query)
 

--- a/api/conf/settings/__init__.py
+++ b/api/conf/settings/__init__.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 
+from decouple import config
 from split_settings.tools import include
 
 


### PR DESCRIPTION
This reverts commit 3d7fa0908e5b18d1b53f1a8c8bee713317556d42.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

We believe this commit may be the root cause of Elasticsearch performance degradation that caused an outage earlier today. Full investigation on this can be seen below:

### "Old" style test query:

`/image-ff1c23632fd149d08239d7c59e11f1a9-filtered/_search`

```json
  {
    "profile": true,
    "query": {
        "bool": {
            "must_not": [
                {"terms": {"provider": ["ccMixter"]}},
                {"term": {"mature": true}},
                {"term": {"identifier": "image_identifier"}}
            ],
            "should": [
                {"match": {"title": "long string not previously searched"}},
                {"terms": {"tags.name.keyword": ["long string not previously searched"]}}
            ]
        }
    }
}
```

Took **24ms**.

### "New" style filter query

`/image-ff1c23632fd149d08239d7c59e11f1a9-filtered/_search`

```json
{
    "profile" true,
    "query": {
        "bool": {
            "filter": [
                {"terms": {"source": ["flickr", "wikimedia", "animaldiversity", "bio_diversity", "brooklynmuseum", "clevelandmuseum", "CAPL", "spacex", "svgsilh", "digitaltmuseum", "thingiverse", "WoRMS", "smithsonian_air_and_space_museum", "smithsonian_american_art_museum", "smithsonian_american_history_museum", "smithsonian_american_indian_museum", "smithsonian_gardens", "smithsonian_anacostia_museum", "nypl", "geographorguk", "met", "museumsvictoria", "nasa", "rawpixel", "rijksmuseum", "sketchfab", "smithsonian_libraries", "smithsonian_african_american_history_museum", "smithsonian_african_art_museum", "smithsonian_national_museum_of_natural_history", "smithsonian_cooper_hewitt_museum", "smithsonian_freer_gallery_of_art", "smithsonian_hirshhorn_museum", "smithsonian_portrait_gallery", "smithsonian_postal_museum", "smithsonian_zoo_and_conservation", "smithsonian_institution_archives", "woc_tech", "finnish_heritage_agency", "stocksnap", "wordpress", "smk", "finnish_satakunnan_museum", "justtakeitfree", "phylopic", "national_museum_of_finland", "europeana", "inaturalist", "nappy", "wellcome_collection"]}}
            ],
            "must_not": [
                {"term": {"mature": true}},
                {"term": {"identifier": "image_identifier"}}
            ],
            "should": [
                {"match": {"title": "zack krida"}},
                {"terms": {"tags.name.keyword": ["zack krida"]}}
            ]
        }
    }
}
```

Took **1473ms**, nearly 53x slower.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Tests should pass, ensure the app runs locally.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
