### PR TITLE
Make Dockerfied development environment compatible with macOS

### DIFF
--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -44,13 +44,10 @@ RUN dnf -y install dnf-plugins-core \
   && pipx install \
     pdm pipenv  \
     pre-commit \
-  && useradd -m opener -G docker \
   && npm install -g \
     n \
     corepack \
   && corepack enable
-
-USER opener
 
 # Avoid overwriting `.venv`'s from the host
 ENV PDM_VENV_IN_PROJECT="False"

--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -1,5 +1,22 @@
 FROM docker.io/library/fedora:latest
 
+# We want to keep all important things in `/opt` as we will preserve the
+# `/opt` directory as a volume.
+
+# location where pipx installs its tools
+ENV PIPX_HOME="/opt/pipx"
+# location where pipx symlinks the binaries, must be on the path
+ENV PIPX_BIN_DIR="/opt/pipx/bin"
+# location where PDM installs Python interpreters
+ENV PDM_PYTHONS="/opt/pdm/bin"
+# location where `n` installs Node.js versions
+ENV N_PREFIX="/opt/n"
+# location where pre-commit stores environments
+ENV PRE_COMMIT_HOME="/opt/pre-commit"
+
+# Add tooling installed in custom locations to `PATH`.
+ENV PATH="${N_PREFIX}/bin:${PDM_PYTHONS}:${PIPX_BIN_DIR}:${PATH}"
+
 # Dependency explanations
 # - git: required by some python package; contributors should use git on their host
 # - perl: used in linting
@@ -35,13 +52,8 @@ RUN dnf -y install dnf-plugins-core \
 
 USER opener
 
-ENV PATH="/home/opener/.local/bin:${PATH}"
-
 # Avoid overwriting `.venv`'s from the host
 ENV PDM_VENV_IN_PROJECT="False"
-
-ENV N_PREFIX="/home/opener/.local/share/n"
-ENV PATH="${N_PREFIX}/bin:${PATH}"
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -17,17 +17,21 @@ ENV PRE_COMMIT_HOME="/opt/pre-commit"
 # Add tooling installed in custom locations to `PATH`.
 ENV PATH="${N_PREFIX}/bin:${PDM_PYTHONS}:${PIPX_BIN_DIR}:${PATH}"
 
-# Dependency explanations
+# Dependency explanations:
 # - git: required by some python package; contributors should use git on their host
 # - perl: used in linting
 # - gcc: required by some pre-commit hooks for node-gyp
 # - just: command runner
 # - which: locate a program file in `PATH`
-# - python3.12, pipx: language runtime and CLI app installer
-# - nodejs, npm: language runtime and dependency manager (system npm required by node-based pre-commit hooks)
-# - docker*: used to interact with host docker socket
+# - pipx: Python CLI app installer
+# - nodejs: language runtime (includes npm but not Corepack)
+# - docker*: used to interact with host Docker socket
+#
+# pipx dependencies:
 # - pdm, pipenv: Python package managers
-# - pre-commit: pre-commit hook manager
+# - pre-commit: Git pre-commit and pre-push hook manager
+#
+# Node dependencies:
 # - n: Node.js distribution manager
 # - corepack: Node.js package-manager-manager
 RUN dnf -y install dnf-plugins-core \
@@ -38,8 +42,8 @@ RUN dnf -y install dnf-plugins-core \
     gcc \
     just \
     which \
-    python3.12 pipx \
-    nodejs npm \
+    pipx \
+    nodejs \
     docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
   && pipx install \
     pdm pipenv  \

--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -2,32 +2,38 @@ FROM docker.io/library/fedora:latest
 
 # Dependency explanations
 # - git: required by some python package; contributors should use git on their host
-# - gcc, make: required by some pre-commit hooks for node-gyp
 # - perl: used in linting
-# - bash: used for scripts
-# - python: language runtime
-# - python-pipx: python CLI app installer
-# - docker*: used to interact with host docker socket
-# - nodejs, npm: language runtime and dependency manager (system npm required by node-based pre-commit hooks)
+# - gcc: required by some pre-commit hooks for node-gyp
 # - just: command runner
-# - n: nodejs distribution manager
+# - which: locate a program file in `PATH`
+# - python3.12, pipx: language runtime and CLI app installer
+# - nodejs, npm: language runtime and dependency manager (system npm required by node-based pre-commit hooks)
+# - docker*: used to interact with host docker socket
 # - pdm, pipenv: Python package managers
 # - pre-commit: pre-commit hook manager
+# - n: Node.js distribution manager
+# - corepack: Node.js package-manager-manager
 RUN dnf -y install dnf-plugins-core \
   && dnf -y config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo \
   && dnf -y install \
-  git bash perl curl gcc just \
-  python3.12 pipx \
-  nodejs npm \
-  docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+    git \
+    perl \
+    gcc \
+    just \
+    which \
+    python3.12 pipx \
+    nodejs npm \
+    docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+  && pipx install \
+    pdm pipenv  \
+    pre-commit \
   && useradd -m opener -G docker \
-  && npm install -g n corepack \
+  && npm install -g \
+    n \
+    corepack \
   && corepack enable
 
 USER opener
-
-# pipx installed tools are user-dependent, so install these after switching to opener
-RUN pipx install pdm pre-commit
 
 ENV PATH="/home/opener/.local/bin:${PATH}"
 

--- a/docker/dev_env/entrypoint.sh
+++ b/docker/dev_env/entrypoint.sh
@@ -29,19 +29,23 @@ if [ -n "$PNPM_HOME" ]; then
   export PATH="$PNPM_HOME:$PATH"
 fi
 
-_python3s=("$HOME"/.local/share/pdm/python/cpython@3.11.*/bin/python3)
+pdm config python.install_root "/opt/pdm/python"
+
+_python3s=(/opt/pdm/python/cpython@3.11.*/bin/python3)
 
 if [ ! -x "${_python3s[0]}" ]; then
   printf "Installing the specific Python version required for pipenv environments; this is only necessary the first time the toolkit runs\n"
   pdm python install 3.11
-  _python3s=("$HOME"/.local/share/pdm/python/cpython@3.11.*/bin/python3)
+  _python3s=(/opt/pdm/python/cpython@3.11.*/bin/python3)
 fi
 
 PYTHON_311=${_python3s[0]}
 export PYTHON_311
 
-if [ ! -x "$HOME"/.local/bin/python3.11 ]; then
-  ln -s "$PYTHON_311" "$HOME"/.local/bin/python3.11
+mkdir -p "$PDM_PYTHONS"
+
+if [ ! -x "$PDM_PYTHONS"/python3.11 ]; then
+  ln -s "$PYTHON_311" "$PDM_PYTHONS"/python3.11
 fi
 
 if [ -z "$(command -v pipenv)" ]; then

--- a/docker/dev_env/entrypoint.sh
+++ b/docker/dev_env/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ "$UID" = "0" ]; then
-  printf "Do not run this container with the root user! Use the 'run.sh' script or pass --user to docker run.\n"
-  exit 1
-fi
-
 if [ ! -d "$OPENVERSE_PROJECT"/.git ]; then
   printf "Repository not mounted to container!\n"
   exit 1

--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -22,8 +22,6 @@ suppress_output() {
   "$@" 2>/dev/null 1>/dev/null
 }
 
-opener_home="/home/opener"
-
 run_args=(
   -i
   --rm
@@ -36,8 +34,8 @@ run_args=(
   # and others don't get confused about where files are supposed to be
   -v "$OPENVERSE_PROJECT:$OPENVERSE_PROJECT:rw,z"
   --workdir "$OPENVERSE_PROJECT"
-  # Save the home directory of the container so we can reuse it each time
-  --mount "type=volume,src=openverse-dev-env,target=$opener_home"
+  # Save the /opt directory of the container so we can reuse it each time
+  --mount "type=volume,src=openverse-dev-env,target=/opt"
   # Expose the host's docker socket to the container so the container can run docker/compose etc
   -v /var/run/docker.sock:/var/run/docker.sock
 )

--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -2,22 +2,6 @@
 
 set -e
 
-# Kudos https://stackoverflow.com/a/10910180 for macOS group ID reading
-case "$OSTYPE" in
-linux*)
-  host_docker_gid="$(getent group docker | cut -d: -f3)"
-  ;;
-
-darwin*)
-  host_docker_gid="$(dscl . -read /Groups/docker | awk '($1 == "PrimaryGroupID:") { print $2 }')"
-  ;;
-
-*)
-  printf "'%s' is not supported for Openverse development. Only Linux and macOS are supported. Use WSL if on Windows." "$OSTYPE" >>/dev/stderr
-  exit 1
-  ;;
-esac
-
 suppress_output() {
   "$@" 2>/dev/null 1>/dev/null
 }
@@ -28,7 +12,6 @@ run_args=(
   --name openverse-dev-env
   --env "OPENVERSE_PROJECT=$OPENVERSE_PROJECT"
   --env "TERM=xterm-256color"
-  --user "$UID:$host_docker_gid"
   --network host
   # Bind the repo to the same exact location inside the container so that pre-commit
   # and others don't get confused about where files are supposed to be

--- a/ov
+++ b/ov
@@ -75,7 +75,7 @@ clean)
 
 link)
   # Assumes XDG-like bin directory... there's probably a better way? :thinking:
-  ln -s "$_self" "${2:$HOME/.local/bin/ov}"
+  ln -s "$_self" "${2:-$HOME/.local/bin/ov}"
   ;;
 
 hook)


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes the Docker-based setup for Openverse usable on macOS. It has some rather major differences from the Linux-compatible implementation in #4343.

This PR
- drops user management entirely, running the container as the default user

  The original approach where user is being supplied to the container via `--user` is inherently incompatible with macOS because there is no `docker` group when running Docker containers on macOS either via Docker Compose or Orbstack.

- changes the preserved volume to target `/opt` instead of from `$HOME`

  This is a consequence of removing user management. This works in fundamentally the same way except that the tools need to be configured via env vars to use paths under `/opt`.

- removes redundant/autoinstalled packages, updates package explanations and fixes a typo in `ov link` command

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the same testing instructions as #4343 using a Mac. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
