### PR TITLE
Add rudimentary support for aliases in ov

### DIFF
--- a/docker/dev_env/shared_aliases.sh
+++ b/docker/dev_env/shared_aliases.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+# Aliases are defined as a one-dimensional bash array
+# where the odd-or-0 index entries are the aliases, and
+# the following even index is the expansion. We cannot use an
+# associative array because macOS's bash version is frozen and
+# doesn't support them.
+# **MULTI-WORD EXPANSIONS MUST BE QUOTED**, plain spaces
+# are the separator of bash array entries. See the `nuxt` alias as an example below.
+# Aliases are also currently limited in that they cannot reference each other or stack.
+
+declare -a shared_aliases
+export shared_aliases
+
+shared_aliases+=(
+  j 'just'
+  nuxt 'just p frontend dev'
+)

--- a/justfile
+++ b/justfile
@@ -66,6 +66,41 @@ install:
 @install-hooks:
     bash -c "cp ./docker/dev_env/hooks/* ./.git/hooks"
 
+# Create an `.ovprofile` as a starting point for development environment customisation. Does not make changes if the file already exists.
+init-ovprofile:
+    #! /usr/bin/env bash
+    [[ -f ./.ovprofile ]] && echo '.ovprofile already exists! No changes made.' && exit 0 || cat <<-'EOPROFILE' > ./.ovprofile
+    #! /usr/bin/env bash
+
+    # Personal modifications to the ov dev environment go here
+    # Use additional entries in the bash array to create aliases
+    # odd-or-0 index entries are the aliases, and even indexes are the expansion
+    # for the previous index
+    # Shared aliases (and more examples) are in docker/dev_env/shared_aliases.sh
+    # Run 'ov welcome' to try the included example personal alias
+
+    declare -a personal_aliases
+    export personal_aliases
+
+    personal_aliases+=(
+        welcome "just welcome-to-openverse"
+    )
+    EOPROFILE
+
+# Recipe used as example alias in default .ovprofile (see init-ovprofile)
+welcome-to-openverse:
+    #! /usr/bin/env bash
+    # ASCII art courtesy of http://patorjk.com/software/taag/#p=display&f=Big&t=Openverse
+    cat <<OPENVERSE
+      ___   ____   ___  ____   __ __    ___  ____    _____   ___
+     /   \ |    \ /  _]|    \ |  |  |  /  _]|    \  / ___/  /  _]
+    |     ||  o  )  [_ |  _  ||  |  | /  [_ |  D  )(   \_  /  [_
+    |  O  ||   _/    _]|  |  ||  |  ||    _]|    /  \__  ||    _]
+    |     ||  | |   [_ |  |  ||  :  ||   [_ |    \  /  \ ||   [_
+    |     ||  | |     ||  |  | \   / |     ||  .  \ \    ||     |
+     \___/ |__| |_____||__|__|  \_/  |_____||__|\_|  \___||_____|
+    OPENVERSE
+
 # Setup pre-commit as a Git hook
 precommit:
     #!/usr/bin/env bash

--- a/ov
+++ b/ov
@@ -12,6 +12,16 @@ _cmd="$1"
 
 dev_env="$OPENVERSE_PROJECT"/docker/dev_env
 
+# shellcheck source=/dev/null
+source "$dev_env"/shared_aliases.sh
+
+if [ -f "$OPENVERSE_PROJECT"/.ovprofile ]; then
+  # shellcheck source=/dev/null
+  source "$OPENVERSE_PROJECT"/.ovprofile
+else
+  declare -a personal_aliases
+fi
+
 if [[ $_cmd == "help" || -z $_cmd ]]; then
   cat <<-'EOF'
 Openverse development toolkit
@@ -57,7 +67,7 @@ fi
 case "$_cmd" in
 init)
   "$_self" build
-  "$_self" just install-hooks
+  "$_self" 'just install-hooks && just init-ovprofile'
   ;;
 
 build)
@@ -79,7 +89,21 @@ hook)
   ;;
 
 *)
-  "$dev_env"/run.sh "$@"
+  args=("$@")
+
+  # Iterate through personal aliases first to allow overriding the shared aliases
+  aliases=("${personal_aliases[@]}" "${shared_aliases[@]}")
+  while (("${#aliases[@]}")); do
+    _alias="${aliases[0]}"
+    _expansion="${aliases[1]}"
+    if [ "$_cmd" = "$_alias" ]; then
+      args=("$_expansion" "${@:2}")
+      break
+    fi
+    aliases=("${aliases[@]:2}")
+  done
+
+  "$dev_env"/run.sh "${args[@]}"
   ;;
 
 esac


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4407 by @sarayourfriend 
cc @dhruvkb and @AetherUnbound who will be the most immediately interested in this

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This approach is similar to the associative array approach, but worse because we cannot easily look up an alias by its name, and there's no non-trivial way for aliases to stack (i.e., refer to another alias). We could do that by not breaking, and continuing to replace the first entry in the `args` array each time an expansion is encountered, but that would make alias expansion and cross-reference dependent on the order in which they're defined.

This approach is also susceptible to coding errors, if the arrays are not an even number of entries, and it could be hard to debug that.

The Python alternative I've described in #4407 might be better in that regard. Implementing cross-referencing aliases would be trivial in Python (because we can use dicts) and there wouldn't be an ordering issue. It's also much harder to introduce a difficult to debug or non-obvious coding error with that approach.

I'll leave this as a draft and try the Python version to see which is better.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try `ov j`, `ov nuxt`, and `ov welcome`. Define your own aliases. See if you understand the approach, does it feel easy to use, or is it too complicated?

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
