### PR TITLE
Add report creation, better filtering and more improvements to admin views for media

### DIFF
--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -288,10 +288,7 @@ class MediaListAdmin(admin.ModelAdmin):
     #############
 
     change_list_template = "admin/api/media/change_list.html"
-    list_display = (
-        "identifier",
-        "has_sensitive_text",
-    )
+    list_display = ("identifier",)
     list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
     sortable_by = ()  # Ordering is defined in ``get_queryset``.
@@ -306,8 +303,13 @@ class MediaListAdmin(admin.ModelAdmin):
                 "pending_report_count",
                 "oldest_report_date",
                 "pending_reports_links",
+                "has_sensitive_text",
             )
-        return self.list_display
+        else:
+            return self.list_display + (
+                "source",
+                "provider",
+            )
 
     def total_report_count(self, obj):
         return obj.total_report_count

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -238,14 +238,14 @@ class MediaListAdmin(admin.ModelAdmin):
         # appear just before the catch-all view.
         urls[-1:-1] = [
             path(
-                "<path:object_id>/complain/",
-                wrap(self.complain_view),
-                name=f"{app}_{model}_complain",
+                "<path:object_id>/report_create/",
+                wrap(self.report_create_view),
+                name=f"{app}_{model}_report_create",
             ),
             path(
-                "<path:object_id>/moderate/",
-                wrap(self.moderate_view),
-                name=f"{app}_{model}_moderate",
+                "<path:object_id>/decision_create/",
+                wrap(self.decision_create_view),
+                name=f"{app}_{model}_decision_create",
             ),
             path(
                 "<path:object_id>/lock/",
@@ -425,11 +425,11 @@ class MediaListAdmin(admin.ModelAdmin):
 
         return redirect(f"admin:api_{self.media_type}_change", object_id)
 
-    #################
-    # Moderate view #
-    #################
+    ########################
+    # Decision create view #
+    ########################
 
-    def moderate_view(self, request, object_id):
+    def decision_create_view(self, request, object_id):
         """
         Create a decision for the media object and associate selected
         reports referencing the media with this decision.
@@ -475,11 +475,11 @@ class MediaListAdmin(admin.ModelAdmin):
 
         return redirect(f"admin:api_{self.media_type}_change", object_id)
 
-    #################
-    # Complain view #
-    #################
+    ######################
+    # Report create view #
+    ######################
 
-    def complain_view(self, request, object_id):
+    def report_create_view(self, request, object_id):
         """Create a report for the media object."""
 
         if request.method == "POST":

--- a/api/api/admin/media_report.py
+++ b/api/api/admin/media_report.py
@@ -161,25 +161,51 @@ class PredeterminedOrderChangelist(ChangeList):
         return []
 
 
-class PendingRecordCountFilter(admin.SimpleListFilter):
-    title = "pending record count"
-    parameter_name = "pending_record_count"
+def get_pending_record_filter(media_type: str):
+    class PendingRecordCountFilter(admin.SimpleListFilter):
+        title = "pending record count"
+        parameter_name = "pending_record_count"
 
-    def choices(self, changelist):
-        """Set default to "pending" rather than "all"."""
-        choices = list(super().choices(changelist))
-        choices[0]["display"] = "Pending"
-        return choices
+        def choices(self, changelist):
+            for lookup, title in self.lookup_choices:
+                yield {
+                    "selected": self.value() == lookup,
+                    "query_string": changelist.get_query_string(
+                        {self.parameter_name: lookup}, []
+                    ),
+                    "display": title,
+                }
 
-    def lookups(self, request, model_admin):
-        return (("all", "All"),)
+        def lookups(self, request, model_admin):
+            return [
+                (None, "Moderation queue"),
+                ("all", "All"),
+            ]
 
-    def queryset(self, request, queryset):
-        value = self.value()
-        if value != "all":
-            return queryset.filter(pending_report_count__gt=0)
+        def queryset(self, request, qs):
+            value = self.value()
+            if value is None:
+                # Filter down to only instances with reports
+                qs = qs.filter(**{f"{media_type}_report__isnull": False})
 
-        return queryset
+                # Annotate and order by report count
+                qs = qs.annotate(total_report_count=Count(f"{media_type}_report"))
+                # Show total pending reports by subtracting the number of reports
+                # from the number of reports that have decisions
+                qs = qs.annotate(
+                    pending_report_count=F("total_report_count")
+                    - Count(f"{media_type}_report__decision__pk")
+                )
+                qs = qs.annotate(
+                    oldest_report_date=Min(f"{media_type}_report__created_at")
+                )
+                qs = qs.order_by(
+                    "-total_report_count", "-pending_report_count", "oldest_report_date"
+                )
+
+            return qs
+
+    return PendingRecordCountFilter
 
 
 class MediaListAdmin(admin.ModelAdmin):
@@ -264,16 +290,24 @@ class MediaListAdmin(admin.ModelAdmin):
     change_list_template = "admin/api/media/change_list.html"
     list_display = (
         "identifier",
-        "total_report_count",
-        "pending_report_count",
-        "oldest_report_date",
-        "pending_reports_links",
         "has_sensitive_text",
     )
-    list_filter = (PendingRecordCountFilter,)
     list_display_links = ("identifier",)
     search_fields = _production_deferred("identifier")
     sortable_by = ()  # Ordering is defined in ``get_queryset``.
+
+    def get_list_filter(self, request):
+        return (get_pending_record_filter(self.media_type),)
+
+    def get_list_display(self, request):
+        if request.GET.get("pending_record_count") != "all":
+            return self.list_display + (
+                "total_report_count",
+                "pending_report_count",
+                "oldest_report_date",
+                "pending_reports_links",
+            )
+        return self.list_display
 
     def total_report_count(self, obj):
         return obj.total_report_count
@@ -474,33 +508,6 @@ class MediaListAdmin(admin.ModelAdmin):
     #############
     # Overrides #
     #############
-
-    # TODO: This construct breaks down if a decision is associated with
-    #   a media item that does not have any reports. Such an item cannot
-    #   be reached at the URL ``admin/api/{media_type}/{id}/change/``.
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        # Return all available image if this is for an autocomplete request
-        if "autocomplete" in request.path:
-            return qs
-
-        # Filter down to only instances with reports
-        qs = qs.filter(**{f"{self.media_type}_report__isnull": False})
-        # Annotate and order by report count
-        qs = qs.annotate(total_report_count=Count(f"{self.media_type}_report"))
-        # Show total pending reports by subtracting the number of reports
-        # from the number of reports that have decisions
-        qs = qs.annotate(
-            pending_report_count=F("total_report_count")
-            - Count(f"{self.media_type}_report__decision__pk")
-        )
-        qs = qs.annotate(
-            oldest_report_date=Min(f"{self.media_type}_report__created_at")
-        )
-        qs = qs.order_by(
-            "-total_report_count", "-pending_report_count", "oldest_report_date"
-        )
-        return qs
 
     def get_changelist(self, request, **kwargs):
         return PredeterminedOrderChangelist

--- a/api/api/templates/admin/api/components/media_complain.html
+++ b/api/api/templates/admin/api/components/media_complain.html
@@ -1,0 +1,38 @@
+{% comment %}
+Props:
+- media_type
+- media_obj
+- report_form
+{% endcomment %}
+
+<fieldset class="module aligned">
+  <h2>Create report</h2>
+
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        {{ report_form.reason.label_tag }}
+        {{ report_form.reason }}
+      </div>
+      <div class="help">{{ report_form.reason.help_text }}</div>
+    </div>
+  </div>
+
+  <div class="form-row field-height">
+    <div>
+      <div class="flex-container">
+        {{ report_form.description.label_tag }}
+        {{ report_form.description }}
+      </div>
+      <div class="help">{{ report_form.description.help_text }}</div>
+    </div>
+  </div>
+
+  <div class="p-10px">
+    <input type="submit" form="report-create" value="Create report">
+  </div>
+
+  <style>
+    .p-10px { padding: 10px; }
+  </style>
+</fieldset>

--- a/api/api/templates/admin/api/components/media_decisions.html
+++ b/api/api/templates/admin/api/components/media_decisions.html
@@ -54,9 +54,9 @@ Props:
     .w-full { width: 100%; }
   </style>
   {% else %}
-  <p>
+  <div class="description">
     There are no decisions. You can take a decision using the form
     "Create decision" above.
-  </p>
+  </div>
   {% endif %}
 </fieldset>

--- a/api/api/templates/admin/api/components/media_decisions.html
+++ b/api/api/templates/admin/api/components/media_decisions.html
@@ -9,6 +9,7 @@ Props:
 <fieldset class="module">
   <h2>Decisions</h2>
 
+  {% if decision_throughs %}
   <table class="w-full">
     <thead>
       <tr>
@@ -52,4 +53,10 @@ Props:
     .hidden { display: none; }
     .w-full { width: 100%; }
   </style>
+  {% else %}
+  <p>
+    There are no decisions. You can take a decision using the form
+    "Create decision" above.
+  </p>
+  {% endif %}
 </fieldset>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -17,6 +17,8 @@ Props:
     or more of them and creating a decision.
   </p>
   {% endif %}
+
+  {% if reports %}
   <table class="w-full">
     <thead>
       <tr>
@@ -75,6 +77,13 @@ Props:
     .hidden { display: none; }
     .w-full { width: 100%; }
   </style>
+  {% else %}
+  <p>
+    There are no reports. You can file a report using the form "Create
+    report" above.
+  </p>
+  {% endif %}
+
   {% if pending_report_count %}
   <div class="form-row field-height">
     <div>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -6,6 +6,8 @@ Props:
 - mod_form
 {% endcomment %}
 
+{% load static %}
+
 <fieldset class="module aligned">
   <h2>Reports/Create decision</h2>
 
@@ -51,9 +53,9 @@ Props:
         <td>{{ report.description }}</td>
         <td>
           {% if report.is_pending %}
-          <img src="/static/admin/img/icon-yes.svg" alt="False">
+          <img src="{% static 'admin/img/icon-yes.svg' %}" alt="False">
           {% else %}
-          <img src="/static/admin/img/icon-no.svg" alt="False">
+          <img src="{% static 'admin/img/icon-no.svg' %}" alt="False">
           {% endif %}
         </td>
         <td>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -7,7 +7,7 @@ Props:
 {% endcomment %}
 
 <fieldset class="module aligned">
-  <h2>Reports</h2>
+  <h2>Reports/Create decision</h2>
 
   {% if pending_report_count %}
   <p>

--- a/api/api/templates/admin/api/components/media_reports.html
+++ b/api/api/templates/admin/api/components/media_reports.html
@@ -12,10 +12,13 @@ Props:
   <h2>Reports/Create decision</h2>
 
   {% if pending_report_count %}
-  <p>
+  <div class="description mb-5px">
     You can take a decision for the pending reports by selecting one
     or more of them and creating a decision.
-  </p>
+  </div>
+  <style>
+    .mb-5px { margin-bottom: 5px; }
+  </style>
   {% endif %}
 
   {% if reports %}
@@ -78,10 +81,10 @@ Props:
     .w-full { width: 100%; }
   </style>
   {% else %}
-  <p>
+  <div class="description">
     There are no reports. You can file a report using the form "Create
     report" above.
-  </p>
+  </div>
   {% endif %}
 
   {% if pending_report_count %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -41,8 +41,8 @@
 {% endblock %}
 
 {% block content %}{{ block.super }}
-<!-- Fields for this form are supplied separately in `media_reports.html`. -->
 {% if pending_report_count %}
+<!-- Fields for this form are supplied separately in `media_reports.html`. -->
 <form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_moderate' object_id %}">
   {% csrf_token %}
 </form>

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -41,6 +41,15 @@
 {% endblock %}
 
 {% block content %}{{ block.super }}
+<!-- Fields for this form are supplied separately in `media_complain.html`. -->
+<form id="report-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_complain' object_id %}">
+  {% csrf_token %}
+  <input
+    type="hidden"
+    name="media_obj"
+    value="{{ media_obj.identifier }}">
+</form>
+
 {% if pending_report_count %}
 <!-- Fields for this form are supplied separately in `media_reports.html`. -->
 <form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_moderate' object_id %}">
@@ -55,6 +64,7 @@
 
 {% block after_field_sets %}
 {% include 'admin/api/components/media_additional.html' with media_type=media_type media_obj=media_obj tags=tags only %}
+{% include 'admin/api/components/media_complain.html' with media_type=media_type media_obj=media_obj report_form=report_form only %}
 {% include 'admin/api/components/media_reports.html' with media_type=media_type reports=reports pending_report_count=pending_report_count mod_form=mod_form only %}
 {% include 'admin/api/components/media_decisions.html' with media_type=media_type decision_throughs=decision_throughs only %}
 {% endblock %}

--- a/api/api/templates/admin/api/media/change_form.html
+++ b/api/api/templates/admin/api/media/change_form.html
@@ -42,7 +42,7 @@
 
 {% block content %}{{ block.super }}
 <!-- Fields for this form are supplied separately in `media_complain.html`. -->
-<form id="report-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_complain' object_id %}">
+<form id="report-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_report_create' object_id %}">
   {% csrf_token %}
   <input
     type="hidden"
@@ -52,7 +52,7 @@
 
 {% if pending_report_count %}
 <!-- Fields for this form are supplied separately in `media_reports.html`. -->
-<form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_moderate' object_id %}">
+<form id="decision-create" method="POST" action="{% url 'admin:api_'|add:media_type|add:'_decision_create' object_id %}">
   {% csrf_token %}
 </form>
 {% endif %}


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4412 by @dhruvkb 
Fixes #4413 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- updates the sidebar filter to show both moderation queue and all media items
- enables the creation of reports from the media change view
- makes code quality and interface improvements
  - use of descriptions as per Django admin UI
  - changing hardcoded URLs to `{% static %}`
  - showing helpful messages when reports/decisions do not exist

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out the PR and run the dev server.
2. Go to the image/audio list, you should see the moderation queue by default.
3. Click on "All" in the sidebar, you should now see all 5000 media items listed.
4. Open an item that's not in the moderation queue, you should see descriptive messages in the report and decision list sections.
5. Create a report using the form in the "Create report", the report should appear in the "Reports" section under it.
6. Take a decision for the report using the "Create decision" section, the decision should appear in the "Decisions" section under it.

This way the complete flow for reporting and moderating any individual media item is present in one page. However moderation flow involving multiple media items cannot be accomplished using this process.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
