### PR TITLE
Add `backfillmoderationdecision` management command

### DIFF
--- a/api/api/management/commands/backfillmoderationdecision.py
+++ b/api/api/management/commands/backfillmoderationdecision.py
@@ -1,0 +1,101 @@
+import argparse
+
+from django.contrib.auth import get_user_model
+
+from django_tqdm import BaseCommand
+
+from api.models import AudioDecision, AudioReport, ImageDecision, ImageReport
+from api.models.media import DMCA, MATURE_FILTERED, NO_ACTION, PENDING
+
+
+class Command(BaseCommand):
+    help = "Back-fill the moderation decision table for a given media type."
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Count reports to process, and don't do anything else.",
+            type=bool,
+            default=True,
+            action=argparse.BooleanOptionalAction,
+        )
+        parser.add_argument(
+            "--media-type",
+            help="The media type to back-fill moderation decisions.",
+            type=str,
+            default="image",
+            choices=["image", "audio"],
+        )
+        parser.add_argument(
+            "--moderator",
+            help="The username of the moderator to attribute the decisions to.",
+            type=str,
+            default="opener",
+        )
+
+    def handle(self, *args, **options):
+        dry = options["dry_run"]
+        username = options["moderator"]
+        media_type = options["media_type"]
+
+        MediaReport = ImageReport
+        MediaDecision = ImageDecision
+        if media_type == "audio":
+            MediaReport = AudioReport
+            MediaDecision = AudioDecision
+
+        non_pending_reports = MediaReport.objects.filter(decision=None).exclude(
+            status=PENDING
+        )
+        count_to_process = non_pending_reports.count()
+
+        if dry:
+            self.info(
+                f"{count_to_process} {media_type} reports to back-fill. "
+                f"This is a dry run, exiting without making changes."
+            )
+            return
+
+        if not count_to_process:
+            self.info("No reports to process.")
+            return
+
+        t = self.tqdm(total=count_to_process)
+
+        User = get_user_model()
+        try:
+            moderator = User.objects.get(username=username)
+        except User.DoesNotExist:
+            t.error(f"User '{username}' not found.")
+            return
+
+        for report in non_pending_reports:
+            decision = MediaDecision.objects.create(
+                action=self.get_action(report),
+                moderator=moderator,
+                notes="__backfilled_from_report_status",
+            )
+            report.decision = decision
+            report.save()
+            t.update(1)
+
+        t.info(
+            self.style.SUCCESS(
+                f"Created {count_to_process} {media_type} moderation decisions from existing reports."
+            )
+        )
+
+    @staticmethod
+    def get_action(report):
+        if report.status == MATURE_FILTERED:
+            return "confirmed_sensitive"
+
+        if report.status == NO_ACTION:
+            return "rejected_reports"
+
+        # Cases with status = DEINDEXED
+        if report.reason == DMCA:
+            return "deindexed_copyright"
+
+        return "deindexed_sensitive"  # For reasons MATURE and OTHER

--- a/api/api/management/commands/backfillmoderationdecision.py
+++ b/api/api/management/commands/backfillmoderationdecision.py
@@ -4,13 +4,14 @@ from django.contrib.auth import get_user_model
 
 from django_tqdm import BaseCommand
 
+from api.constants.moderation import DecisionAction
 from api.models import AudioDecision, AudioReport, ImageDecision, ImageReport
 from api.models.media import DMCA, MATURE_FILTERED, NO_ACTION, PENDING
 
 
 class Command(BaseCommand):
     help = "Back-fill the moderation decision table for a given media type."
-    batch_size = 100
+    batch_size = 3
 
     @staticmethod
     def add_arguments(parser):
@@ -93,13 +94,13 @@ class Command(BaseCommand):
     @staticmethod
     def get_action(report):
         if report.status == MATURE_FILTERED:
-            return "confirmed_sensitive"
+            return DecisionAction.MARKED_SENSITIVE
 
         if report.status == NO_ACTION:
-            return "rejected_reports"
+            return DecisionAction.REJECTED_REPORTS
 
         # Cases with status = DEINDEXED
         if report.reason == DMCA:
-            return "deindexed_copyright"
+            return DecisionAction.DEINDEXED_COPYRIGHT
 
-        return "deindexed_sensitive"  # For reasons MATURE and OTHER
+        return DecisionAction.DEINDEXED_SENSITIVE  # For reasons MATURE and OTHER

--- a/api/test/factory/models/audio.py
+++ b/api/test/factory/models/audio.py
@@ -3,7 +3,11 @@ from factory.django import DjangoModelFactory
 
 from api.models.audio import Audio, AudioAddOn, AudioReport, SensitiveAudio
 from test.factory.faker import Faker
-from test.factory.models.media import IdentifierFactory, MediaFactory, MediaReportFactory
+from test.factory.models.media import (
+    IdentifierFactory,
+    MediaFactory,
+    MediaReportFactory,
+)
 
 
 class SensitiveAudioFactory(DjangoModelFactory):

--- a/api/test/factory/models/audio.py
+++ b/api/test/factory/models/audio.py
@@ -3,7 +3,7 @@ from factory.django import DjangoModelFactory
 
 from api.models.audio import Audio, AudioAddOn, AudioReport, SensitiveAudio
 from test.factory.faker import Faker
-from test.factory.models.media import IdentifierFactory, MediaFactory
+from test.factory.models.media import IdentifierFactory, MediaFactory, MediaReportFactory
 
 
 class SensitiveAudioFactory(DjangoModelFactory):
@@ -29,7 +29,7 @@ class AudioAddOnFactory(DjangoModelFactory):
     waveform_peaks = Faker("waveform")
 
 
-class AudioReportFactory(DjangoModelFactory):
+class AudioReportFactory(MediaReportFactory):
     class Meta:
         model = AudioReport
 

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from django.contrib.auth import get_user_model
 
 import factory
 from factory.django import DjangoModelFactory
@@ -67,3 +68,8 @@ class AccessTokenFactory(DjangoModelFactory):
         tzinfo=timezone.get_current_timezone(),
     )
     application = factory.SubFactory(ThrottledApplicationFactory)
+
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = get_user_model()

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -1,5 +1,5 @@
-from django.utils import timezone
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 import factory
 from factory.django import DjangoModelFactory

--- a/api/test/unit/management/commands/test_backfillmoderationdecision.py
+++ b/api/test/unit/management/commands/test_backfillmoderationdecision.py
@@ -4,6 +4,7 @@ from django.core.management import call_command
 
 import pytest
 
+from api.constants.moderation import DecisionAction
 from api.models import (
     DEINDEXED,
     DMCA,
@@ -44,15 +45,15 @@ def make_reports(media_type, reason: str, status: str, count: int = 1):
 @pytest.mark.parametrize(
     ("reason", "status", "expected_action"),
     (
-        (MATURE, MATURE_FILTERED, "confirmed_sensitive"),
-        (DMCA, MATURE_FILTERED, "confirmed_sensitive"),
-        (OTHER, MATURE_FILTERED, "confirmed_sensitive"),
-        (MATURE, NO_ACTION, "rejected_reports"),
-        (DMCA, NO_ACTION, "rejected_reports"),
-        (OTHER, NO_ACTION, "rejected_reports"),
-        (MATURE, DEINDEXED, "deindexed_sensitive"),
-        (DMCA, DEINDEXED, "deindexed_copyright"),
-        (OTHER, DEINDEXED, "deindexed_sensitive"),
+        (MATURE, MATURE_FILTERED, DecisionAction.MARKED_SENSITIVE),
+        (DMCA, MATURE_FILTERED, DecisionAction.MARKED_SENSITIVE),
+        (OTHER, MATURE_FILTERED, DecisionAction.MARKED_SENSITIVE),
+        (MATURE, NO_ACTION, DecisionAction.REJECTED_REPORTS),
+        (DMCA, NO_ACTION, DecisionAction.REJECTED_REPORTS),
+        (OTHER, NO_ACTION, DecisionAction.REJECTED_REPORTS),
+        (MATURE, DEINDEXED, DecisionAction.DEINDEXED_SENSITIVE),
+        (DMCA, DEINDEXED, DecisionAction.DEINDEXED_COPYRIGHT),
+        (OTHER, DEINDEXED, DecisionAction.DEINDEXED_SENSITIVE),
     ),
 )
 @pytest.mark.parametrize(("media_type"), ("image", "audio"))

--- a/api/test/unit/management/commands/test_backfillmoderationdecision.py
+++ b/api/test/unit/management/commands/test_backfillmoderationdecision.py
@@ -1,10 +1,19 @@
 from io import StringIO
-import pytest
 
 from django.core.management import call_command
 
-from api.models import AudioDecision, ImageDecision
-from api.models import DMCA, MATURE, OTHER, MATURE_FILTERED, NO_ACTION, DEINDEXED
+import pytest
+
+from api.models import (
+    DEINDEXED,
+    DMCA,
+    MATURE,
+    MATURE_FILTERED,
+    NO_ACTION,
+    OTHER,
+    AudioDecision,
+    ImageDecision,
+)
 from test.factory.models.audio import AudioReportFactory
 from test.factory.models.image import ImageReportFactory
 from test.factory.models.oauth2 import UserFactory
@@ -31,6 +40,7 @@ def make_reports(media_type, reason: str, status: str, count: int = 1):
     else:
         ImageReportFactory.create_batch(count, status=status, reason=reason)
 
+
 @pytest.mark.parametrize(
     ("reason", "status", "expected_action"),
     (
@@ -43,17 +53,19 @@ def make_reports(media_type, reason: str, status: str, count: int = 1):
         (MATURE, DEINDEXED, "deindexed_sensitive"),
         (DMCA, DEINDEXED, "deindexed_copyright"),
         (OTHER, DEINDEXED, "deindexed_sensitive"),
-    )
+    ),
 )
 @pytest.mark.parametrize(("media_type"), ("image", "audio"))
 @pytest.mark.django_db
-def test_create_moderation_decision_for_reports(media_type, reason, status, expected_action):
+def test_create_moderation_decision_for_reports(
+    media_type, reason, status, expected_action
+):
     username = "opener"
     UserFactory.create(username=username)
 
     make_reports(media_type=media_type, reason=reason, status=status)
 
-    out , err = call_cmd(dry_run=False, media_type=media_type, moderator=username)
+    out, err = call_cmd(dry_run=False, media_type=media_type, moderator=username)
 
     MediaDecision = ImageDecision if media_type == "image" else AudioDecision
     assert MediaDecision.objects.count() == 1

--- a/api/test/unit/management/commands/test_backfillmoderationdecision.py
+++ b/api/test/unit/management/commands/test_backfillmoderationdecision.py
@@ -1,0 +1,72 @@
+from io import StringIO
+import pytest
+
+from django.core.management import call_command
+
+from api.models import AudioDecision, ImageDecision
+from api.models import DMCA, MATURE, OTHER, MATURE_FILTERED, NO_ACTION, DEINDEXED
+from test.factory.models.audio import AudioReportFactory
+from test.factory.models.image import ImageReportFactory
+from test.factory.models.oauth2 import UserFactory
+
+
+def call_cmd(**options):
+    out = StringIO()
+    err = StringIO()
+    call_command(
+        "backfillmoderationdecision",
+        **options,
+        stdout=out,
+        stderr=err,
+    )
+    res = out.getvalue(), err.getvalue()
+    print(res)
+
+    return res
+
+
+def make_reports(media_type, reason: str, status: str, count: int = 1):
+    if media_type == "audio":
+        AudioReportFactory.create_batch(count, status=status, reason=reason)
+    else:
+        ImageReportFactory.create_batch(count, status=status, reason=reason)
+
+@pytest.mark.parametrize(
+    ("reason", "status", "expected_action"),
+    (
+        (MATURE, MATURE_FILTERED, "confirmed_sensitive"),
+        (DMCA, MATURE_FILTERED, "confirmed_sensitive"),
+        (OTHER, MATURE_FILTERED, "confirmed_sensitive"),
+        (MATURE, NO_ACTION, "rejected_reports"),
+        (DMCA, NO_ACTION, "rejected_reports"),
+        (OTHER, NO_ACTION, "rejected_reports"),
+        (MATURE, DEINDEXED, "deindexed_sensitive"),
+        (DMCA, DEINDEXED, "deindexed_copyright"),
+        (OTHER, DEINDEXED, "deindexed_sensitive"),
+    )
+)
+@pytest.mark.parametrize(("media_type"), ("image", "audio"))
+@pytest.mark.django_db
+def test_create_moderation_decision_for_reports(media_type, reason, status, expected_action):
+    username = "opener"
+    UserFactory.create(username=username)
+
+    make_reports(media_type=media_type, reason=reason, status=status)
+
+    out , err = call_cmd(dry_run=False, media_type=media_type, moderator=username)
+
+    MediaDecision = ImageDecision if media_type == "image" else AudioDecision
+    assert MediaDecision.objects.count() == 1
+    assert f"Created 1 {media_type} moderation decisions from existing reports." in out
+
+    decision = MediaDecision.objects.first()
+    assert decision.action == expected_action
+    assert decision.moderator.username == username
+
+
+@pytest.mark.django_db
+def test_catch_user_exception():
+    make_reports(media_type="image", reason=MATURE, status=MATURE_FILTERED)
+    _, err = call_cmd(dry_run=False, moderator="nonexistent")
+
+    assert "User 'nonexistent' not found." in err


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3641 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the command as described in the implementation plan section for [Deprecating and removing report status](https://docs.openverse.org/projects/proposals/trust_and_safety/content_report_moderation/20231208-implementation_plan_django_admin_moderator_access.html#deprecating-and-removing-report-status). It takes as options the media type, the username of the moderator (in production it should be `opener` but in local we use `deploy`) and a flag for whether to run the command or just get the count of report to process.

Verify that the mapping is according to the specification.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To test manually, create some reports, mark them with a `reason` other than "pending" and run the command.

```
just dj backfillmoderationdecision [--dry-run | --no-dry-run] [--media-type {image,audio}] --moderator deploy
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
