### PR TITLE
Add DAG to trim and deduplicate tags

### DIFF
--- a/catalog/dags/maintenance/trim_and_deduplicate_tags.py
+++ b/catalog/dags/maintenance/trim_and_deduplicate_tags.py
@@ -55,7 +55,7 @@ def trim_and_deduplicate_tags():
                                 )
                             )
                         FROM (
-                            SELECT DISTINCT ON (tag->>'name')
+                            SELECT DISTINCT ON (tag->>'name', tag->'provider')
                                 trim(tag->>'name') trimmed_name,
                                 tag
                             FROM jsonb_array_elements(tags || '[]'::jsonb) tag

--- a/catalog/dags/maintenance/trim_and_deduplicate_tags.py
+++ b/catalog/dags/maintenance/trim_and_deduplicate_tags.py
@@ -33,7 +33,7 @@ def trim_and_deduplicate_tags():
         trigger_dag_id=BATCHED_UPDATE_DAG_ID,
         wait_for_completion=True,
         execution_timeout=timedelta(hours=5),
-        max_active_tis_per_dag=1,
+        max_active_tis_per_dag=2,
         map_index_template="""{{ task.conf['table_name'] }}""",
         retries=0,
     ).expand(

--- a/catalog/dags/maintenance/trim_and_deduplicate_tags.py
+++ b/catalog/dags/maintenance/trim_and_deduplicate_tags.py
@@ -1,6 +1,4 @@
 """
-# Trim and Deduplicate Tags
-
 See the issue for context and motivation: https://github.com/WordPress/openverse/issues/4199
 
 This DAG triggers a run of the batched update DAG. It generates a new list of tags by
@@ -25,6 +23,7 @@ DAG_ID = "trim_and_deduplicate_tags"
     schedule=None,
     start_date=datetime(2024, 6, 3),
     tags=["database"],
+    doc_md=__doc__,
     max_active_runs=1,
     default_args=DAG_DEFAULT_ARGS,
 )

--- a/catalog/dags/maintenance/trim_and_deduplicate_tags.py
+++ b/catalog/dags/maintenance/trim_and_deduplicate_tags.py
@@ -1,0 +1,68 @@
+"""
+# Trim and Deduplicate Tags
+
+See the issue for context and motivation: https://github.com/WordPress/openverse/issues/4199
+
+This DAG triggers a run of the batched update DAG. It generates a new list of tags by
+trimming all existing tags and re-inserting only the distinct tags of the resulting list of tags.
+"""
+
+from datetime import datetime, timedelta
+from textwrap import dedent
+
+from airflow.decorators import dag
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+
+from common.constants import DAG_DEFAULT_ARGS, MEDIA_TYPES
+from database.batched_update.constants import DAG_ID as BATCHED_UPDATE_DAG_ID
+
+
+DAG_ID = "trim_and_deduplicate_tags"
+
+
+@dag(
+    dag_id=DAG_ID,
+    schedule=None,
+    start_date=datetime(2024, 6, 3),
+    tags=["database"],
+    max_active_runs=1,
+    default_args=DAG_DEFAULT_ARGS,
+)
+def trim_and_deduplicate_tags():
+    TriggerDagRunOperator.partial(
+        task_id=DAG_ID,
+        trigger_dag_id=BATCHED_UPDATE_DAG_ID,
+        wait_for_completion=True,
+        execution_timeout=timedelta(hours=5),
+        max_active_tis_per_dag=1,
+        map_index_template="""{{ task.conf['table_name'] }}""",
+        retries=0,
+    ).expand(
+        conf=[
+            {
+                "query_id": f"{DAG_ID}_{media_type}",
+                "table_name": media_type,
+                # Just iterate through all the rows, don't bother sub-selecting as it's impossible to reasonably do so for trimming
+                "select_query": "WHERE true",
+                "update_query": dedent(
+                    """SET tags = (
+                        SELECT
+                            jsonb_strip_nulls(jsonb_agg(trimed_and_deduped))
+                        FROM (
+                            SELECT DISTINCT ON (trim("name"))
+                                trim("name") "name",
+                                provider,
+                                accuracy
+                            FROM
+                                jsonb_to_recordset(tags || '[]'::jsonb) as x("name" text, provider text, accuracy float)
+                        ) trimed_and_deduped
+                    )"""
+                ),
+                "dry_run": False,
+            }
+            for media_type in MEDIA_TYPES
+        ]
+    )
+
+
+trim_and_deduplicate_tags()

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -54,6 +54,7 @@ The following are DAGs grouped by their primary tag:
 | [`recreate_image_popularity_calculation`](#recreate_media_type_popularity_calculation) | `None`            |
 | [`report_pending_reported_media`](#report_pending_reported_media)                      | `@weekly`         |
 | [`staging_database_restore`](#staging_database_restore)                                | `@monthly`        |
+| [`trim_and_deduplicate_tags`](#trim_and_deduplicate_tags)                              | `None`            |
 
 ### Elasticsearch
 
@@ -174,6 +175,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`smk_workflow`](#smk_workflow)
 1.  [`staging_database_restore`](#staging_database_restore)
 1.  [`stocksnap_workflow`](#stocksnap_workflow)
+1.  [`trim_and_deduplicate_tags`](#trim_and_deduplicate_tags)
 1.  [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)
 1.  [`wikimedia_reingestion_workflow`](#wikimedia_commons_workflow)
 1.  [`wordpress_workflow`](#wordpress_workflow)
@@ -1065,6 +1067,17 @@ Output: TSV file containing the image, the respective meta-data.
 Notes: <https://stocksnap.io/api/load-photos/date/desc/1>
 <https://stocksnap.io/faq> All images are licensed under CC0. No rate limits or
 authorization required. API is undocumented.
+
+----
+
+### `trim_and_deduplicate_tags`
+
+See the issue for context and motivation:
+https://github.com/WordPress/openverse/issues/4199
+
+This DAG triggers a run of the batched update DAG. It generates a new list of
+tags by trimming all existing tags and re-inserting only the distinct tags of
+the resulting list of tags.
 
 ----
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4199 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I've made use of the `batched_update_dag` to trim and deduplicate tags.

The approach is essentially: for each row, filter the list of tags distinct on the trimmed tag name, then set tags to the filtered list.
It's worth noting that I don't know whether doing this "for all rows" by using a `WHERE true` query is safe, and I'm asking for clarification on what the specific limitations of our data transformation are in https://github.com/WordPress/openverse/pull/4143#issuecomment-2143228283.

The update query produced by the batched update DAG looks like this:

```sql
UPDATE image
    SET tags = (
                        SELECT
                            jsonb_agg(
                                jsonb_set(
                                    deduped.tag,
                                    '{name}',
                                    to_jsonb(deduped.trimmed_name)
                                )
                            )
                        FROM (
                            SELECT DISTINCT ON (tag->>'name', tag->>'provider')
                                trim(tag->>'name') trimmed_name
                                tag
                            FROM jsonb_array_elements(tags || '[]'::jsonb) tag
                        ) deduped
                    )
    WHERE identifier in (
        SELECT identifier FROM trim_and_deduplicate_tags_image_rows_to_update
        WHERE row_id > 0 AND row_id <= 10000
        FOR UPDATE SKIP LOCKED
    );
```

There is one huge and significant caveat to this approach: it assumes that if the trimmed name and the provider match, that there is no other possibly meaningful difference. We can change that by adding additional clauses to `SELECT DISTINCT ON`. Are the name and provider the "unique" pair for a tag? I believe so, but I could be wrong!

The select query is just `WHERE true`, which selects every row. There's no other way to do this I can think of, because any _other_ approach would require doing the trimming and deduplication in the select query, which I don't believe is an option, and would require duplicating the transformation regardless (I think). Instead, this will just go through row-by-row and perform the transformation for each row, without causing a full table scan.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To test this, you need to augment your local data. I've done this locally with this very hacky query. It duplicates the existing tags of a single image. It also adds one of the tags known to be on this image with an additional entry of that tag but from a distinct provider. That lets you test that the distinct on clause works.

```sql
UPDATE image
SET tags = (
  SELECT jsonb_strip_nulls(jsonb_agg(augmented) || jsonb_agg(augmented) || jsonb_build_array(jsonb_object('{name, "   background  ", provider, unmagical_stats_bot}')))
  FROM (
    SELECT
      '  ' || "name" || ' ' "name",
      provider,
      accuracy
    FROM jsonb_to_recordset(tags || '[]'::jsonb) as x("name" text, provider text, accuracy float)
  ) augmented
)
WHERE identifier = '4bc43a04-ef46-4544-a0c1-63c63f56e276';
```
This is an awful way to test it, but I don't know what the better way is. @WordPress/openverse-catalog if y'all can give guidance here, beyond modifying this query to make it create more cases, is there a better way to test this? Is there a way to write unit tests for this?

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
