### PR TITLE
More precisely handle waveform generation failures

### DIFF
--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from rest_framework.decorators import action
-from rest_framework.exceptions import APIException, NotFound
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -92,13 +92,10 @@ class AudioViewSet(MediaViewSet):
 
         audio = self.get_object()
 
-        try:
-            obj = {"points": audio.get_or_create_waveform()}
-            serializer = self.get_serializer(obj)
+        obj = {"points": audio.get_or_create_waveform()}
+        serializer = self.get_serializer(obj)
 
-            return Response(status=200, data=serializer.data)
-        except Exception as e:
-            raise APIException(getattr(e, "message", str(e)))
+        return Response(status=200, data=serializer.data)
 
     @report
     @action(

--- a/api/test/integration/test_audio_integration.py
+++ b/api/test/integration/test_audio_integration.py
@@ -1,13 +1,14 @@
 """
 End-to-end API tests for audio.
 
-Can be used to verify a live deployment is functioning as designed.
-Run with the `pytest -s` command from this directory, inside the Docker
-container.
-
 Tests common to all media types are in ``test_media_integration.py``.
 """
 
+import os
+import subprocess
+from unittest import mock
+
+import pook
 import pytest
 
 
@@ -27,3 +28,40 @@ def test_audio_search_without_thumb(api_client):
     assert resp.status_code == 200
     parsed = resp.json()
     assert parsed["results"][0]["thumbnail"] is None
+
+
+def test_audio_waveform(api_client):
+    resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
+    assert resp.status_code == 200
+    parsed = resp.json()
+    assert parsed["len"] == len(parsed["points"])
+
+
+def test_audio_generation_failure(monkeypatch, api_client):
+    mock_subprocess_run = mock.Mock()
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "", "", "")
+    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+    resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
+    assert resp.status_code == 424
+    mock_subprocess_run.assert_called_once()
+
+
+def test_audio_waveform_cleanup_failure_does_not_fail_request(monkeypatch, api_client):
+    mock_os_remove = mock.Mock()
+    mock_os_remove.side_effect = OSError("beep boop")
+    monkeypatch.setattr(os, "remove", mock_os_remove)
+    resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
+    assert resp.status_code == 200
+    mock_os_remove.assert_called_once()
+
+
+@pytest.mark.pook(start_active=False)
+def test_audio_waveform_upstream_failure(api_client):
+    audio_res = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/")
+    audio = audio_res.json()
+
+    pook.on()
+    pook.get(audio["url"]).reply(500)
+
+    resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
+    assert resp.status_code == 424

--- a/api/test/integration/test_audio_integration.py
+++ b/api/test/integration/test_audio_integration.py
@@ -44,6 +44,7 @@ def test_audio_generation_failure(monkeypatch, api_client):
     resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
     assert resp.status_code == 424
     mock_subprocess_run.assert_called_once()
+    assert "Could not generate the waveform." == resp.json()["detail"]
 
 
 def test_audio_waveform_cleanup_failure_does_not_fail_request(monkeypatch, api_client):
@@ -65,3 +66,4 @@ def test_audio_waveform_upstream_failure(api_client):
 
     resp = api_client.get("/v1/audio/44540200-91eb-483d-9e99-38ce86a52fb6/waveform/")
     assert resp.status_code == 424
+    assert "problem connecting to the provider" in resp.json()["detail"]

--- a/api/test/integration/test_image_integration.py
+++ b/api/test/integration/test_image_integration.py
@@ -1,10 +1,6 @@
 """
 End-to-end API tests for images.
 
-Can be used to verify a live deployment is functioning as designed.
-Run with the `pytest -s` command from this directory, inside the Docker
-container.
-
 Tests common to all media types are in ``test_media_integration.py``.
 """
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4218 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I've added error handling in three specific places:

1. When downloading the audio and processing the response. This will cause a downstream exception similar to the 424 of the thumbnails
2. When generating the waveform using `audiowaveform`. This will cause a separate 424 indicating the issue was with waveform generation, not an upstream provider connection issue.
3. When removing the file. This will not cause the request to fail, but will be logged to Sentry for us to investigate. This happens after the request payload is actually generated, and does not need to prevent the request from completing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the unit tests and confirm they cover the error cases. There's no real way to manually test this that I can see, other than changing the code to explicitly cause the errors.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
