### PR TITLE
Capture thumbnails during europeana ingestion

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/catalog/dags/providers/provider_api_scripts/europeana.py
@@ -71,6 +71,7 @@ class EuropeanaRecordBuilder:
                 "license_info": self._get_license_info(data),
                 "filetype": self._get_filetype(item_data),
                 "filesize": self._get_filesize(item_data),
+                "thumbnail_url": self._get_thumbnail(data),
             } | self._get_image_dimensions(item_data)
 
             data_providers = set(record["meta_data"]["dataProvider"])
@@ -180,6 +181,14 @@ class EuropeanaRecordBuilder:
             return description[0].strip()
 
         return ""
+
+    def _get_thumbnail(self, data: dict) -> str | None:
+        # looks like edmPreview can either be a list or string
+        # this was inferred from observing the difference
+        # between sample data in item_full.json and europeana_example.json
+        # so it's best to handle both cases.
+        if preview := data.get("edmPreview", None):
+            return preview[0] if isinstance(preview, list) else preview
 
 
 class EuropeanaDataIngester(ProviderDataIngester):

--- a/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_europeana.py
@@ -206,6 +206,7 @@ def test_record_builder_get_record_data(ingester, record_builder):
         "width": 381,
         "filesize": 36272,
         "filetype": "jpeg",
+        "thumbnail_url": "https://api.europeana.eu/api/v2/thumbnail-by-url.json?uri=http%3A%2F%2Fbibliotecadigital.jcyl.es%2Fi18n%2Fcatalogo_imagenes%2Fimagen_id.cmd%3FidImagen%3D102620362&type=IMAGE",
     }
 
 
@@ -416,6 +417,7 @@ def test_process_image_data_with_sub_provider(record_builder):
         ),
         "meta_data": expect_meta_data,
         "source": "wellcome_collection",
+        "thumbnail_url": "https://api.europeana.eu/thumbnail/v2/url.json?uri=https%3A%2F%2Fiiif.wellcomecollection.org%2Fimage%2FV0013398.jpg%2Ffull%2F500%2C%2F0%2Fdefault.jpg&type=IMAGE",
     }
 
 
@@ -460,3 +462,24 @@ def test_record_builder_returns_None_if_missing_required_field(
         image_data[field_name] = value
 
     assert record_builder.get_record_data(image_data) is None
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        pytest.param({}, None, id="empty_object"),
+        pytest.param(
+            {"edmPreview": ["preview_is_list", "preview_is_list_2"]},
+            "preview_is_list",
+            id="preview_is_list",
+        ),
+        pytest.param(
+            {"edmPreview": "preview_is_string"},
+            "preview_is_string",
+            id="preview_is_string",
+        ),
+        pytest.param({"no": "thumbnail"}, None, id="no_thumbnail"),
+    ],
+)
+def test_get_thumbnail(data, expected, record_builder):
+    assert record_builder._get_thumbnail(data) == expected


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4403 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR aims to use the thumbnails already generated by provider(Europeana) at the point of ingestion, as against trying to generate our own.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
See `test_get_thumbnail` in `catalog/tests/dags/providers/provider_api_scripts/test_europeana.py`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
