### PR TITLE
Remove single quotes in values of Ingestion Server's TSV files

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -64,6 +64,8 @@ TLS_CACHE = {
     "www.eol.org": True,
     ".digitaltmuseum.org": True,
     "collections.musee-mccord.qc.ca": False,
+    ".stocksnap.io": True,
+    "cdn.stocksnap.io": True,
 }
 
 TMP_DIR = pathlib.Path("/tmp/cleaned_data").resolve()

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -8,6 +8,7 @@ import csv
 import logging as log
 import multiprocessing
 import pathlib
+import shutil
 import time
 import uuid
 from urllib.parse import urlparse
@@ -307,8 +308,9 @@ def clean_image_data(table):
     :return: None
     """
 
-    # Create directory to store cleaned data temporarily
-    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    # Recreate directory where cleaned data is stored
+    shutil.rmtree(TMP_DIR, ignore_errors=True)
+    TMP_DIR.mkdir(parents=True)
 
     # Map each table to the fields that need to be cleaned up. Then, map each
     # field to its cleanup function.

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -7,6 +7,7 @@ This includes cleaning up malformed URLs and filtering out undesirable tags.
 import csv
 import logging as log
 import multiprocessing
+import pathlib
 import time
 import uuid
 from urllib.parse import urlparse
@@ -64,6 +65,8 @@ TLS_CACHE = {
     "collections.musee-mccord.qc.ca": False,
 }
 
+TMP_DIR = pathlib.Path("/tmp/cleaned_data").resolve()
+
 
 def _tag_denylisted(tag):
     """Check if a tag is banned or contains a banned substring."""
@@ -106,9 +109,9 @@ class CleanupFunctions:
                 log.debug(f"Tested domain {_tld}")
 
             if tls_supported:
-                return f"'https://{url}'"
+                return f"https://{url}"
             else:
-                return f"'http://{url}'"
+                return f"http://{url}"
         else:
             return None
 
@@ -141,6 +144,7 @@ class CleanupFunctions:
 
         if update_required:
             fragment = Json(tag_output)
+            log.debug(f"Tags fragment: {fragment}")
             return fragment
         else:
             return None
@@ -200,7 +204,7 @@ class TlsTest:
             https = url.replace("http://", "https://")
             try:
                 res = re.get(https, timeout=2)
-                log.info(f"{https}:{res.status_code}")
+                log.info(f"tls_test - {https}:{res.status_code}")
                 return 200 <= res.status_code < 400
             except re.RequestException:
                 return False
@@ -243,23 +247,27 @@ def _clean_data_worker(rows, temp_table, sources_config, all_fields: list[str]):
             if clean:
                 cleaned_data[update_field] = clean
                 log.debug(
-                    f"Updated {update_field} for {identifier} "
-                    f"from '{dirty_value}' to '{clean}'"
+                    f"Updated {update_field} for {identifier}\n\t"
+                    f"from '{dirty_value}' \n\tto '{clean}'"
                 )
         # Generate SQL update for all the fields we just cleaned
         update_field_expressions = []
         for field, clean_value in cleaned_data.items():
-            update_field_expressions.append(f"{field} = {clean_value}")
-            # Save cleaned values for later
-            # (except for tags, which take up too much space)
             if field == "tags":
+                # The `clean_value` for tags already includes the single quotes,
+                # so it's not necessary to add them, and they're omitted in
+                # `cleaned_values` to save in files later because they take up
+                # too much disk space.
+                update_field_expressions.append(f"{field} = {clean_value}")
                 continue
+            update_field_expressions.append(f"{field} = '{clean_value}'")
             cleaned_values[field].append((identifier, clean_value))
 
         if len(update_field_expressions) > 0:
             update_query = f"""UPDATE {temp_table} SET
             {', '.join(update_field_expressions)} WHERE id = {_id}
             """
+            log.debug(f"Executing update query: \n\t{update_query}")
             write_cur.execute(update_query)
     log.info(f"TLS cache: {TLS_CACHE}")
     log.info("Worker committing changes...")
@@ -273,18 +281,17 @@ def _clean_data_worker(rows, temp_table, sources_config, all_fields: list[str]):
 
 
 def save_cleaned_data(result: dict) -> dict[str, int]:
-    log.info("Saving cleaned data...")
     start_time = time.perf_counter()
 
     cleanup_counts = {field: len(items) for field, items in result.items()}
     for field, cleaned_items in result.items():
         # Skip the tag field because the file is too large and fills up the disk
-        if field == "tag":
+        if field == "tag" or not cleaned_items:
             continue
-        if cleaned_items:
-            with open(f"{field}.tsv", "a") as f:
-                csv_writer = csv.writer(f, delimiter="\t")
-                csv_writer.writerows(cleaned_items)
+
+        with open(TMP_DIR.joinpath(f"{field}.tsv"), "a", encoding="utf-8") as f:
+            csv_writer = csv.writer(f, delimiter="\t")
+            csv_writer.writerows(cleaned_items)
 
     end_time = time.perf_counter()
     total_time = end_time - start_time
@@ -299,6 +306,9 @@ def clean_image_data(table):
     :param table: The staging table for the new data
     :return: None
     """
+
+    # Create directory to store cleaned data temporarily
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
 
     # Map each table to the fields that need to be cleaned up. Then, map each
     # field to its cleanup function.

--- a/ingestion_server/test/unit_tests/test_cleanup.py
+++ b/ingestion_server/test/unit_tests/test_cleanup.py
@@ -47,12 +47,12 @@ class TestCleanup:
         tls_support_cache = {}
         pook.get("https://flickr.com").reply(200)
         result = CleanupFunctions.cleanup_url(bad_url, tls_support_cache)
-        expected = "'https://flickr.com'"
+        expected = "https://flickr.com"
 
         bad_http = "neverssl.com"
         pook.get("https://neverssl.com").reply(500)
         result_http = CleanupFunctions.cleanup_url(bad_http, tls_support_cache)
-        expected_http = "'http://neverssl.com'"
+        expected_http = "http://neverssl.com"
         assert result == expected
         assert result_http == expected_http
 


### PR DESCRIPTION
## Fixes

Related to #3912 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes several issues on the Ingestion Server and prepares it to upload the files.
- Saves files of cleaned data to a specific temporary directory locally before being send to S3 (this was an @AetherUnbound's previous suggestion)
- Recreates the temp directory before cleaning to avoid mixing values between different data refresh processes
- **Removes single quotes on cleaned values**. Otherwise, the file has URLs surrounded by `'`, which isn't necessary and makes it quite complicated to save the data in a database table later
- Adds stocksnap to TLS_CACHE manually (for some reason, it was being registered as TLS not supported, which is not true)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Spin up the services
```
just a && just c
```

2. Make some rows of the image table in the catalog "dirty" by removing the protocol in one or more of the URLs fields (url, creator_url, or foreign_landing_url)

3. Run an image data refresh
```
# Optionally, delete the image index before to avoid the error of "index already exists"
just docker/es/delete-index image-init

just ingestion_server/ingest-upstream "image" "init"
```

4. Check the files are in the container, and check for their content:

```
just exec ingestion_server bash
```

```
ls /tmp/cleaned_data/
cat /tmp/cleaned_data/url.tsv
```

and that the content of each file is the identifier and values without quotes, eg.:

```
0041b4ec-f55e-4cd0-a491-84f41be72232	https://cdn.stocksnap.io/img-thumbs/960w/YUJXHHKSMI.jpg
00252271-e1dc-4faf-b840-7fcc386f2529	https://cdn.stocksnap.io/img-thumbs/960w/7HHEXNL6AQ.jpg
```
While in our bucket, you can find the manually uploaded files containing rows like the following:
```
4e406052-5d90-4c30-87b6-6f1b6ba533e7	'http://musee-mccord.qc.ca/ObjView/MP-1986.85.4.jpg'
3eba813d-6e24-4aa3-9fdb-9242d4bdfc4e	'https://flora-on.pt/Carlina-vulgaris_ori_v6Wn.jpg'
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog PRs) or the media properties generator (`just catalog/generate-docs media-props` for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
