### PR TITLE
Fix trim and deduplicate tags deduplication

### DIFF
--- a/catalog/dags/maintenance/trim_and_deduplicate_tags.py
+++ b/catalog/dags/maintenance/trim_and_deduplicate_tags.py
@@ -69,7 +69,7 @@ def trim_and_deduplicate_tags():
                                     )
                                 )
                             FROM (
-                                SELECT DISTINCT ON (tag->>'name', tag->'provider')
+                                SELECT DISTINCT ON (trimmed_name, tag->'provider')
                                     trim(tag->>'name') trimmed_name,
                                     tag
                                 FROM jsonb_array_elements({media_type}.tags || '[]'::jsonb) tag


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #4429 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I realised when working on https://github.com/WordPress/openverse/issues/4452 that the deduplication does not actually work on the _trimmed_ name :facepalm:. This fixes that by using the trimmed name in the distinct on clause.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To test, start with a fresh catalog DB (`just down -v && just catalog/init`) then run this sql in `just catalog/pgcli`):

```sql
UPDATE image
 SET tags = (
   SELECT jsonb_strip_nulls(jsonb_agg(augmented.tag) || jsonb_agg(augmented.new_tag) || jsonb_agg(augmen
 ted.old_tag))
   FROM (
     SELECT
         jsonb_build_object('name', '  ' || "name" || ' ', 'provider', provider, 'accuracy', accuracy) t
 ag,
         jsonb_build_object('name', "name", 'provider', 'magical_computer_vision', 'accuracy', accuracy)
  new_tag,
         jsonb_build_object('name', "name", 'provider', provider, 'accuracy', accuracy) old_tag
     FROM jsonb_to_recordset(tags || '[]'::jsonb) as x("name" text, provider text, accuracy float)
   ) augmented
 )
 WHERE identifier IN (SELECT identifier FROM image WHERE provider = 'flickr' AND tags IS NOT NULL LIMIT 10);
```

Then run the following sql in `just catalog/pgcli` to find one of the providers that got augmented with the "magical_computer_vision" provided tag:

```sql
select tags from image where jsonb_array_length(jsonb_path_query_array(tags, '$[*].provider 
 ? (@ == "magical_computer_vision")')) > 0;
```

Confirm the tags have duplicates both in terms of ones with whitespace, and ones with different providers (the computer vision ones).

Then, run the `trim_and_deduplicate_tags` DAG (you need to turn on the the batched update DAG as well).

Confirm that the select task logs 10 records for the image table to update.

Run the select again from above to query the same 10 rows that got updated for testing, and confirm they no longer have any duplicates _including within the `flickr` provider_. Without this fix, that last part is not true, you'll end up with duplicate _trimmed_ tags (on `main`).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
