### PR TITLE
Moved by tag from the fuzzy match group to exact match

### DIFF
--- a/catalog/dags/common/storage/media.py
+++ b/catalog/dags/common/storage/media.py
@@ -16,13 +16,13 @@ TAG_DENYLIST = {
     "no person",
     "squareformat",
     "undefined",
+    "by",
 }
 
 # Filter out tags that contain the following terms. All entrées should be lowercase.
 TAG_CONTAINS_DENYLIST = {
     ":",
     "=",
-    "by",
     "by-nc",
     "by-nc-nd",
     "by-nc-sa",

--- a/catalog/tests/dags/common/storage/test_media.py
+++ b/catalog/tests/dags/common/storage/test_media.py
@@ -566,7 +566,10 @@ def test_MediaStore_validates_filetype(filetype, url, expected_filetype):
         ),
         pytest.param(
             ["cc0", "valid", "garbage:=metacrap", "uploaded:by=flickrmobile", "frisby"],
-            [{"name": "frisby", "provider": "test_provider"}, {"name": "valid", "provider": "test_provider"} ],
+            [
+                {"name": "frisby", "provider": "test_provider"},
+                {"name": "valid", "provider": "test_provider"},
+            ],
             id="exclude tags by the denylist",
         ),
         pytest.param("notalist", None, id="nonlist tags should be None"),

--- a/catalog/tests/dags/common/storage/test_media.py
+++ b/catalog/tests/dags/common/storage/test_media.py
@@ -565,8 +565,8 @@ def test_MediaStore_validates_filetype(filetype, url, expected_filetype):
             id="sort and enriches multiple tags",
         ),
         pytest.param(
-            ["cc0", "valid", "garbage:=metacrap", "uploaded:by=flickrmobile"],
-            [{"name": "valid", "provider": "test_provider"}],
+            ["cc0", "valid", "garbage:=metacrap", "uploaded:by=flickrmobile", "frisby"],
+            [{"name": "frisby", "provider": "test_provider"}, {"name": "valid", "provider": "test_provider"} ],
             id="exclude tags by the denylist",
         ),
         pytest.param("notalist", None, id="nonlist tags should be None"),

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -29,6 +29,7 @@ TAG_DENYLIST = {
     "uploaded:by=flickrmobile",
     "uploaded:by=instagram",
     "flickriosapp:filter=flamingo",
+    "by",
 }
 
 # Filter out tags that contain the following terms. All entrees should be
@@ -39,7 +40,6 @@ TAG_CONTAINS_DENYLIST = {
     ":",
     "=",
     "cc0",
-    "by",
     "by-nc",
     "by-nd",
     "by-sa",


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
Fixes #4464 by @AetherUnbound 

## Description
The pull requests moved the by tag from the fuzzy match group to the exact match group.


## Testing Instructions
run the command `./ov just catalog/test`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
