### PR TITLE
Use a persistent container for `ov`

### DIFF
--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -60,8 +60,8 @@ RUN bash -c 'chmod -Rv 0777 /opt'
 # Avoid overwriting `.venv`'s from the host
 ENV PDM_VENV_IN_PROJECT="False"
 
-COPY entrypoint.sh /entrypoint.sh
+# Infinite sleep loop so that we create a persistent environment
+# Everything runs in the same container, rather than new one-off containers for each command
+ENTRYPOINT /bin/bash -c 'while true; do sleep 1; done;'
 
-ENTRYPOINT ["/entrypoint.sh"]
-
-CMD ["/bin/sh"]
+CMD ["/bin/bash"]

--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -60,8 +60,6 @@ RUN bash -c 'chmod -Rv 0777 /opt'
 # Avoid overwriting `.venv`'s from the host
 ENV PDM_VENV_IN_PROJECT="False"
 
-# Infinite sleep loop so that we create a persistent environment
-# Everything runs in the same container, rather than new one-off containers for each command
-ENTRYPOINT /bin/bash -c 'while true; do sleep 1; done;'
-
-CMD ["/bin/bash"]
+# The fedora container's default entrypoint + command behaviour is to keep running
+# so we do not need to modify entrypoint and command to use the container as a
+# persistent environment.

--- a/docker/dev_env/exec.py
+++ b/docker/dev_env/exec.py
@@ -26,4 +26,7 @@ def expand_aliases(args: list[str]):
 
 if __name__ == "__main__":
     args = expand_aliases(sys.argv[1:])
-    os.execvp(args[0], args)
+    try:
+        os.execvp(args[0], args)
+    except FileNotFoundError:
+        sys.stdout.buffer.write(args[0].encode() + b": command not found\n")

--- a/docker/dev_env/exec.py
+++ b/docker/dev_env/exec.py
@@ -21,8 +21,9 @@ def expand_aliases(args: list[str]):
     while args[0] in aliases:
         args = aliases.pop(args[0]) + args[1:]
 
-    print(*args)
+    return args
 
 
 if __name__ == "__main__":
-    expand_aliases(sys.argv[1:])
+    args = expand_aliases(sys.argv[1:])
+    os.execvp(args[0], args)

--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -86,4 +86,4 @@ else
   docker start "$existing_container_id" 1>/dev/null
 fi
 
-docker exec "${shared_args[@]}" "$container_name" "$@"
+docker exec "${shared_args[@]}" "$container_name" python3 docker/dev_env/exec.py "$@"

--- a/docker/dev_env/setup_env.sh
+++ b/docker/dev_env/setup_env.sh
@@ -9,10 +9,10 @@ fi
 
 cd "$OPENVERSE_PROJECT" || exit 1
 
-corepack install 1>/dev/null
+corepack install
 
 if [ -z "$(n ls 2>/dev/null)" ]; then
-  printf "Installing the specific Node JS version required by Openverse frontend; this is only necessary the first time the toolkit runs\n"
+  printf "Installing the specific Node JS version required by Openverse frontend\n"
   n install auto
 fi
 
@@ -26,7 +26,7 @@ pdm config venv.location "/opt/pdm/venvs"
 _python3s=(/opt/pdm/python/cpython@3.11.*/bin/python3)
 
 if [ ! -x "${_python3s[0]}" ]; then
-  printf "Installing the specific Python version required for pipenv environments; this is only necessary the first time the toolkit runs\n"
+  printf "Installing the specific Python version required for pipenv environments\n"
   pdm python install 3.11
   _python3s=(/opt/pdm/python/cpython@3.11.*/bin/python3)
 fi
@@ -50,5 +50,5 @@ if [ -n "$PDM_CACHE_DIR" ]; then
   pdm config install.cache on
 fi
 
-expanded_args=$(python3 "$OPENVERSE_PROJECT"/docker/dev_env/expand_aliases.py "$@")
-bash -c "$expanded_args"
+# expanded_args=$(python3 "$OPENVERSE_PROJECT"/docker/dev_env/expand_aliases.py "$@")
+# bash -c "$expanded_args"

--- a/docker/dev_env/setup_env.sh
+++ b/docker/dev_env/setup_env.sh
@@ -49,6 +49,3 @@ fi
 if [ -n "$PDM_CACHE_DIR" ]; then
   pdm config install.cache on
 fi
-
-# expanded_args=$(python3 "$OPENVERSE_PROJECT"/docker/dev_env/expand_aliases.py "$@")
-# bash -c "$expanded_args"

--- a/ov
+++ b/ov
@@ -24,18 +24,31 @@ COMMANDS
     Initialise the Openverse development toolkit for the first time
     Alias for:
 
-        ov build && ov setup-env && ov just install-hooks
+        ov build && ov setup-env && ov just install-hooks && ov just init-ov-aliases
 
   ov build [...ARGS]
     Build the Openverse development toolkit Docker image.
     ARGS are passed to `docker build`. See `docker build --help` for options.
 
+  ov setup-env
+    Setup the environment inside the container. `ov init` automatically runs this,
+    and in most cases you should not need to run this manually. However, you may
+    occasionally need to run it manually if tool requirements inside the container
+    change. This can also be a helpful debugging step if tools in the container are
+    not working as expected.
+
+  ov stop
+    Stop the persistent `ov` Docker container.
+
   ov clean
-    Remove the Openverse development toolkit Docker image and volume
+    Remove the Openverse development toolkit Docker container, image and volume.
     Use in conjunction with `ov init` to recreate the environment from
     scratch:
 
         ov clean && ov init
+
+    Warning: running `ov clean` will result in needing to fully rebuild the environment
+    including downloading tools handled by `ov setup-env` and pre-commit environments.
 
   ov hook HOOK
     Run Git hooks through pre-commit inside the development toolkit container
@@ -69,6 +82,10 @@ build)
 
 setup-env)
   "$_self" bash "$dev_env"/setup_env.sh
+  ;;
+
+stop)
+  docker stop openverse-dev-env
   ;;
 
 clean)

--- a/ov
+++ b/ov
@@ -17,17 +17,18 @@ if [[ $_cmd == "help" || -z $_cmd ]]; then
 Openverse development toolkit
 
 USAGE
-  ov <subcommand> [args]
+  ov <subcommand> [...ARGS]
 
 COMMANDS
   ov init
     Initialise the Openverse development toolkit for the first time
     Alias for:
 
-        ov build && ov just install-hooks
+        ov build && ov setup-env && ov just install-hooks
 
-  ov build
-    Build the Openverse development toolkit Docker image
+  ov build [...ARGS]
+    Build the Openverse development toolkit Docker image.
+    ARGS are passed to `docker build`. See `docker build --help` for options.
 
   ov clean
     Remove the Openverse development toolkit Docker image and volume
@@ -39,7 +40,7 @@ COMMANDS
   ov hook HOOK
     Run Git hooks through pre-commit inside the development toolkit container
 
-  ov COMMAND
+  ov COMMAND [...ARGS]
     Run COMMAND inside the development toolkit container
     Hints: The toolkit comes loaded with many tools for working with Openverse! Try
     some of the following:
@@ -57,14 +58,23 @@ fi
 case "$_cmd" in
 init)
   "$_self" build
-  "$_self" 'just install-hooks && just init-ov-aliases'
+  "$_self" setup-env
+  "$_self" just install-hooks
+  "$_self" just init-ov-aliases
   ;;
 
 build)
-  docker build -t openverse-dev-env:latest "$dev_env"
+  docker build "${@:2}" -t openverse-dev-env:latest "$dev_env"
+  ;;
+
+setup-env)
+  "$_self" bash "$dev_env"/setup_env.sh
   ;;
 
 clean)
+  docker kill openverse-dev-env
+  docker rm openverse-dev-env
+  docker rmi openverse-dev-env
   docker volume rm openverse-dev-env
   ;;
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4490 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Implements the solution described in the issue for using a persistent container to run `ov`. I've also added support on Linux for running commands as root (macOS already always runs commands in the container as root).

Anecdotally, `ov` commands do run noticeably faster for me. It's a matter of maybe 50-100ms at most, which is less so _faster_ and moreso just plain responsive feeling. If you happen to notice a change here one way or the other, please let me know. I'm curious to know how fast `docker ps` is on macOS hosts that have the virtual machine to contend with (my impression is they should be plenty fast?).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

To test this change:

1. Run `ov clean && ov init` to get a brand new environment set up
2. Make sure things still work, like `ov just api/up`, `ov just api/test`, `ov nuxt`, etc. Just pick some things you'd normally do with the development environment and try them out.
3. Prove the environment's persistence by running `ov sudo dnf update --downloadonly`. `dnf` should list some updates (hopefully some exist) and ask if you want to download them. Respond yes (type `y`, then return), and let them download. Now run the same command again, and respond yes again. dnf should report that all the packages are already downloaded. If you try the same process on `main`, the second time dnf will download the packages again, because the container environment was not persisted.

I will make sure the pinged reviewers include at least one macOS user and one Linux user. In doing so, the changes to accommodate `sudo` exercised in step 3 will be sufficiently tested cross platform.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
