### PR TITLE
Prevent concurrency between release app and draft releases

### DIFF
--- a/.github/workflows/draft_releases.yml
+++ b/.github/workflows/draft_releases.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - main
 
+# Prevent concurrency with other workflows in the "Release workflow group"
+# See https://github.com/WordPress/openverse/issues/4505 for context
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Freely interrupt release drafting workflows, they do not depend on each other and always generate the full release based on the previous one
-  cancel-in-progress: true
+  group: operates_on_github_releases
+  cancel-in-progress: false
 
 jobs:
   draft-release:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -4,16 +4,11 @@ on:
   release:
     types: [released]
 
-# The app-name expression is duplicated between here and `env` below because neither context is able to reference the other
-# but both need it
-concurrency: >
-  ${{ github.workflow }}-
-  ${{
-    startsWith(github.ref_name, 'api-') && 'api'
-    || startsWith(github.ref_name, 'ingestion_server-') && 'ingestion_server'
-    || startsWith(github.ref_name, 'catalog-') && 'catalog'
-    || startsWith(github.ref_name, 'frontend-') && 'frontend'
-  }}
+# Prevent concurrency with other workflows in the "Release workflow group"
+# See https://github.com/WordPress/openverse/issues/4505 for context
+concurrency:
+  group: operates_on_github_releases
+  cancel-in-progress: false
 
 jobs:
   release-app:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4505 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Prevent concurrency between these workflows by putting them in the same [concurrency group (GitHub docs)](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency). This means they will never run at the same time, and will queue until previous runs of either workflow are finished.

The "draft releases" workflow is very fast (< 1 minute, often around 30 seconds), so this will not add a big delay to "release app" (and therefore production deployments).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Confirm I've got the syntax right and my understanding of GitHub's concurrency groups is correct (refer to docs link above).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
