### PR TITLE
Log dead link verification request timings

### DIFF
--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -44,14 +44,26 @@ _timeout = aiohttp.ClientTimeout(total=2)
 
 
 async def _head(url: str, session: aiohttp.ClientSession) -> tuple[str, int]:
+    start_time = time.time()
+
     try:
         response = await session.head(
             url, allow_redirects=False, headers=HEADERS, timeout=_timeout
         )
-        return url, response.status
+        status = response.status
     except (aiohttp.ClientError, asyncio.TimeoutError) as exception:
         _log_validation_failure(exception)
-        return url, -1
+        status = -1
+
+    end_time = time.time()
+    logger.info(
+        "dead_link_validation_timing",
+        url=url,
+        status=status,
+        time=end_time - start_time,
+    )
+
+    return url, status
 
 
 # https://stackoverflow.com/q/55259755

--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -44,7 +44,7 @@ _timeout = aiohttp.ClientTimeout(total=2)
 
 
 async def _head(url: str, session: aiohttp.ClientSession) -> tuple[str, int]:
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     try:
         response = await session.head(
@@ -55,7 +55,7 @@ async def _head(url: str, session: aiohttp.ClientSession) -> tuple[str, int]:
         _log_validation_failure(exception)
         status = -1
 
-    end_time = time.time()
+    end_time = time.perf_counter()
     logger.info(
         "dead_link_validation_timing",
         url=url,

--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -43,9 +43,8 @@ def _get_expiry(status, default):
 _timeout = aiohttp.ClientTimeout(total=2)
 
 
-async def _head(url: str) -> tuple[str, int]:
+async def _head(url: str, session: aiohttp.ClientSession) -> tuple[str, int]:
     try:
-        session = await get_aiohttp_session()
         response = await session.head(
             url, allow_redirects=False, headers=HEADERS, timeout=_timeout
         )
@@ -58,7 +57,8 @@ async def _head(url: str) -> tuple[str, int]:
 # https://stackoverflow.com/q/55259755
 @async_to_sync
 async def _make_head_requests(urls: list[str]) -> list[tuple[str, int]]:
-    tasks = [asyncio.ensure_future(_head(url)) for url in urls]
+    session = await get_aiohttp_session()
+    tasks = [asyncio.ensure_future(_head(url, session)) for url in urls]
     responses = asyncio.gather(*tasks)
     await responses
     return responses.result()


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Part of https://github.com/WordPress/openverse/issues/4507 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
See the issue for rationale of both the `get_aiohttp_session` change and the new timing logs.

The PR does both, using `time.time` to calculate the request timing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the API locally with `./ov just api/up` (and `./ov just api/init` if you don't have data). Tail the logs with `./ov just logs web` and make an image request with `filter_dead=True` (this matches the production default): http://localhost:50280/v1/images/?filter_dead=True

In your logs, you should see a line like this for each verified link:

```
web-1  | 2024-06-18T03:30:03.753846Z [info     ] dead_link_validation_timing    [api.utils.check_dead_links] filename=__init__.py func_name=_head ip=172.18.0.1 lineno=59 request_id=50cdc9a5-cf63-4f1e-9df6-366ce3cce800 status=200 time=0.45412659645080566 url=https://live.staticflickr.com/65535/51747932079_de3b535418_b.jpg
```

Note that if you make the request again, the verification will be cached, and you will not see it on subsequent requests (this is just how dead link verification works). That also means that if you've made a verification request recently, you'll need to either choose a query that pulls records that you haven't verified yet, or run `./ov just exec cache redis-cli FLUSHALL` to wipe Redis clean.

Do the same on main and notice that instead of a timing log, you have a `get_aiohttp_session` log for each verified link. That's fixed in this PR too (see issue for rationale).

I did not add unit tests because I didn't think it made sense (far more complex to do that, I think), but existing tests will confirm that the original functionality hasn't changed, and a manual test will confirm the new logs are correct. This code will be removed as soon as we decide what to reduce the timeout to.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`just catalog/generate-docs media-props`
      for the catalog or `just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
