### PR TITLE
Add caching to frontend Nginx configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[nginx.conf.template]
+indent_size = 4
+
 [*.py]
 indent_size = 4
 

--- a/frontend/Dockerfile.nginx
+++ b/frontend/Dockerfile.nginx
@@ -19,7 +19,10 @@ LABEL org.opencontainers.image.source = "https://github.com/WordPress/openverse"
 
 WORKDIR /app
 
-COPY nginx.conf.template /etc/nginx/templates/openverse-frontend.conf.template
+RUN mkdir -p /data/nginx/cache
+
+COPY nginx/nginx.conf.template /etc/nginx/templates/openverse-frontend.conf.template
+COPY nginx/snippets /etc/nginx/snippets
 
 # Only environment variables with this prefix will be available in the template
 ENV NGINX_ENVSUBST_FILTER="OPENVERSE_NGINX_"

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -22,6 +22,7 @@ log_format json_combined escape=json
     '"http_referrer":"$http_referer",'
     '"http_user_agent":"$http_user_agent",'
     '"upstream_response_time":$upstream_response_time,'
+    '"upstream_cache_status":"$upstream_cache_status",'
     '"http_x_forwarded_for":"$http_x_forwarded_for"'
     '}';
 
@@ -43,6 +44,8 @@ upstream ov_service {
     server          $OPENVERSE_NGINX_UPSTREAM_URL;
 }
 
+proxy_cache_path  /data/nginx/cache levels=1:2 keys_zone=nuxt-cache:25m max_size=1g inactive=7d use_temp_path=off;
+
 server {
     access_log  /var/log/nginx/access.log  json_combined;
 
@@ -54,12 +57,26 @@ server {
     absolute_redirect off;
 
     location / {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $http_host;
-        proxy_redirect off;
-        proxy_pass http://ov_service;
+        include snippets/nuxt_location.conf;
         error_page 500 /500.json;
+    }
+
+    location /_nuxt {
+        include snippets/cached_location.conf;
+    }
+
+    location /homepage_images {
+        include snippets/cached_location.conf;
+    }
+
+    location /error_images {
+        include snippets/cached_location.conf;
+    }
+
+    # Refers to the nested src/static/static directory
+    # See README in that directory for details
+    location /static {
+        include snippets/cached_location.conf;
     }
 
     location /version {

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -21,7 +21,7 @@ log_format json_combined escape=json
     '"request_time":"$request_time",'
     '"http_referrer":"$http_referer",'
     '"http_user_agent":"$http_user_agent",'
-    '"upstream_response_time":$upstream_response_time,'
+    '"upstream_response_time":"$upstream_response_time",'
     '"upstream_cache_status":"$upstream_cache_status",'
     '"http_x_forwarded_for":"$http_x_forwarded_for"'
     '}';

--- a/frontend/nginx/snippets/cached_location.conf
+++ b/frontend/nginx/snippets/cached_location.conf
@@ -1,0 +1,12 @@
+expires 7d;
+include snippets/nuxt_location.conf;
+add_header X-Cache-Status $upstream_cache_status;
+
+proxy_ignore_headers        Cache-Control;
+proxy_http_version          1.1;
+proxy_read_timeout          1m;
+proxy_connect_timeout       1m;
+proxy_cache                 nuxt-cache;
+proxy_cache_valid           200 302 7d;
+proxy_cache_valid           404      1m;
+proxy_cache_lock            on;

--- a/frontend/nginx/snippets/nuxt_location.conf
+++ b/frontend/nginx/snippets/nuxt_location.conf
@@ -1,0 +1,8 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+add_header X-Frame-Options "SAMEORIGIN";
+
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Host $http_host;
+proxy_redirect off;
+proxy_pass http://ov_service;


### PR DESCRIPTION

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4470 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Using a modified version of the Nginx configuration Nuxt suggests here: https://v2.nuxt.com/deployments/nginx/#using-nginx-with-generated-pages-and-a-caching-proxy-as-fallback


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To test this, first run Nuxt with Nginx on `main`. For this testing **you may need to comment out the block in nuxt.config.ts** that forces browsers to upgrade requests to HTTPS, as we won't be working with HTTPS for this local testing. Whether you'll need to or not depends on how your browser enforces CSP. If you see CSP errors logged in your browser dev console, comment this block out to solve them.

https://github.com/WordPress/openverse/blob/83ed9647e8b33dbb13b356f2c92f683041506534/frontend/nuxt.config.ts#L20-L26

On `main`, run `ov just p frontend build:only && ov just p frontend start -H 0.0.0.0`. Wait until Nuxt finishes loading. In another terminal, run `ov just frontend/up --build` to get Nginx correctly configured with the latest configuration (and ensure an old configuration doesn't cause differences).

Visit http://localhost:50290/ with your browser dev tools open, and inspect the response headers of various static assets (anything under `/_nuxt`, `/homepage_images`, etc, though keep in mind that homepage images are randomly selected so if you haven't requested the particular group things of course won't be cached). Note the lack of expires header, `x-cache-status` header. Maybe just copy the headers down somewhere to reference in the next part. Open the nginx logs with `ov j logs frontend_nginx` and note that each request for a static asset includes an `upstream_response_time`.

Now checkout this branch and run the same process above to start Nginx (you don't technically need to rebuild the frontend as there aren't code changes to the frontend in this PR. Make the same requests as before, and also check the nginx logs. You should now see an expires header and x-cache-status header on responses for static assets, as well as an empty `upstream_response_time` on requests that are handled by the cache (where cache status is HIT).

Importantly, the app should also still work when you access it from Nginx. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
