### PR TITLE
Set `ov` workdir to current working directory

### DIFF
--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -13,7 +13,7 @@ shared_args=(
   -i
   --env "OPENVERSE_PROJECT=$OPENVERSE_PROJECT"
   --env "TERM=xterm-256color"
-  --workdir "$OPENVERSE_PROJECT"
+  --workdir "$CWD"
 )
 
 run_args=(

--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -13,7 +13,7 @@ shared_args=(
   -i
   --env "OPENVERSE_PROJECT=$OPENVERSE_PROJECT"
   --env "TERM=xterm-256color"
-  --workdir "$CWD"
+  --workdir "$(pwd)"
 )
 
 run_args=(
@@ -104,4 +104,4 @@ else
   docker start "$existing_container_id" 1>/dev/null
 fi
 
-docker exec "${shared_args[@]}" "$container_name" python3 docker/dev_env/exec.py "${_cmd[@]}"
+docker exec "${shared_args[@]}" "$container_name" python3 "$OPENVERSE_PROJECT"/docker/dev_env/exec.py "${_cmd[@]}"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This makes `ov` contextual to the working directory, so you can rely on your host CWD inside `ov`. This works because the Openverse repository is mapped with the literal directory path from your host (rather than to a distinct container path), so the CWD will exist in the container, so long as `ov` is run from within the repository.

I considered making this conditional by testing whether `$(pwd)` is actually a subpath of `OPENVERSE_PROJECT`, but running `ov` outside of the repository seems weird to try to explicitly support :thinking: 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Think of something you often do that is CWD contextual. Maybe, for example, running a just recipe from withing a subproject's directory. Or maybe using `pnpm exec`. Or `pdm run`. Now cd to the directory and prefix it with `ov`. Start with `pwd` and you'll see it work directly, hopefully. This also mostly only matters if you have `ov` on your PATH, but it should also work if you evoke it using a direct reference (e.g,, `../ov` from inside `/api`).

```
$ cd frontend && ov pwd
/path/to/openverse/frontend

$ cd ../api && ov pwd
/path/to/openverse/api
```

Then try other stuff that would be context dependent:
```
$ cd api && ov pdm info
PDM version:
  2.15.4
Python Interpreter:
  /opt/pdm/venvs/api-UJMDzYmD-3.11/bin/python (3.11)
Project Root:
  /home/sara/projects/openverse/api
Local Packages:

```

etc...

You get the idea, hopefully!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
