### PR TITLE
Do not use unstable pook reference for API

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -30,7 +30,7 @@ ENV PIP_NO_COLOR=1
 # - Create a virtualenv inside `/venv`
 # - Install PDM to install Python dependencies
 RUN apt-get update \
-  && apt-get install -y python3-dev git \
+  && apt-get install -y python3-dev \
   && rm -rf /var/lib/apt/lists/* \
   && pip install pdm~=2.14
 

--- a/api/pdm.lock
+++ b/api/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "overrides", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:7e9f8e52e78990958b094effb69b7b3500def794137e4d75c5d05de015bb99d4"
+content_hash = "sha256:91e8af4c323c960f6fa1eac0dd89ffaba079b5e4696f4e58a39b01943a021986"
 
 [[package]]
 name = "adrf"
@@ -1255,15 +1255,16 @@ files = [
 name = "pook"
 version = "1.4.3"
 requires_python = ">=3.8"
-git = "https://github.com/h2non/pook.git"
-ref = "master"
-revision = "a790994e5b0528210ea39d69878de38136d61628"
 summary = "HTTP traffic mocking and expectations made easy"
 groups = ["test"]
 dependencies = [
     "furl>=0.5.6",
     "jsonschema>=2.5.1",
     "xmltodict>=0.11.0",
+]
+files = [
+    {file = "pook-1.4.3-py3-none-any.whl", hash = "sha256:4683a8a9d11fb56901ae15001a5bfb76a1bb960b1a841de1f0ca11c8c2d9eef8"},
+    {file = "pook-1.4.3.tar.gz", hash = "sha256:61dbd9f6f9bf4d0bbab4abdf382bf7e8fbaae8561c5de3cd444e7c4be67df651"},
 ]
 
 [[package]]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -57,7 +57,7 @@ test = [
   "factory-boy >=3.3.0, <4",
   "fakeredis >=2.21.3, <3",
   "freezegun >=1.4.0, <2",
-  "pook @ git+https://github.com/h2non/pook.git@master",
+  "pook >=1.4.3, <2",
   "pytest >=7.4.4, <8",
   "pytest-django >=4.8.0, <5",
   "pytest-pook>=1.0.0",

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -436,7 +436,7 @@ def test_caches_failures_if_cache_surpasses_tolerance(mock_image_data, settings,
         )
         .header("User-Agent", UA_HEADER)
         .header("Accept", "image/*")
-        .times(tolerance)
+        .times(tolerance + 1)
         .reply(401)
         .body(MOCK_BODY)
     )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

https://github.com/h2non/pook/pull/132 will introduce breaking changes to pook. There isn't a version released with the breaking changes yet, but if I merged the PR, the Openverse API tests would start failing due to it being affected by the breaking changes that will come in pook v2. The API uses `master` instead of a stable version reference, so anything that changes on `master` could break the API if a new `pdm lock` updates the git revision used in the lock file.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Change `pook` in the API pyproject.toml to use a real version range.

The catalog and ingestion servers also use pook but already use a specific version or range.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass. This shouldn't have any effect on the actual test runs. Everything the API relied on (why it started using `master`) already exists on the latest version of pook (1.4.3)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
