### PR TITLE
Fix Plausible setup after domain was already set

### DIFF
--- a/setup_plausible.sh
+++ b/setup_plausible.sh
@@ -34,7 +34,7 @@ RES=$(curl \
   -F 'timezone="UTC"' \
   "$local_plausible/api/v1/sites")
 
-if [[ $RES == *"\"error\":\"domain This domain has already been taken"* ]]; then
+if [[ $RES == *"This domain cannot be registered. Perhaps one of your colleagues registered it"* ]]; then
   echo "Domain already exists."
 elif [[ $RES == *"\"domain\":\"localhost\""* ]]; then
   echo "Domain created."


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #942 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
#943 has made the Plausible setup idempotent. However, it appears that the API response text has changed, and the check for domain does not work anymore. So, when you run `just init` for the frontend again, you get this error:
```
Error: {"error":"domain: This domain cannot be registered. Perhaps one of your colleagues registered it? If that's not the case, please contact support@plausible.io\n"}

```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and run `./ov just init` twice. You should not see the domain-related error logged in the terminal (the one you would currently see on main.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
