### PR TITLE
Shorten PDM hash to first 8 characters

### DIFF
--- a/api/justfile
+++ b/api/justfile
@@ -16,7 +16,7 @@ NO_COLOR := "\\033[0m"
 
 # These commands use standard GNU tools instead of `pdm` because we do not
 # require PDM on the host machine for API development.
-export API_PDM_HASH := `grep 'content_hash' pdm.lock | awk -F'[:"]' '{print $3}'`
+export API_PDM_HASH := `grep 'content_hash' pdm.lock | awk -F'[:"]' '{print $3}' | cut -c1-8`
 export API_PY_VERSION := `grep 'requires-python' pyproject.toml | awk -F'"' '{print $2}' | sed 's/^==//g; s/\.\*$//g'`
 export PGCLI_VERSION := `grep -A 1 'name = "pgcli"' pdm.lock | grep 'version' | awk -F'"' '{print $2}'`
 


### PR DESCRIPTION
## Description

This PR shortens the PDM hash used by the API image to the first 8 characters.

This hash is useful to automatically build a new API image when the API packages have changed. Truncating it to 8 chars keeps it long enough to avoid collisions while making it short enough to not completely break the table layout the output of `docker image ls`.

### Before

<img width="1304" alt="Screenshot 2024-06-25 at 5 24 01 PM" src="https://github.com/WordPress/openverse/assets/16580576/4016525a-b32a-4819-bd76-82a77d772657">

### After

<img width="869" alt="Screenshot 2024-06-25 at 5 24 48 PM" src="https://github.com/WordPress/openverse/assets/16580576/a3897827-c2bd-4faf-9225-b56cca3fc69e">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
