### PR TITLE
Split `batched_update` DAG into automated and manual DAGs

### DIFF
--- a/catalog/dags/database/batched_update/batched_update_dag.py
+++ b/catalog/dags/database/batched_update/batched_update_dag.py
@@ -94,9 +94,7 @@ from database.batched_update.batched_update import (
 
 logger = logging.getLogger(__name__)
 
-
-@dag(
-    dag_id=constants.DAG_ID,
+DAG_CONFIG = dict(
     schedule=None,
     start_date=constants.START_DATE,
     tags=["database"],
@@ -170,6 +168,8 @@ logger = logging.getLogger(__name__)
         ),
     },
 )
+
+
 def batched_update():
     # Unique Airflow variable name for tracking the batch_start for this query
     BATCH_START_VAR = "batched_update_start_{{ params.query_id }}"
@@ -269,4 +269,5 @@ def batched_update():
     ]
 
 
-batched_update()
+for dag_id in [constants.DAG_ID, constants.AUTOMATED_DAG_ID]:
+    dag(dag_id, **DAG_CONFIG)(batched_update)()

--- a/catalog/dags/database/batched_update/constants.py
+++ b/catalog/dags/database/batched_update/constants.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 
 DAG_ID = "batched_update"
+AUTOMATED_DAG_ID = f"automated_{DAG_ID}"
 START_DATE = datetime(2023, 5, 1)
 SLACK_USERNAME = "Upstream Batched Update"
 SLACK_ICON = ":database:"

--- a/catalog/dags/popularity/popularity_refresh_dag_factory.py
+++ b/catalog/dags/popularity/popularity_refresh_dag_factory.py
@@ -32,7 +32,7 @@ from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from common import slack
 from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
-from database.batched_update.constants import DAG_ID as BATCHED_UPDATE_DAG_ID
+from database.batched_update.constants import AUTOMATED_DAG_ID as BATCHED_UPDATE_DAG_ID
 from popularity import sql
 from popularity.popularity_refresh_types import (
     POPULARITY_REFRESH_CONFIGS,

--- a/catalog/utilities/dag_doc_gen/dag_doc_generation.py
+++ b/catalog/utilities/dag_doc_gen/dag_doc_generation.py
@@ -64,6 +64,7 @@ DAG_ID_TERMS_TO_COLLAPSE = {
     "audio": "{media_type}",
     "production": "{environment}",
     "staging": "{environment}",
+    "automated": "",
 }
 # DAG IDs to ignore when collapsing reference documentation for a mapped term
 DAG_IDS_TO_IGNORE_COLLAPSE = {
@@ -147,6 +148,9 @@ def determine_mapped_dag_id(dag_id: str) -> str:
     for idx, part in enumerate(parts):
         if part in DAG_ID_TERMS_TO_COLLAPSE:
             parts[idx] = DAG_ID_TERMS_TO_COLLAPSE[part]
+            if not parts[idx]:
+                # If there's no replacement, remove the section entirely
+                parts.pop(idx)
     return "_".join(parts)
 
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -47,6 +47,7 @@ The following are DAGs grouped by their primary tag:
 
 | DAG ID                                                                                 | Schedule Interval |
 | -------------------------------------------------------------------------------------- | ----------------- |
+| [`automated_batched_update`](#batched_update)                                          | `None`            |
 | [`batched_update`](#batched_update)                                                    | `None`            |
 | [`delete_records`](#delete_records)                                                    | `None`            |
 | [`recreate_full_staging_index`](#recreate_full_staging_index)                          | `None`            |
@@ -136,6 +137,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`add_license_url`](#add_license_url)
 1.  [`airflow_log_cleanup`](#airflow_log_cleanup)
 1.  [`auckland_museum_workflow`](#auckland_museum_workflow)
+1.  [`automated_batched_update`](#batched_update)
 1.  [`batched_update`](#batched_update)
 1.  [`cc_mixter_workflow`](#cc_mixter_workflow)
 1.  [`check_silenced_dags`](#check_silenced_dags)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4457 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR splits the `batched_update` into two separate DAGs as described in the above linked issue: `batched_update` and `automated_batched_update`. None of the parameters for each DAG are changed _at this time_, though they may be affected later as part of the [batched update improvements milestone](https://github.com/WordPress/openverse/milestone/34).

@stacimc this might interest you - this was the first time I've tried to create a dynamic DAG using the TaskFlow API/`@dag` decorator syntax. Turned out to be pretty simple, even if it's a little wonky! I'm happy to change the format to use the `with DAG(...) as dag` syntax if that makes it easier. I haven't seen anyone do it this way in the research I did online, for what it's worth.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Run `ov just c` to start the catalog
1. Observe that there is a `batched_update` DAG and an `automated_batched_update` DAG
1. Enable the `automated_batched_update` DAG
1. Enable the `image_popularity_refresh` DAG, which should immediately start a run
1. Check on the `automated_batched_update` DAG and see that there are a number of runs kicked off on it


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
