### PR TITLE
Revert "Changes all sensible occurrences of the just commands to have them run using ov"

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_source_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/new_source_suggestion.yml
@@ -71,7 +71,7 @@ body:
         - The script must not use anything from `catalog/dags/retired/providers/provider_api_scripts/modules/etlMods.py`, since that module is deprecated.
         - If the provider API has can be queried by 'upload date' or something similar, the script should take a `--date` parameter when run as a script, giving the date for which we should collect images. The form should be `YYYY-MM-DD` (so, the script can be run via `python my_favorite_provider.py --date 2018-01-01`).
         - The script must provide a main function that takes the same parameters as from the CLI. In our example from above, we'd then have a main function `my_favorite_provider.main(date)`. The main should do the same thing calling from the CLI would do.
-        - The script *must* conform to [PEP8][pep8]. Please use `./ov just lint` before committing.
+        - The script *must* conform to [PEP8][pep8]. Please use `just lint` before committing.
         - The script should use small, testable functions.
         - The test suite for the script may break PEP8 rules regarding long lines where appropriate (e.g., long strings for testing).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,9 @@ Fixes #[issue number] by @[issue author]
 - [ ] I added or updated tests for the changes I made (if applicable).
 - [ ] I added or updated documentation (if applicable).
 - [ ] I tried running the project locally and verified that there are no visible errors.
-- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
-      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
-      for the catalog or `./ov just api/generate-docs` for the API) where applicable.
+- [ ] I ran the DAG documentation generator (`just catalog/generate-docs` for catalog
+      PRs) or the media properties generator (`just catalog/generate-docs media-props`
+      for the catalog or `just api/generate-docs` for the API) where applicable.
 
 [best_practices]:
   https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

--- a/.vale/README.md
+++ b/.vale/README.md
@@ -11,8 +11,8 @@ the Openverse monorepo, refer to the README at
 
 To run Vale with Openverse's configuration, use the just recipe:
 
-```bash
-./ov just .vale/run
+```
+$ just .vale/run
 ```
 
 This recipe _always_ builds Vale. The Openverse Vale docker image is fast to

--- a/catalog/templates/template_test.py_template
+++ b/catalog/templates/template_test.py_template
@@ -3,7 +3,7 @@ TODO: Add additional tests for any methods you added in your subclass.
 Try to test edge cases (missing keys, different data types returned, Nones, etc).
 You may also need to update the given test names to be more specific.
 
-Run your tests locally with `./ov just catalog/test -k {provider_underscore}`
+Run your tests locally with `just test -k {provider_underscore}`
 """
 
 import json

--- a/catalog/tests/dags/providers/provider_api_scripts/test_cc_mixter.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_cc_mixter.py
@@ -1,4 +1,4 @@
-"""Run these tests locally with `./ov just catalog/test -k cc_mixter`"""
+"""Run these tests locally with `just test -k cc_mixter`"""
 
 import json
 from pathlib import Path

--- a/catalog/tests/dags/providers/provider_api_scripts/test_inaturalist.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_inaturalist.py
@@ -37,7 +37,7 @@ from providers.provider_api_scripts import inaturalist
 #    to pull a sample of records without breaking referential integrity.
 #  - Putting your final zipped test files in /tests/s3-data/inaturalist-open-data
 #    so that they will be synced over to minio.
-#  - Run `./ov just down -v` and then `./ov just recreate` to make sure that the test data gets to
+#  - Run `just down -v` and then `just recreate` to make sure that the test data gets to
 #    the test s3 instance. That process may take on the order of 15 minutes for the full
 #    dataset. You'll know that it's done when the s3-load container in docker exits.
 #  - Then, in airflow, trigger the dag possibly with configuration

--- a/docker/minio/load_to_s3_entrypoint.sh
+++ b/docker/minio/load_to_s3_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This does *not* allow for testing permissions issues that may come up in real AWS.
-# And, if you remove files from /tests/s3-data, you will need to use `./ov just down -v`
-# and `./ov just up` or `./ov just recreate` to see the minio bucket without those files.
+# And, if you remove files from /tests/s3-data, you will need to use `just down -v`
+# and `just up` or `just recreate` to see the minio bucket without those files.
 # Loop through subdirectories mounted to the volume and load them to s3/minio.
 # This takes care of filesystem delays on some local dev environments that may make
 # minio miss files included directly in the minio volume.

--- a/documentation/api/guides/https.md
+++ b/documentation/api/guides/https.md
@@ -19,7 +19,7 @@ Additionally, you will need to install
 1. Create certificates for NGINX to use.
 
    ```bash
-   ./ov just docker/nginx/cert
+   just docker/nginx/cert
    ```
 
    This will create a certificate file `openversse.crt` and a key file
@@ -29,7 +29,7 @@ Additionally, you will need to install
    services.
 
    ```bash
-   ./ov just api/up
+   just api/up
    ```
 
    The `api/up` recipe orchestrates the following services: `cache`, `db`,
@@ -41,8 +41,8 @@ Additionally, you will need to install
 3. Make an API call over HTTPS.
 
    ```bash
-   ./ov just api/stats images https://localhost:50243
-   ./ov just _curl-get "images/stats/" https://localhost:50243
+   just api/stats images https://localhost:50243
+   just _curl-get "images/stats/" https://localhost:50243
    curl "https://localhost:50243/v1/images/stats/"
    [{"source_name":"flickr","display_name":"Flickr","source_url":"https://www.flickr.com","logo_url":null,"media_count":2500},{"source_name":"stocksnap","display_name":"StockSnap","source_url":"https://stocksnap.io","logo_url":null,"media_count":2500}]%
    ```

--- a/documentation/api/guides/quickstart.md
+++ b/documentation/api/guides/quickstart.md
@@ -41,7 +41,7 @@ you need to run this.
    services.
 
    ```bash
-   ./ov just api/up
+   just api/up
    ```
 
    The `api/up` recipe orchestrates the following services: `cache`, `db`,
@@ -56,15 +56,15 @@ you need to run this.
 4. Load the sample data. This step can take a few minutes to complete.
 
    ```bash
-   ./ov just api/init
+   just api/init
    ```
 
    ````{admonition} Troubleshooting
    If this step fails, cleaning up and restarting usually fixes it.
 
    ```bash
-   ./ov just down -v
-   ./ov just api/init
+   just down -v
+   just api/init
    ```
    ````
 
@@ -72,8 +72,8 @@ you need to run this.
    requests.
 
    ```bash
-   ./ov just api/stats
-   ./ov just _curl-get "images/stats/" http://localhost:50280
+   just api/stats
+   just _curl-get "images/stats/" http://localhost:50280
    curl "http://localhost:50280/v1/images/stats/"
    [{"source_name":"flickr","display_name":"Flickr","source_url":"https://www.flickr.com","logo_url":null,"media_count":2500},{"source_name":"stocksnap","display_name":"StockSnap","source_url":"https://stocksnap.io","logo_url":null,"media_count":2500}]%
    ```
@@ -84,7 +84,7 @@ you need to run this.
    transform it.
 
    ```bash
-   ./ov just api/stats | jq '.[0]'
+   just api/stats | jq '.[0]'
    {
      "source_name": "flickr",
      "display_name": "Flickr",
@@ -93,7 +93,7 @@ you need to run this.
      "media_count": 2500
    }
 
-   ./ov just api/stats 'audio' | jq '[.[] | .source_name]'
+   just api/stats 'audio' | jq '[.[] | .source_name]'
    [
      "freesound",
      "jamendo",

--- a/documentation/api/guides/test.md
+++ b/documentation/api/guides/test.md
@@ -10,7 +10,7 @@ Once you've made some changes to the codebase, it is important to run tests.
 2. Run the tests.
 
    ```bash
-   ./ov just api/test
+   just api/test
    ```
 
    ```{note}

--- a/documentation/automations/guides/quickstart.md
+++ b/documentation/automations/guides/quickstart.md
@@ -12,7 +12,7 @@ you need to run this.
 
 ## Installation
 
-`./ov just install` in the repository root directory will install all Python and
+`just install` in the repository root directory will install all Python and
 Node.js dependencies for automations as well as other parts of the repository.
 If you wish to install only dependencies for automations, run the following:
 
@@ -27,7 +27,7 @@ Run Python automation scripts using the `automations/python/run` just recipe.
 Ex.:
 
 ```bash
-./ov just automations/python/run print_labels.py
+just automations/python/run print_labels.py
 ```
 
 The recipe is an alias for running `pipenv run <script>` inside the
@@ -39,7 +39,7 @@ configuration as expected by many scripts.
 Run Node.js automation scripts using the `automations/js/run` just recipe. Ex.:
 
 ```bash
-./ov just automations/js/run render-jinja.js
+just automations/js/run render-jinja.js
 ```
 
 The recipe is an alias for running `pnpm exec <script>` inside the

--- a/documentation/catalog/guides/adding_a_new_provider.md
+++ b/documentation/catalog/guides/adding_a_new_provider.md
@@ -62,18 +62,18 @@ that can be used to generate the files you'll need and get you started:
 # MEDIA: Optionally, a space-delineated list of media types ingested by this provider
 #        (and supported by Openverse). If not provided, defaults to "image".
 
-> ./ov just catalog/add-provider <PROVIDER_NAME> <ENDPOINT> <MEDIA>
+> just catalog/add-provider <PROVIDER_NAME> <ENDPOINT> <MEDIA>
 
 # Example usages:
 
 # Creates a provider that supports just audio
-> ./ov just catalog/add-provider TestProvider https://test.test/search audio
+> just catalog/add-provider TestProvider https://test.test/search audio
 
 # Creates a provider that supports images and audio
-> ./ov just catalog/add-provider "Foobar Museum" https://foobar.museum.org/api/v1 image audio
+> just catalog/add-provider "Foobar Museum" https://foobar.museum.org/api/v1 image audio
 
 # Creates a provider that supports the default, just image
-> ./ov just catalog/add-provider TestProvider https://test.test/search
+> just catalog/add-provider TestProvider https://test.test/search
 ```
 
 You should see output similar to this:
@@ -101,7 +101,7 @@ You can run the provider script directly from the command line via a just
 recipe. This will open a bash shell inside the docker stack of the catalog.
 
 ```
-./ov just catalog/run
+just catalog/run
 ```
 
 Now you can just run the script like so:
@@ -151,8 +151,8 @@ These are documented in the definition of the `ProviderWorkflow` dataclass.
 
 <!--TODO: add docs for other options.-->
 
-After adding your configuration, run `./ov just up` and you should now have a
-fully functioning provider DAG!
+After adding your configuration, run `just up` and you should now have a fully
+functioning provider DAG!
 
 <!--TODO: add and link to docs for how to run provider DAGs locally, preferably with images.-->
 
@@ -173,21 +173,21 @@ manually turn the DAG on in production.
    selecting only the tests associated with the provider.
 
    ```bash
-   ./ov just catalog/test-session
+   just catalog/test-session
    pytest -k <provider_name>
    ```
 
    Alternatively, the test selection can be run in Docker directly with:
 
    ```bash
-   ./ov just catalog/test -k <provider_name>
+   just catalog/test -k <provider_name>
    ```
 
 ```{note}
-Using `./ov just catalog/test-session` opens Docker to access a shell which is set up to run
+Using `just catalog/test-session` opens Docker to access a shell which is set up to run
 tests. This allows one to run tests repeatedly while potentially modifying the code,
 without having to start the Docker container up each time the tests need to be run.
-Running the tests on Docker directly (e.g. using `./ov just catalog/test`) will spin up the
+Running the tests on Docker directly (e.g. using `just catalog/test`) will spin up the
 container, run the selected tests if any are provided (or all by default) and then stop
 and remove the container. That can be useful for ensuring that all tests pass if one
 does not need to iterate and check the test failures repeatedly.

--- a/documentation/catalog/guides/dag_testing.md
+++ b/documentation/catalog/guides/dag_testing.md
@@ -17,7 +17,7 @@ might need to get the API keys from the provider and add them to the
 1. Refer to and follow the instructions at [Quickstart](./quickstart.md) to
    setup and make sure the catalog service is up and running. If you have
    successfully completed the general setup then this can be started by running
-   `./ov just catalog/up`.
+   `just catalog/up`.
 
 2. Navigate to http://localhost:9090
 

--- a/documentation/catalog/guides/quickstart.md
+++ b/documentation/catalog/guides/quickstart.md
@@ -52,11 +52,9 @@ To set up the local python environment along with the pre-commit hook, run:
 <!-- vale Vale.Repetition = NO -->
 
 ```shell
-./ov just catalog/venv
-./ov bash
-source catalog/.venv/bin/activate
+just venv
+source .venv/bin/activate
 just catalog/install
-exit
 ```
 
 <!-- vale Vale.Repetition = YES -->
@@ -65,7 +63,7 @@ The containers will be built when starting the stack up for the first time. If
 you'd like to build them prior to that, run:
 
 ```shell
-./ov just build
+just build
 ```
 
 ### Environment
@@ -73,7 +71,7 @@ you'd like to build them prior to that, run:
 To set up environment variables run:
 
 ```shell
-./ov just env
+just env
 ```
 
 This will generate a `.env` file which is used by the containers.
@@ -96,7 +94,7 @@ There is a [`docker-compose.yml`][dockercompose] provided in the
 [`catalog`][cc_airflow] directory, so from that directory, run
 
 ```shell
-./ov just catalog/up
+just catalog/up
 ```
 
 This results, among other things, in the following running containers:
@@ -128,10 +126,10 @@ The various services can be accessed using these links:
 At this stage, you can run the tests via:
 
 ```shell
-./ov just catalog/test
+just catalog/test
 
 # Alternatively, run all tests including longer-running ones
-./ov just catalog/test --extended
+just catalog/test --extended
 ```
 
 Edits to the source files or tests can be made on your local machine, then tests
@@ -140,39 +138,39 @@ can be run in the container via the above command to see the effects.
 If you'd like, it's possible to login to the webserver container via:
 
 ```shell
-./ov just catalog/shell
+just catalog/shell
 ```
 
 If you just need to run an airflow command, you can use the `airflow` recipe.
 Arguments passed to airflow must be quoted:
 
 ```shell
-./ov just run scheduler airflow config list
+just run scheduler airflow config list
 ```
 
 To follow the logs of the running container:
 
 ```shell
-./ov just logs
+just logs
 ```
 
 To begin an interactive [`pgcli` shell](https://www.pgcli.com/) on the database
 container, run:
 
 ```shell
-./ov just catalog/pgcli
+just catalog/pgcli
 ```
 
 If you'd like to bring down the containers, run
 
 ```shell
-./ov just down
+just down
 ```
 
 To reset the test DB (wiping out all databases, schemata, and tables), run
 
 ```shell
-./ov just down -v
+just down -v
 ```
 
 `docker volume prune` can also be useful if you've already stopped the running
@@ -182,7 +180,7 @@ stopped containers, not just catalog ones.
 To fully recreate everything from the ground up, you can use:
 
 ```shell
-./ov just recreate
+just recreate
 ```
 
 > **Note**: Any recipes or scripts which output files to the container's mounted

--- a/documentation/frontend/guides/analytics.md
+++ b/documentation/frontend/guides/analytics.md
@@ -13,22 +13,22 @@ Use the following `just` recipes to set Plausible up locally:
 
 ```sh
 # Runs the portion of the docker-compose stack that includes Plausible
-./ov just frontend/up
+just frontend/up
 
 # Sets up Plausible with a default user and the localhost testing site
 # Only necessary the first time you run Plausible locally, when adding
-# new custom events, or any time after you run `./ov just down -v`
-./ov just frontend/init
+# new custom events, or any time after you run `just down -v`
+just frontend/init
 ```
 
-If you have already run `./ov just up` and `./ov just init` at the root of the
-repository, then Plausible is already set up and running the commands above is
-not necessary.
+If you have already run `just up` and `just init` at the root of the repository,
+then Plausible is already set up and running the commands above is not
+necessary.
 
 > **Note**
 >
-> `./ov just frontend/up` may take some time on first run as it will need to
-> download various docker images required for the Plausible stack.
+> `just frontend/up` may take some time on first run as it will need to download
+> various docker images required for the Plausible stack.
 
 ## Access Plausible
 
@@ -57,8 +57,8 @@ Custom events must be added to Plausible for it to record them. You may do this
 one of two ways:
 
 - Automatically:
-  1.  Run `./ov just frontend/init`, which automatically extracts the events
-      name from the `Events` type
+  1.  Run `just frontend/init`, which automatically extracts the events name
+      from the `Events` type
 - Manually:
   1.  Visit <http://0.0.0.0:50288/localhost/settings/goals> and click the "+ Add
       goal" button
@@ -67,8 +67,8 @@ one of two ways:
   3.  Click "add goal" to save the new custom event
 
 **If you are testing custom events added by others, you must also follow this
-process for them to appear in your local environment. `./ov just frontend/init`
-will be the simplest way to do so in those cases, provided the change request
+process for them to appear in your local environment. `just frontend/init` will
+be the simplest way to do so in those cases, provided the change request
 includes the necessary changes to the `Events` type.**
 
 After adding the custom event, upon receiving at least one instance of the

--- a/documentation/frontend/guides/icons.md
+++ b/documentation/frontend/guides/icons.md
@@ -46,11 +46,10 @@ environment and is not available in production.
 Openverse uses
 [svg-sprite-module](https://github.com/nuxt-community/svg-sprite-module) to
 automatically generate the SVG sprite when you add an SVG file to
-`frontend/src/assets/icons/raw/`. It runs when you run
-`./ov just frontend/run dev` or `./ov just frontend/run build`. The module also
-watches the content of the `frontend/src/assets/icons/raw` directory, and
-re-generates the sprite if you add an icon there, so you don't need to re-run
-the app.
+`frontend/src/assets/icons/raw/`. It runs when you run `just frontend/run dev`
+or `just frontend/run build`. The module also watches the content of the
+`frontend/src/assets/icons/raw` directory, and re-generates the sprite if you
+add an icon there, so you don't need to re-run the app.
 
 So, to add a new icon to the SVG sprite, you only need to create an SVG file
 containing the icon in `frontend/src/assets/icons/raw/` directory. The name of

--- a/documentation/frontend/guides/quickstart.md
+++ b/documentation/frontend/guides/quickstart.md
@@ -41,14 +41,14 @@ you need to run this.
    dependencies to run the frontend.
 
    ```bash
-   ./ov just node-install
+   just node-install
    ```
 
 4. To bring up the frontend, we have another `just` recipe. We have `just`
    recipes for almost everything.
 
    ```bash
-   ./ov just frontend/run dev
+   just frontend/run dev
    ```
 
    If you want your frontend to use a different API instance, you can set the
@@ -57,7 +57,7 @@ you need to run this.
    use the local API with the frontend.
 
    ```bash
-   ./ov env API_URL="http://localhost:50280" just frontend/run dev
+   env API_URL="http://localhost:50280" just frontend/run dev
    ```
 
    Now you should be able to access the following endpoints:

--- a/documentation/frontend/guides/test.md
+++ b/documentation/frontend/guides/test.md
@@ -18,7 +18,7 @@ Storybook visual regression tests, read
 2. Run unit tests for the frontend.
 
    ```bash
-   ./ov just frontend/run test:unit
+   just frontend/run test:unit
    ```
 
    ````{note}
@@ -26,7 +26,7 @@ Storybook visual regression tests, read
    up pre-commit's Git hooks by running the following command.
 
    ```bash
-   ./ov just precommit
+   just precommit
    ```
 
    ````
@@ -35,13 +35,13 @@ Storybook visual regression tests, read
    visual regression tests.
 
    ```bash
-   ./ov just frontend/run test:playwright
+   just frontend/run test:playwright
    ```
 
 4. Run the Storybook visual regression tests.
 
    ```bash
-   ./ov just frontend/run test:storybook
+   just frontend/run test:storybook
    ```
 
 ## Updating snapshots
@@ -51,11 +51,11 @@ run both the playwright and storybook tests with the `-u` flag. For example,
 this will update the snapshots for the app visual regression tests:
 
 ```bash
-./ov just frontend/run test:playwright visual-regression -u
+just frontend/run test:playwright visual-regression -u
 ```
 
 This will similarly update the storybook snapshots:
 
 ```bash
-./ov just frontend/run test:storybook -u
+just frontend/run test:storybook -u
 ```

--- a/documentation/frontend/reference/i18n.md
+++ b/documentation/frontend/reference/i18n.md
@@ -105,10 +105,10 @@ To use the script:
 
 ```shell
 # Install python dependencies
-./ov just utilities/generate_test_locales/install
+just utilities/generate_test_locales/install
 
 # Run the script
-./ov just utilities/generate_test_locales/run
+just utilities/generate_test_locales/run
 ```
 
 The script caches Argos translation packages on your local machine. The first

--- a/documentation/frontend/reference/miscellaneous.md
+++ b/documentation/frontend/reference/miscellaneous.md
@@ -4,9 +4,8 @@
 
 The code in this repository is formatted using `prettier`. If you have prettier
 setup in your code editor it should work out of the box; otherwise you can use
-the `./ov just frontend/run lint` script to format and fix lint errors in your
-code. Checks are run to lint your code and validate the formatting on git
-precommit.
+the `just frontend/run lint` script to format and fix lint errors in your code.
+Checks are run to lint your code and validate the formatting on git precommit.
 
 You will need to fix any linting issues before committing. We recommend
 formatting your JavaScript files on save in your text editor. You can learn how

--- a/documentation/frontend/reference/nginx.md
+++ b/documentation/frontend/reference/nginx.md
@@ -16,8 +16,8 @@ Additionally, the reverse proxy may be used in the future for the following:
 
 ## Testing
 
-To test the frontend reverse proxy locally, run `./ov just frontend/up`. To test
-the integration with your local Plausible container, follow the existing
+To test the frontend reverse proxy locally, run `just frontend/up`. To test the
+integration with your local Plausible container, follow the existing
 instructions in [the frontend analytics documentation][analytics_docs].
 Everything should "just work".
 

--- a/documentation/frontend/reference/playwright_tests.md
+++ b/documentation/frontend/reference/playwright_tests.md
@@ -54,14 +54,14 @@ codebase.
 To run the end-to-end tests, after having installed docker, run the following:
 
 ```bash
-./ov just frontend/run test:playwright
+just frontend/run test:playwright
 ```
 
 You may pass arguments to playwright directly, for example `-u` to update
 snapshots or a filter.
 
 ```bash
-./ov just frontend/run test:playwright visual-regression -u
+just frontend/run test:playwright visual-regression -u
 ```
 
 The above will run only test files with `visual-regression` in the path and will
@@ -150,7 +150,7 @@ If you've added new tests or updated existing ones, you may get errors about API
 responses not being found. To remedy this, you'll need to update the tapes:
 
 ```bash
-./ov just frontend/run test:playwright:update-tapes
+just frontend/run test:playwright:update-tapes
 ```
 
 If for some reason you find yourself needing to completely recreate the tapes,
@@ -189,7 +189,7 @@ renders the page compared to the docker container.
 To run the debug tests:
 
 ```bash
-./ov just frontend/run test:playwright:debug
+just frontend/run test:playwright:debug
 ```
 
 Note that this still runs the talkback proxy and the Nuxt server for you. If
@@ -216,7 +216,7 @@ When writing end-to-end tests, it can be helpful to use Playwright
 tests by performing actions in the browser:
 
 ```bash
-./ov just frontend/run test:playwright:gen
+just frontend/run test:playwright:gen
 ```
 
 This will open the app in a new browser window, and record any actions you take
@@ -229,5 +229,5 @@ To generate tests for a non-default breakpoint, set the viewport size using the
 `--viewport-size` flag. For example, to test the `xs` breakpoint, run:
 
 ```bash
-./ov just frontend/run test:playwright:gen --viewport-size=340,600"
+just frontend/run test:playwright:gen --viewport-size=340,600"
 ```

--- a/documentation/frontend/reference/storybook_tests.md
+++ b/documentation/frontend/reference/storybook_tests.md
@@ -28,7 +28,7 @@ Our Nuxt playwright tests are described by the
 To run the tests:
 
 ```bash
-./ov just frontend/run test:storybook
+just frontend/run test:storybook
 ```
 
 This will run the tests inside a docker container. Should you wish to run the
@@ -38,7 +38,7 @@ there are likely to be visual rendering differences that will cause snapshot
 tests to fail on false-positives.
 
 ```bash
-./ov just frontend/run test:storybook:local
+just frontend/run test:storybook:local
 ```
 
 ## Writing tests
@@ -52,11 +52,11 @@ See
 ### Codegen
 
 You can use Playwright's `codegen` tool to generate tests. For this you will
-need to run Storybook locally on your own using
-`./ov just frontend/run storybook`. Then run:
+need to run Storybook locally on your own using `just frontend/run storybook`.
+Then run:
 
 ```bash
-./ov just frontend/run test:storybook:gen
+just frontend/run test:storybook:gen
 ```
 
 Please note that the codegen script automatically runs against the non-iframed

--- a/documentation/frontend/reference/testing_guidelines.md
+++ b/documentation/frontend/reference/testing_guidelines.md
@@ -75,7 +75,7 @@ API_CLIENT_ID=""
 API_CLIENT_SECRET=""
 ```
 
-Then run the API as usual using `./ov just api/up` & `./ov just api/init`. Nuxt
+Then run the API as usual using `just api/up` & `just api/init`. Nuxt
 automatically loads `.env` files into the environment. With these variables in
 the environment, all requests made by your server will be made using an access
 token retrieved by the `~/plugins/api-token.server.ts` plugin.
@@ -84,7 +84,7 @@ Once the `.env` file is set up, you may run the development build the typical
 way:
 
 ```shell
-./ov just frontend/run dev
+just frontend/run dev
 ```
 
 ## Browsers

--- a/documentation/general/contribution/good_first_and_help_wanted_issues.md
+++ b/documentation/general/contribution/good_first_and_help_wanted_issues.md
@@ -82,12 +82,12 @@ contain the following block of requirements:
 
 - Have I filled out the PR template correctly?
   - Did I include testing instructions?
-- Does my PR pass linting? (Test either via precommit or by running
-  `./ov just lint` manually)
+- Does my PR pass linting? (Test either via precommit or by running `just lint`
+  manually)
 - Do all the tests still pass?
   - If JavaScript changes, run `pnpm -r run test`
-  - If API changes, run `./ov just api/test`
-  - If catalog changes, run `./ov just catalog/test`
+  - If API changes, run `just api/test`
+  - If catalog changes, run `just catalog/test`
 ```
 
 ## On "help wanted" issues

--- a/documentation/general/general_setup.md
+++ b/documentation/general/general_setup.md
@@ -31,6 +31,20 @@ Installation instructions for WSL on Windows 10 and 11 can be found in
 Microsoft's
 [official documentation](https://docs.microsoft.com/en-us/windows/wsl/install).
 
+## `ov` development environment
+
+Openverse maintainers are currently working on a tool `ov` to make setting up
+and maintaining the Openverse development environment easier for everyone
+involved, but especially new contributors. You may see references to `ov` in
+issues or pull requests for this reason. For now, `ov` is not documented or
+recommended for use by inexperienced contributors. Once the Openverse
+maintainers have decided `ov` is stable enough to recommend for new
+contributors, we will update this documentation to exclusively use an `ov` based
+approach to setting up the environment.
+
+For now, if you'd like to try `ov`, run `./ov help` from the repository root to
+view the command's built-in documentation.
+
 ## Requirement matrix
 
 Based on which part of the Openverse stack you are contributing to, you might

--- a/documentation/general/https.md
+++ b/documentation/general/https.md
@@ -5,8 +5,7 @@ that serves the API over `https` by proxying to the Gunicorn server which serves
 over `http`.
 
 This proxy uses certificates from the `nginx/certs/` directory. These
-certificates can be generated using `mkcert` with the `./ov just nginx/cert`
-command.
+certificates can be generated using `mkcert` with the `just nginx/cert` command.
 
 Additionally, to test with the dev hostname `dev.openverse.test`, add the
 following line to your hosts file.

--- a/documentation/general/logging.md
+++ b/documentation/general/logging.md
@@ -33,7 +33,7 @@ searchable and filterable. For example, to see all the logs for a method and
 only that method, one can pipe the logs through `grep` like so.
 
 ```bash
-./ov just logs web | grep 'func_name=<function name>'
+just logs web | grep 'func_name=<function name>'
 ```
 
 ## Request IDs
@@ -46,7 +46,7 @@ codebase and understand what specific parts of the code are causing problems
 with these particular requests.
 
 ```bash
-./ov just logs web | grep 'request_id=<request ID>'
+just logs web | grep 'request_id=<request ID>'
 ```
 
 ## Future improvements

--- a/documentation/general/quickstart.md
+++ b/documentation/general/quickstart.md
@@ -61,20 +61,20 @@ prerequisites.
    using Docker containers.
 
    ```bash
-   ./ov just install
+   just install
    ```
 
    To be more specific with your install, you can run either of the following.
 
    ```bash
-   ./ov just node-install # only frontend and Node.js automations
-   ./ov just py-install # only documentation and Python automations
+   just node-install # only frontend and Node.js automations
+   just py-install # only documentation and Python automations
    ```
 
 4. Spin up and orchestrate all Docker services.
 
    ```bash
-   ./ov just up
+   just up
    ```
 
    The `up` recipe orchestrates the following services: `cache`, `db`,
@@ -83,7 +83,7 @@ prerequisites.
    `plausible`.
 
    The `up` recipe also prints out services that have ports exposed to the host
-   (this can also be seen by running `./ov just ps`):
+   (this can also be seen by running `just ps`):
 
    ```
    ================================================================================
@@ -120,15 +120,15 @@ prerequisites.
 5. Load the sample data. This step can take a few minutes to complete.
 
    ```bash
-   ./ov just init
+   just init
    ```
 
    ````{admonition} Troubleshooting
    If this step fails, cleaning up and restarting usually fixes it.
 
    ```bash
-   ./ov just down -v
-   ./ov just api/init
+   just down -v
+   just api/init
    ```
    ````
 
@@ -136,8 +136,8 @@ prerequisites.
    requests.
 
    ```bash
-   ./ov just api/stats
-   ./ov just _curl-get "images/stats/" http://localhost:50280
+   just api/stats
+   just _curl-get "images/stats/" http://localhost:50280
    curl "http://localhost:50280/v1/images/stats/"
    [{"source_name":"flickr","display_name":"Flickr","source_url":"https://www.flickr.com","logo_url":null,"media_count":2500},{"source_name":"stocksnap","display_name":"StockSnap","source_url":"https://stocksnap.io","logo_url":null,"media_count":2500}]%
    ```
@@ -148,7 +148,7 @@ prerequisites.
    transform it.
 
    ```bash
-   ./ov just api/stats | jq '.[0]'
+   just api/stats | jq '.[0]'
    {
      "source_name": "flickr",
      "display_name": "Flickr",
@@ -157,7 +157,7 @@ prerequisites.
      "media_count": 2500
    }
 
-   ./ov just api/stats 'audio' | jq '[.[] | .source_name]'
+   just api/stats 'audio' | jq '[.[] | .source_name]'
    [
      "freesound",
      "jamendo",
@@ -173,7 +173,7 @@ prerequisites.
    recipes for almost everything.
 
    ```bash
-   ./ov env API_URL="http://localhost:50280" just frontend/run dev
+   env API_URL="http://localhost:50280" just frontend/run dev
    ```
 
    Now you should be able to access the following endpoints:
@@ -189,7 +189,7 @@ prerequisites.
    Plausible, use another `just` recipe to bring them down.
 
    ```bash
-   ./ov just down
+   just down
    ```
 
    ````{tip}
@@ -197,6 +197,6 @@ prerequisites.
    be deleted too, which is useful in case you want a fresh start.
 
    ```bash
-   ./ov just down -v
+   just down -v
    ```
    ````

--- a/documentation/general/run.md
+++ b/documentation/general/run.md
@@ -18,18 +18,18 @@ To run the API inside Docker, follow the instructions in the
 1. Create environment variables from the stencil file.
 
    ```bash
-   ./ov just env
+   just env
    ```
 
 2. Install Python dependencies.
 
    ```bash
-   ./ov just install
+   just install
    ```
 
 3. Start the Django dev server.
    ```bash
-   ./ov just api/dj runserver
+   just api/dj runserver
    ```
 
 ## Django admin

--- a/documentation/general/test.md
+++ b/documentation/general/test.md
@@ -5,14 +5,14 @@
 1. Before running the tests, make sure to initialise the system with data.
 
    ```bash
-   ./ov just init
+   just init
    ```
 
    This step is a part of the {doc}`"Quickstart" <./quickstart>` process.
 
 2. Run the tests in an interactive TTY connected to a `web` container.
    ```bash
-   ./ov just api/test
+   just api/test
    ```
 
 ## Flaky tests

--- a/documentation/ingestion_server/guides/quickstart.md
+++ b/documentation/ingestion_server/guides/quickstart.md
@@ -52,7 +52,7 @@ you need to run this.
    - The list of ingestion jobs on
      [http://localhost:50281/task](http://localhost:50281/task)
 
-   You can view logs for the service using `./ov just logs ingestion_server`.
+   You can view logs for the service using `just logs ingestion_server`.
 
 ## Shutting down
 

--- a/documentation/ingestion_server/guides/test.md
+++ b/documentation/ingestion_server/guides/test.md
@@ -11,7 +11,7 @@ Once you've made some changes to the codebase, it is important to run tests.
 2. Install the Python dependencies, including dev-dependencies.
 
    ```bash
-   ./ov just ingestion_server/install
+   just ingestion_server/install
    ```
 
    ```{caution}
@@ -22,7 +22,7 @@ Once you've made some changes to the codebase, it is important to run tests.
 3. Run the integration tests.
 
    ```bash
-   ./ov just ingestion_server/test-local
+   just ingestion_server/test-local
    ```
 
    Note that if an `.env` file exists in the folder you're running `just` from,
@@ -34,7 +34,7 @@ Once you've made some changes to the codebase, it is important to run tests.
 To make cURL requests to the local server:
 
 ```bash
-./ov just ingestion_server/curl-post '{"model": <model>, "action": <action>}'
+just ingestion_server/curl-post '{"model": <model>, "action": <action>}'
 ```
 
 Replace `<model>` and `<action>` with the correct values. For example, to

--- a/documentation/meta/ci_cd/jobs/preparation.md
+++ b/documentation/meta/ci_cd/jobs/preparation.md
@@ -56,7 +56,7 @@ It is still possible to run this hook locally, assuming the docker image works
 on your computer's architecture, by invoking the `lint-codeowners` just recipe:
 
 ```bash
-./ov just lint-codeowners
+just lint-codeowners
 ```
 
 ````{tip}
@@ -65,7 +65,7 @@ in the just recipe because they fail if there are uncommitted changes.
 To run precisely the check that CI uses, enable experimental checks:
 
 ```bash
-./ov just lint-codeowners all
+just lint-codeowners all
 ```
 
 ````

--- a/documentation/meta/documentation/adding_docs.md
+++ b/documentation/meta/documentation/adding_docs.md
@@ -31,7 +31,7 @@ The following demonstrates the process of adding a new documentation page.
 
 3. Write the document using [MyST flavored Markdown](https://mystmd.org/guide).
 
-4. Run `./ov just lint` to properly format the document.
+4. Run `just lint` to properly format the document.
 
-5. Run `./ov just documentation/live` locally (following the quick start guide)
-   and navigate to the new page to make sure it looks okay!
+5. Run `just documentation/live` locally (following the quick start guide) and
+   navigate to the new page to make sure it looks okay!

--- a/documentation/meta/documentation/quickstart.md
+++ b/documentation/meta/documentation/quickstart.md
@@ -41,14 +41,14 @@ you need to run this.
    dependencies to run the documentation.
 
    ```bash
-   ./ov just documentation/install
+   just documentation/install
    ```
 
 4. Run the documentation live server. Once this is done, you should be able to
    see the documentation on [http://127.0.0.1:50230](http://127.0.0.1:50230).
 
    ```bash
-   ./ov just documentation/live
+   just documentation/live
    ```
 
    ````{admonition} Troubleshooting
@@ -57,8 +57,8 @@ you need to run this.
    caches and restart the live server.
 
    ```bash
-   ./ov just documentation/clean
-   ./ov just documentation/live
+   just documentation/clean
+   just documentation/live
    ```
    ````
 

--- a/documentation/packages/index.md
+++ b/documentation/packages/index.md
@@ -19,18 +19,17 @@ Openverse does not currently have any method for publishing packages to NPM.
 
 ### Running package scripts
 
-Run scripts for individual packages using `./ov just p {package} {script}`. For
+Run scripts for individual packages using `just p {package} {script}`. For
 example, to run tests for the `eslint-plugin`, run:
 
 ```
-./ov just p eslint-plugin test:unit
+just p eslint-plugin test:unit
 ```
 
-This also works for the Nuxt frontend as an alternative to
-`./ov just frontend/run`:
+This also works for the Nuxt frontend as an alternative to `just frontend/run`:
 
 ```
-./ov just p frontend dev
+just p frontend dev
 ```
 
 ### Adding new packages

--- a/documentation/projects/planning.md
+++ b/documentation/projects/planning.md
@@ -47,7 +47,7 @@ accepts one argument as the project name, followed optionally by any number of
 implementation plans.
 
 ```bash
-./ov just documentation/create-project 'Project name' 'First IP' 'Second IP'
+just documentation/create-project 'Project name' 'First IP' 'Second IP'
 ```
 
 This will create the directory structure for your project with the specified
@@ -67,7 +67,7 @@ plan, you can use the `just` recipe `create-ip`. It accepts the directory name
 (not full path) of the project and the plan name as arguments.
 
 ```bash
-./ov just documentation/create-ip project_name 'New IP'
+just documentation/create-ip project_name 'New IP'
 ```
 ````
 

--- a/frontend/src/locales/scripts/bulk-download.js
+++ b/frontend/src/locales/scripts/bulk-download.js
@@ -58,7 +58,7 @@ const extractZip = async (zipPath) => {
   const issue = "https://github.com/WordPress/openverse/issues/2438"
   if (deprecatedKeys.count > 0) {
     let warning = `${deprecatedKeys.count} deprecated kebab-case keys replaced in locale files. `
-    warning += `To see the keys, run \`./ov just frontend/run i18n:get-translations --verbose\`. For more details, see ${issue}.`
+    warning += `To see the keys, run \`just frontend/run i18n:get-translations --verbose\`. For more details, see ${issue}.`
     if (process.argv.includes("--verbose")) {
       warning += `\n${JSON.stringify(deprecatedKeys.keys, null, 2)}`
     }

--- a/ov
+++ b/ov
@@ -20,6 +20,9 @@ USAGE
   ov <subcommand> [...ARGS]
 
 COMMANDS
+  ov [help|--help|-h]
+    Show this documentation and exit.
+
   ov init
     Initialise the Openverse development toolkit for the first time
     Alias for:

--- a/ov
+++ b/ov
@@ -12,7 +12,7 @@ _cmd="$1"
 
 dev_env="$OPENVERSE_PROJECT"/docker/dev_env
 
-if [[ $_cmd == "help" || -z $_cmd ]]; then
+if [[ $_cmd == "help" || $_cmd == "--help" || $_cmd == "-h" || -z $_cmd ]]; then
   cat <<-'EOF'
 Openverse development toolkit
 

--- a/utilities/generate_test_locales/__main__.py
+++ b/utilities/generate_test_locales/__main__.py
@@ -10,7 +10,7 @@ reporoot = Path(__file__).parents[2]
 
 from_lang = "en"
 
-# Must be generated using `./ov just p frontend i18n:en`
+# Must be generated using `just p frontend i18n:en`
 from_json_path = reporoot / "frontend" / "src" / "locales" / "en.json"
 
 to_langs = ["ar", "es"]

--- a/utilities/load_testing/README.md
+++ b/utilities/load_testing/README.md
@@ -37,25 +37,22 @@ important to disable the Cloudflare cache and WAF security settings for the
 duration of the test to test the actual performance of the application instead
 of testing Cloudflare cache or getting blocked by WAF. By default, the tests
 request only the English static pages. You can specify other scenarios to run,
-with `./ov just load_testing/k6 all` being the most comprehensive test that
-requests static and search pages in English. The `locales` tests request pages
-in 3 other locales.
+with `just k6 all` being the most comprehensive test that requests static and
+search pages in English. The `locales` tests request pages in 3 other locales.
 
 ### Running
 
 All load tests are accessible through `just` scripts in this directory's
 `justfile`.
 
-To run API load tests against a local API instance, use
-`./ov just load_testing/api`. You can optionally specify a host (the default is
-to point to local). For example
-`./ov just load_testing/api https://api-staging.openverse.org` will run the load
-tests against the staging API.
+To run API load tests against a local API instance, use `just api`. You can
+optionally specify a host (the default is to point to local). For example
+`just api https://api-staging.openverse.org` will run the load tests against the
+staging API.
 
-To run the frontend load tests, use `./ov just load_testing/k6-frontend`. You
-can optionally specify the scenarios to run, for example,
-`./ov just load_testing/k6-frontend all`. To specify a host (the default is to
-point to the `openverse.org`), set the `FRONTEND_URL` environment variable. For
-example,
-`./ov env FRONTEND_URL=https://staging.openverse.org just load_testing/k6-frontend`
-will run the load tests against the staging frontend.
+To run the frontend load tests, use `just k6-frontend`. You can optionally
+specify the scenarios to run, for example, `just k6-frontend all`. To specify a
+host (the default is to point to the `openverse.org`), set the `FRONTEND_URL`
+environment variable. For example,
+`FRONTEND_URL=https://staging.openverse.org just k6-frontend` will run the load
+tests against the staging frontend.


### PR DESCRIPTION
I'm temporarily reverting this PR. Until we are confident `ov` is 100% ready to be _the_ Openverse development environment (as in, the only one that is supported), and until its general usage is documented in our getting started/entry point documentation, we should hold off on downstream documentation referencing it.

I fully expect to re-revert these changes in the new future, though, once `ov` is deemed ready by the Openverse maintainers.