### PR TITLE
Specify pull policy for `openverse-` images

### DIFF
--- a/api/compose.yml
+++ b/api/compose.yml
@@ -20,6 +20,7 @@ services:
         - API_PY_VERSION
         - PDM_INSTALL_ARGS=--dev
     image: openverse-api:${API_PDM_HASH:-latest}
+    pull_policy: never
     volumes:
       - .:/api:z
       - ../packages/python:/packages/python:z

--- a/catalog/compose.yml
+++ b/catalog/compose.yml
@@ -8,6 +8,7 @@ x-airflow-common: &airflow-common
     - postgres
     - s3
   image: openverse-catalog
+  pull_policy: never
   env_file:
     - .env
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       target: db
       args: # Automatically inferred from env vars, unless specified
         - PGCLI_VERSION
-    image: openverse-upstream_db
     ports:
       - "50255:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       target: db
       args: # Automatically inferred from env vars, unless specified
         - PGCLI_VERSION
+    image: openverse-upstream_db
+    pull_policy: never
     ports:
       - "50255:5432"
     volumes:

--- a/ingestion_server/compose.yml
+++ b/ingestion_server/compose.yml
@@ -9,6 +9,7 @@ x-ingestion-server-common: &ingestion-server-common
     args: # Automatically inferred from env vars, unless specified
       - INGESTION_PY_VERSION
   image: openverse-ingestion_server
+  pull_policy: never
   env_file:
     - env.docker
     - .env


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- specifies a `pull_policy` of `never` for custom Openverse images that are meant to be built on-device
- <s>removes the `image` field for services where the image name is the same as the default `openverse-<service_name>`</s> (this had to be reversed because ingestion server integration tests would fail)

Effectively, these changes mean that the warning referenced in https://github.com/WordPress/openverse/pull/4526#discussion_r1646764935 will go away. <s>This will be further expanded by #1910 which will expand the second change to apply to more services.</s>

This also makes it safer by ensuring that we never accidentally pull a (potentially nefarious) image named `openverse-*` from the Docker registry.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out this PR.
2. Remove any number of `openverse-*` images from Docker. 
3. Run `just up`.
4. You should not see any warnings and the missing images should be built and tagged automatically.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
