### PR TITLE
Bump `schemathesis` to v3.31.0 and silence warnings on API tests

### DIFF
--- a/api/pdm.lock
+++ b/api/pdm.lock
@@ -744,6 +744,17 @@ files = [
 ]
 
 [[package]]
+name = "harfile"
+version = "0.3.0"
+requires_python = ">=3.8"
+summary = "Writer for HTTP Archive (HAR) files"
+groups = ["test"]
+files = [
+    {file = "harfile-0.3.0-py3-none-any.whl", hash = "sha256:ac11177e06c88c9553c8c73c16ab20428a176d1d2ebe00b41ce527ff0bdc47e6"},
+    {file = "harfile-0.3.0.tar.gz", hash = "sha256:23be8037e1296bb4787a15543a37835ed91f408c8296988f9ba022a44accad9e"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.5"
 requires_python = ">=3.8"
@@ -795,7 +806,7 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.100.1"
+version = "6.104.2"
 requires_python = ">=3.8"
 summary = "A library for property-based testing"
 groups = ["test"]
@@ -804,8 +815,8 @@ dependencies = [
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "hypothesis-6.100.1-py3-none-any.whl", hash = "sha256:3dacf6ec90e8d14aaee02cde081ac9a17d5b70105e45e6ac822db72052c0195b"},
-    {file = "hypothesis-6.100.1.tar.gz", hash = "sha256:ebff09d7fa4f1fb6a855a812baf17e578b4481b7b70ec6d96496210d1a4c6c35"},
+    {file = "hypothesis-6.104.2-py3-none-any.whl", hash = "sha256:8b52b7e2462e552c75b819495d5cb6251a2b840accc79cf2ce52588004c915d9"},
+    {file = "hypothesis-6.104.2.tar.gz", hash = "sha256:6f2a1489bc8fe1c87ffd202707319b66ec46b2bc11faf6e0161e957b8b9b1eab"},
 ]
 
 [[package]]
@@ -1655,19 +1666,19 @@ files = [
 
 [[package]]
 name = "schemathesis"
-version = "3.27.0"
+version = "3.31.0"
 requires_python = ">=3.8"
 summary = "Property-based testing framework for Open API and GraphQL based apps"
 groups = ["test"]
 dependencies = [
-    "anyio<4",
     "backoff<3.0,>=2.1.2",
     "click<9.0,>=7.0",
     "colorama<1.0,>=0.4",
+    "harfile<1.0,>=0.3.0",
     "httpx<1.0,>=0.22.0",
     "hypothesis-graphql<1,>=0.11.0",
     "hypothesis-jsonschema<0.24,>=0.23.1",
-    "hypothesis<7,>=6.84.3; python_version > \"3.8\"",
+    "hypothesis<7,>=6.103.4; python_version > \"3.8\"",
     "jsonschema<5.0,>=4.18.0",
     "junit-xml<2.0,>=1.9",
     "pyrate-limiter<4.0,>=2.10",
@@ -1675,7 +1686,7 @@ dependencies = [
     "pytest<9,>=4.6.4",
     "pyyaml<7.0,>=5.1",
     "requests<3,>=2.22",
-    "starlette-testclient<1",
+    "starlette-testclient<1,>=0.4.1",
     "starlette<1,>=0.13",
     "tomli-w<2.0,>=1.0.0",
     "tomli<3.0,>=2.0.1",
@@ -1683,8 +1694,8 @@ dependencies = [
     "yarl<2.0,>=1.5",
 ]
 files = [
-    {file = "schemathesis-3.27.0-py3-none-any.whl", hash = "sha256:d17dfbf0f1e085b14199e831fdc5d524ded7f461e0bdc9b18446e9ad29ff6495"},
-    {file = "schemathesis-3.27.0.tar.gz", hash = "sha256:15ce5e2bf8a9c3cce425022db30fd506f241272fd99daec45ba4f491e5a8ea3e"},
+    {file = "schemathesis-3.31.0-py3-none-any.whl", hash = "sha256:1a05b8d15ced5065e22a60fa9f1d2bca79aa3207634949561108273a457fee5f"},
+    {file = "schemathesis-3.31.0.tar.gz", hash = "sha256:334068ff2d39f6bad46cd61e6e1fb64e55042da9fc727a5ba8d5e2789fbf73a6"},
 ]
 
 [[package]]
@@ -1824,7 +1835,7 @@ files = [
 
 [[package]]
 name = "starlette-testclient"
-version = "0.3.0"
+version = "0.4.1"
 requires_python = ">=3.7"
 summary = "A backport of Starlette TestClient using requests! ⏪️"
 groups = ["test"]
@@ -1833,8 +1844,8 @@ dependencies = [
     "starlette>=0.20.1",
 ]
 files = [
-    {file = "starlette_testclient-0.3.0-py3-none-any.whl", hash = "sha256:84306a5ca443f81b2d5e838071ed175e9f1ece4ff0806b94778f5122b1c57ee6"},
-    {file = "starlette_testclient-0.3.0.tar.gz", hash = "sha256:31c28c10abd240beb327ef1ee4dc395403c87da07d4665126b7d3c7b60444e04"},
+    {file = "starlette_testclient-0.4.1-py3-none-any.whl", hash = "sha256:dcf0eb237dc47f062ef5925f98330af46f67e547cb587119c9ae78c17ae6c1d1"},
+    {file = "starlette_testclient-0.4.1.tar.gz", hash = "sha256:9e993ffe12fab45606116257813986612262fe15c1bb6dc9e39cc68693ac1fc5"},
 ]
 
 [[package]]

--- a/api/test/unit/configuration/test_link_validation_cache.py
+++ b/api/test/unit/configuration/test_link_validation_cache.py
@@ -26,6 +26,10 @@ def test_all_default_values(status, td):
     assert config[status] == int(td.total_seconds())
 
 
+@pytest.mark.filterwarnings(
+    # Due to expected exceptions raised by the tests
+    "ignore:A plugin raised an exception during an old-style hookwrapper teardown"
+)
 @pytest.mark.parametrize(
     ("overrides", "expecteds"),
     (

--- a/api/test/unit/configuration/test_link_validation_cache.py
+++ b/api/test/unit/configuration/test_link_validation_cache.py
@@ -26,10 +26,6 @@ def test_all_default_values(status, td):
     assert config[status] == int(td.total_seconds())
 
 
-@pytest.mark.filterwarnings(
-    # Due to expected exceptions raised by the tests
-    "ignore:A plugin raised an exception during an old-style hookwrapper teardown"
-)
 @pytest.mark.parametrize(
     ("overrides", "expecteds"),
     (

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -58,6 +58,10 @@ def unreachable_search_con_cache(unreachable_django_cache, monkeypatch):
     yield cache
 
 
+@pytest.mark.filterwarnings(
+    # Due to expected `ZeroDivisionError` in the test cases
+    "ignore:A plugin raised an exception during an old-style hookwrapper teardown"
+)
 @pytest.mark.parametrize(
     "total_hits, real_result_count, page_size, page, expected",
     [

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -58,10 +58,6 @@ def unreachable_search_con_cache(unreachable_django_cache, monkeypatch):
     yield cache
 
 
-@pytest.mark.filterwarnings(
-    # Due to expected `ZeroDivisionError` in the test cases
-    "ignore:A plugin raised an exception during an old-style hookwrapper teardown"
-)
 @pytest.mark.parametrize(
     "total_hits, real_result_count, page_size, page, expected",
     [

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -1,7 +1,7 @@
-import datetime
 import random
 import re
 from collections.abc import Callable
+from datetime import datetime, timezone
 from enum import Enum, auto
 from unittest import mock
 from unittest.mock import patch
@@ -858,7 +858,7 @@ def test_get_excluded_sources_query_returns_excluded(
     else:
         for i in range(excluded_count):
             ContentSourceFactory.create(
-                created_on=datetime.datetime.now(),
+                created_on=datetime.now(tz=timezone.utc),
                 source_identifier=f"source{i + 1}",
                 source_name=f"Source {i + 1}",
                 filter_content=True,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Several warning messages have been accumulating in the running of API tests. In `main`, you will see and output like the following below. Most of these can be fixed or silenced and should be addressed given they're just noise in the tests' output.

```python
test/unit/controllers/test_search_controller.py::test_get_result_and_page_count[5-5-0-1-expected1]
  /.venv/lib/python3.11/site-packages/_pytest/python.py:1792: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
  Plugin: schemathesis, Hook: pytest_pyfunc_call
  ZeroDivisionError: division by zero
  For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)

test/unit/controllers/test_search_controller.py::test_get_excluded_sources_query_returns_excluded[2-result0-False-unreachable_search_con_cache]
  /.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField ContentSource.created_on received a naive datetime (2024-07-02 18:16:51.471033) while time zone support is active.
    warnings.warn(

test/unit/controllers/test_search_controller.py::test_get_excluded_sources_query_returns_excluded[2-result0-False-unreachable_search_con_cache]
  /.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField ContentSource.created_on received a naive datetime (2024-07-02 18:16:51.492997) while time zone support is active.
    warnings.warn(

test/unit/configuration/test_link_validation_cache.py::test_environment_overrides[overrides4-expecteds4]
  /.venv/lib/python3.11/site-packages/_pytest/python.py:1792: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
  Plugin: schemathesis, Hook: pytest_pyfunc_call
  ImproperlyConfigured: Invalid link validation cache setting. Impossible to parse default.
  For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)

test/unit/configuration/test_link_validation_cache.py::test_environment_overrides[overrides5-expecteds5]
  /.venv/lib/python3.11/site-packages/_pytest/python.py:1792: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
  Plugin: schemathesis, Hook: pytest_pyfunc_call
  ImproperlyConfigured: Invalid link validation cache setting name: LINK_VALIDATION_CACHE_EXPIRY__. Please ensure settings are named in the format of 'LINK_VALIDATION_CACHE_EXPIRY__<http integer status code>'.
  For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)

test/unit/configuration/test_link_validation_cache.py::test_environment_overrides[overrides6-expecteds6]
  /.venv/lib/python3.11/site-packages/_pytest/python.py:1792: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
  Plugin: schemathesis, Hook: pytest_pyfunc_call
  ImproperlyConfigured: Invalid link validation cache setting. Impossible to parse 500.
  For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
```

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

- The warning on naive datetime is fixed by specifying the UTC timezone
- The `PluggyTeardownRaisedWarning` messages are silecended given those exceptions are expected and captured in the same tests

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Observe said warnings are no longer shown in this branch.
```
ov just api/test
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`./ov just catalog/generate-docs media-props` for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
