### PR TITLE
Add internet archive to robots.txt denylist

### DIFF
--- a/frontend/src/server-middleware/robots.js
+++ b/frontend/src/server-middleware/robots.js
@@ -13,6 +13,7 @@ const deniedUserAgents = [
   "Bytespider",
   "ImagesiftBot",
   "cohere-ai",
+  "ia_archiver", // Internet Archive for the Wayback Machine. Not malicious, but we don't want to allow single and search results to be indexed at the risk of preserving deindexed works.
 ]
 
 const aiDisallowRules = deniedUserAgents


### PR DESCRIPTION
This PR blocks Internet Archive from crawling search and single result endpoints. Wayback Machine is an awesome tool for preserving the history of the web, but in the case of Openverse we only want historical snapshots of our home and static content pages (/about, /sources, etc.). We do not want to archive single and search results because:

- The latest, most accurate information about a work should always be on the live openverse.org
- If a work is _removed_ from Openverse, it is likely for copyright, sensitivity, or other, potentially legal, reasons. This isn't _always_ the case though. Sometimes, sadly, sources go down or stop working. 