### PR TITLE
Decrease link validation timeout

### DIFF
--- a/api/api/controllers/search_controller.py
+++ b/api/api/controllers/search_controller.py
@@ -98,9 +98,8 @@ def _post_process_results(
     results = list(search_results)
 
     if filter_dead:
-        to_validate = [res.url for res in search_results]
         query_hash = get_query_hash(s)
-        check_dead_links(query_hash, start, results, to_validate)
+        check_dead_links(query_hash, start, results)
 
         if len(results) == 0:
             # first page is all dead links

--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -40,7 +40,7 @@ def _get_expiry(status, default):
     return config(f"LINK_VALIDATION_CACHE_EXPIRY__{status}", default=default, cast=int)
 
 
-_timeout = aiohttp.ClientTimeout(total=2)
+_timeout = aiohttp.ClientTimeout(total=settings.LINK_VALIDATION_TIMEOUT_SECONDS)
 
 
 async def _head(url: str, session: aiohttp.ClientSession) -> tuple[str, int]:

--- a/api/conf/settings/__init__.py
+++ b/api/conf/settings/__init__.py
@@ -42,7 +42,7 @@ include(
     "spectacular.py",
     "thumbnails.py",
     # Openverse-specific settings
-    "link_validation_cache.py",
+    "link_validation.py",
     "misc.py",
     "openverse.py",
 )

--- a/api/conf/settings/link_validation.py
+++ b/api/conf/settings/link_validation.py
@@ -12,6 +12,11 @@ from decouple import config
 logger = structlog.get_logger(__name__)
 
 
+LINK_VALIDATION_TIMEOUT_SECONDS = config(
+    "LINK_VALIDATION_TIMEOUT_SECONDS", default=0.8, cast=float
+)
+
+
 class LinkValidationCacheExpiryConfiguration(defaultdict):
     """Link validation cache expiry configuration."""
 

--- a/api/test/factory/es_http.py
+++ b/api/test/factory/es_http.py
@@ -6,7 +6,11 @@ MOCK_DEAD_RESULT_URL_PREFIX = "https://example.com/openverse-dead-image-result-u
 
 
 def create_mock_es_http_image_hit(
-    _id: str, index: str, live: bool = True, identifier: str | None = None
+    _id: str,
+    index: str,
+    live: bool = True,
+    identifier: str | None = None,
+    **additional_fields,
 ):
     return {
         "_index": index,
@@ -39,7 +43,8 @@ def create_mock_es_http_image_hit(
             "created_on": "2022-02-26T08:48:33+00:00",
             "tags": [{"name": "bird"}],
             "mature": False,
-        },
+        }
+        | additional_fields,
     }
 
 

--- a/api/test/integration/test_dead_link_filter.py
+++ b/api/test/integration/test_dead_link_filter.py
@@ -32,7 +32,7 @@ _MAKE_HEAD_REQUESTS_MODULE_PATH = "api.utils.check_dead_links._make_head_request
 
 
 def _patch_make_head_requests():
-    def _make_head_requests(urls):
+    def _make_head_requests(urls, *args, **kwargs):
         responses = []
         for idx, url in enumerate(urls):
             status_code = 200 if idx % 10 != 0 else 404
@@ -45,7 +45,7 @@ def _patch_make_head_requests():
 def patch_link_validation_dead_for_count(count):
     total_res_count = 0
 
-    def _make_head_requests(urls):
+    def _make_head_requests(urls, *args, **kwargs):
         nonlocal total_res_count
         responses = []
         for idx, url in enumerate(urls):

--- a/api/test/unit/configuration/test_link_validation_cache.py
+++ b/api/test/unit/configuration/test_link_validation_cache.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 import pytest
 
-from conf.settings.link_validation_cache import LinkValidationCacheExpiryConfiguration
+from conf.settings.link_validation import LinkValidationCacheExpiryConfiguration
 
 
 @pytest.mark.parametrize(

--- a/api/test/unit/controllers/test_search_controller.py
+++ b/api/test/unit/controllers/test_search_controller.py
@@ -810,7 +810,8 @@ def test_excessive_recursion_in_post_process(
     redis,
     caplog,
 ):
-    def _delete_all_results_but_first(_, __, results, ___):
+    def _delete_all_results_but_first(*args):
+        results = args[2]
         results[1:] = []
 
     mock_check_dead_links.side_effect = _delete_all_results_but_first


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4507 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Please see the linked issue for the rationale of lowering to 0.8 specifically.

The PR lowers the timeout to 0.8, and makes it configurable via environment variables. That's mostly a convenience/safety net, in case this timeout ends up not working out. The environment variable will allow us to change it without needing to create a new release.

As discussed in the issue, I also added the provider to the timing log lines, which we can use to decide whether we need certain provider-specific timeouts (e.g., if there are particularly slow providers). Adding the provider to the log contents makes it easier for us to check if one provider or other is overly affected by the lower timeout.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI must pass, and existing tests must pass. Follow instructions from #4508 to test the validation logs and confirm they now include the `provider` entry. You should see lines like this:

```
web-1  | 2024-07-04T03:20:02.797988Z [info     ] dead_link_validation_timing    [api.utils.check_dead_links] filename=__init__.py func_name=_head ip=172.18.0.1 lineno=62 provider=flickr request_id=061e6db2-a654-4b47-8a1e-6f78e667b34c status=200 time=0.7856568309998693 url=https://live.staticflickr.com/65535/51744296832_5399845f06_b.jpg
```

Please note that 0.8 may be too low for your home internet connection. It's only barely enough for me to get results from Flickr. In production, Flickr responds much faster. **Do not take your local network behaviour and speed as representative of production conditions**. Please refer to the issue for the reasoning behind 0.8. If you run into issues where links are timing out for you locally (more so than you want or need for testing), then increase the timeout by adding `LINK_VALIDATION_TIMEOUT_SECONDS` to your `api/.env` and set to something high enough for your purposes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
