### PR TITLE
Create a dataclass for indexer worker TaskStatus

### DIFF
--- a/indexer_worker/indexer_worker/tasks.py
+++ b/indexer_worker/indexer_worker/tasks.py
@@ -2,10 +2,11 @@
 
 import datetime
 from dataclasses import dataclass
+from multiprocessing.sharedctypes import Synchronized
 from typing import Any
 
 
-def _time_fmt(timestamp: int) -> str | None:
+def _time_fmt(timestamp: float) -> str | None:
     """
     Format the timestamp into a human-readable date and time notation.
 
@@ -21,11 +22,11 @@ def _time_fmt(timestamp: int) -> str | None:
 @dataclass
 class TaskInfo:
     task: Any
-    start_time: int
+    start_time: float
     model: str
     target_index: str
-    finish_time: int
-    progress: float
+    finish_time: Synchronized
+    progress: Synchronized
 
 
 class TaskTracker:

--- a/indexer_worker/indexer_worker/tasks.py
+++ b/indexer_worker/indexer_worker/tasks.py
@@ -1,5 +1,7 @@
 """Simple in-memory tracking of executed tasks."""
 
+from __future__ import annotations
+
 import datetime
 from dataclasses import dataclass
 from multiprocessing.sharedctypes import Synchronized
@@ -25,8 +27,8 @@ class TaskInfo:
     start_time: float
     model: str
     target_index: str
-    finish_time: Synchronized
-    progress: Synchronized
+    finish_time: Synchronized[float]
+    progress: Synchronized[float]
 
 
 class TaskTracker:

--- a/indexer_worker/indexer_worker/tasks.py
+++ b/indexer_worker/indexer_worker/tasks.py
@@ -4,6 +4,7 @@ import datetime
 from dataclasses import dataclass
 from typing import Any
 
+
 def _time_fmt(timestamp: int) -> str | None:
     """
     Format the timestamp into a human-readable date and time notation.
@@ -16,14 +17,16 @@ def _time_fmt(timestamp: int) -> str | None:
         return None
     return str(datetime.datetime.utcfromtimestamp(timestamp))
 
+
 @dataclass
 class TaskInfo:
     task: Any
-    start_time: Any
+    start_time: int
     model: str
     target_index: str
-    finish_time: Any
-    progress: Any
+    finish_time: int
+    progress: float
+
 
 class TaskTracker:
     def __init__(self):
@@ -37,12 +40,11 @@ class TaskTracker:
         :param task_id: the UUID of the task
         """
         task_info = TaskInfo(
-            start_time=datetime.datetime.utcnow().timestamp(),
-            **kwargs
+            start_time=datetime.datetime.utcnow().timestamp(), **kwargs
         )
 
         self.tasks[task_id] = task_info
-   
+
     def get_task_status(self, task_id: str) -> dict:
         """
         Get the status of a single task with the given task ID.

--- a/indexer_worker/indexer_worker/tasks.py
+++ b/indexer_worker/indexer_worker/tasks.py
@@ -1,7 +1,8 @@
 """Simple in-memory tracking of executed tasks."""
 
 import datetime
-
+from dataclasses import dataclass
+from typing import Any
 
 def _time_fmt(timestamp: int) -> str | None:
     """
@@ -15,6 +16,14 @@ def _time_fmt(timestamp: int) -> str | None:
         return None
     return str(datetime.datetime.utcfromtimestamp(timestamp))
 
+@dataclass
+class TaskInfo:
+    task: Any
+    start_time: Any
+    model: str
+    target_index: str
+    finish_time: Any
+    progress: Any
 
 class TaskTracker:
     def __init__(self):
@@ -27,10 +36,13 @@ class TaskTracker:
         :param task: the task being performed
         :param task_id: the UUID of the task
         """
-        self.tasks[task_id] = {
-            "start_time": datetime.datetime.utcnow().timestamp(),
-        } | kwargs
+        task_info = TaskInfo(
+            start_time=datetime.datetime.utcnow().timestamp(),
+            **kwargs
+        )
 
+        self.tasks[task_id] = task_info
+   
     def get_task_status(self, task_id: str) -> dict:
         """
         Get the status of a single task with the given task ID.
@@ -39,12 +51,12 @@ class TaskTracker:
         :return: response dictionary containing all relevant info about the task
         """
         task_info = self.tasks[task_id]
-        active = task_info["task"].is_alive()
-        model = task_info["model"]
-        target_index = task_info["target_index"]
-        start_time = task_info["start_time"]
-        finish_time = task_info["finish_time"].value
-        progress = task_info["progress"].value
+        active = task_info.task.is_alive()
+        model = task_info.model
+        target_index = task_info.target_index
+        start_time = task_info.start_time
+        finish_time = task_info.finish_time.value
+        progress = task_info.progress.value
 
         return {
             "task_id": task_id,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4534 by @stacimc  

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a dataclass with type hints for each field for index worker task status. The task status was stored as dictionary before.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just build && just up`

Use [elasticvue](https://app.elasticvue.com/cluster/0/indices) to Delete All Documents from one of your existing indices. Eg:  `audio-init-filtered`. The index should now have 0 documents.

Now run just `catalog/shell`, and you should be able to curl the indexer worker.

Replace the target_index name if you don't have audio-init-filtered
Note the start_id/end_id we're using, to make it reindex only 100 records
`curl -X POST -d '{"model_name": "audio", "table_name": "audio", "start_id": 0, "end_id": 100, "target_index": "audio-init-filtered"}' -H "Content-Type: application/json" 'http://catalog_indexer_worker:8003/task'`

You should get back a response like:

> {
> "message": "Successfully scheduled task.", 
> "task_id": "acfb9919708c4ef2a505fe5f8c6a10a8", 
> "status_check": "http://catalog_indexer_worker:8003/task/acfb9919708c4ef2a505fe5f8c6a10a8"
> }

Now curl the status_check endpoint that was just returned:

`curl 'http://catalog_indexer_worker:8003/task/acfb9919708c4ef2a505fe5f8c6a10a8`
And you should see something like:

> {
> "task_id": "acfb9919708c4ef2a505fe5f8c6a10a8",
> "active": false,
> "model": "audio",
> "target_index": "audio-init-filtered",
> "progress": 100.0,
> "start_time": "2024-07-04 18:56:28.288367", 
> "finish_time": "2024-07-04 18:56:28.384862", 
> "error": false
> }
> 

### Which is similar to the response returned before adding dataclass for the task status.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`./ov just catalog/generate-docs media-props`
      for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
