### PR TITLE
Add `catalog_cleaner` DAG

### DIFF
--- a/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
+++ b/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
@@ -50,9 +50,10 @@ def count_dirty_rows_and_notify(temp_table_name: str, task: AbstractOperator = N
         handler=single_value,
         task=task,
     )
+    column = temp_table_name.split("_")[-1]
     notify_slack.function(
-        text=f"Starting the cleaning process in upstream DB. Expecting {count:,} rows"
-        f" affected given `{temp_table_name}` table."
+        text=f"Starting the cleaning process in upstream DB for column `{column}`."
+        f" Expecting {count:,} rows affected given `{temp_table_name}` table."
     )
     return count
 

--- a/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
+++ b/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
@@ -27,8 +27,6 @@ from database.catalog_cleaner import constants
 
 logger = logging.getLogger(__name__)
 
-DAG_ID = "catalog_cleaner"
-
 
 @task
 def count_dirty_rows(temp_table_name: str, task: AbstractOperator = None):
@@ -45,16 +43,6 @@ def count_dirty_rows(temp_table_name: str, task: AbstractOperator = None):
 
 @task
 def get_batches(total_row_count: int, batch_size: int) -> list[tuple[int, int]]:
-    # batch_list = []
-    # batch_start = 0
-    # while batch_start <= total_row_count:
-    #     batch_end = min(batch_start + batch_size, total_row_count)
-    #     batch_list.append({
-    #         "batch_start": batch_start,
-    #         "batch_end": batch_end
-    #     })
-    #     batch_start += batch_size
-    # return batch_list
     return [(i, i + batch_size) for i in range(0, total_row_count, batch_size)]
 
 
@@ -85,7 +73,7 @@ def update_batch(
 
 
 @dag(
-    dag_id=DAG_ID,
+    dag_id=constants.DAG_ID,
     default_args={
         **DAG_DEFAULT_ARGS,
         "retries": 0,

--- a/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
+++ b/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
@@ -141,6 +141,10 @@ def notify_slack(text):
 )
 def catalog_cleaner():
     aws_region = Variable.get("AWS_DEFAULT_REGION", default_var="us-east-1")
+    max_concurrent_tasks = Variable.get(
+        "CLEANER_MAX_CONCURRENT_DB_UPDATE_TASKS", default_var=3, deserialize_json=True
+    )
+
     column = "{{ params.column }}"
     temp_table_name = f"temp_cleaned_image_{column}"
 
@@ -176,7 +180,7 @@ def catalog_cleaner():
 
     updates = (
         update_batch.override(
-            max_active_tis_per_dag=3,
+            max_active_tis_per_dag=max_concurrent_tasks,
             retries=0,
         )
         .partial(temp_table_name=temp_table_name, column=column)

--- a/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
+++ b/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
@@ -1,8 +1,18 @@
 """
 Catalog Data Cleaner DAG
 
-Use TSV files created during the clean step of the ingestion process to bring the
-changes into the catalog.
+Use the TSV files created during the cleaning step of the ingestion process to bring
+the changes into the catalog database and make the updates permanent.
+
+The DAG has a structure similar to the batched_update DAG, but with a few key
+differences:
+  1. Given the structure of the TSV, it updates a single column at a time.
+  2. The batch updates are parallelized to speed up the process. The maximum number of
+     active tasks is limited to 3 (at first to try it out and) to avoid overwhelming
+     the database.
+  3. It needs slightly different SQL queries to update the data. One change for example,
+     is that it only works with the `image` table given that is the only one where the
+     cleaning steps are applied to in the ingestion server.
 """
 
 import logging
@@ -13,7 +23,9 @@ from airflow.models import Variable
 from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.param import Param
 from airflow.operators.python import get_current_context
+from airflow.utils.trigger_rule import TriggerRule
 
+from common import slack
 from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
 from common.sql import (
     RETURN_ROW_COUNT,
@@ -30,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 @task
 def count_dirty_rows(temp_table_name: str, task: AbstractOperator = None):
+    """Get the number of rows in the temp table before the updates."""
     count = run_sql.function(
         dry_run=False,
         sql_template=f"SELECT COUNT(*) FROM {temp_table_name}",
@@ -43,6 +56,7 @@ def count_dirty_rows(temp_table_name: str, task: AbstractOperator = None):
 
 @task
 def get_batches(total_row_count: int, batch_size: int) -> list[tuple[int, int]]:
+    """Return a list of tuples with the start and end row_id for each batch."""
     return [(i, i + batch_size) for i in range(0, total_row_count, batch_size)]
 
 
@@ -55,6 +69,9 @@ def update_batch(
 ):
     batch_start, batch_end = batch
     logger.info(f"Going through row_id {batch_start:,} to {batch_end:,}.")
+
+    # Includes the formatted batch range in the context to be used as the index
+    # template for easier identification of the tasks in the UI.
     context = get_current_context()
     context["index_template"] = f"{batch_start}__{batch_end}"
 
@@ -70,6 +87,21 @@ def update_batch(
     )
     count = pg.run(query, handler=RETURN_ROW_COUNT)
     return count
+
+
+@task
+def sum_up_counts(counts: list[int]) -> int:
+    return sum(counts)
+
+
+@task
+def notify_slack(text):
+    slack.send_message(
+        text=text,
+        username=constants.SLACK_USERNAME,
+        icon_emoji=constants.SLACK_ICON,
+        dag_id=constants.DAG_ID,
+    )
 
 
 @dag(
@@ -100,7 +132,6 @@ def update_batch(
             enum=["url", "creator_url", "foreign_landing_url"],
             description="The column of the table to apply the updates.",
         ),
-        # "table": Param(type="str", description="The media table to update."),
         "batch_size": Param(
             default=10000,
             type="integer",
@@ -113,11 +144,12 @@ def catalog_cleaner():
     column = "{{ params.column }}"
     temp_table_name = f"temp_cleaned_image_{column}"
 
-    create = PGExecuteQueryOperator(
+    create_table = PGExecuteQueryOperator(
         task_id="create_temp_table",
         postgres_conn_id=POSTGRES_CONN_ID,
-        sql=constants.CREATE_SQL.format(temp_table_name=temp_table_name, column=column),
-        execution_timeout=timedelta(minutes=1),
+        sql=constants.CREATE_TEMP_TABLE_SQL.format(
+            temp_table_name=temp_table_name, column=column
+        ),
     )
 
     load = PGExecuteQueryOperator(
@@ -130,16 +162,28 @@ def catalog_cleaner():
             s3_path_to_file="{{ params.s3_path }}",
             aws_region=aws_region,
         ),
-        execution_timeout=timedelta(hours=1),
+    )
+
+    create_index = PGExecuteQueryOperator(
+        task_id="create_temp_table_index",
+        postgres_conn_id=POSTGRES_CONN_ID,
+        sql=constants.CREATE_INDEX_SQL.format(temp_table_name=temp_table_name),
     )
 
     count = count_dirty_rows(temp_table_name)
 
     batches = get_batches(total_row_count=count, batch_size="{{ params.batch_size }}")
 
-    updates = update_batch.partial(
-        temp_table_name=temp_table_name, column=column
-    ).expand(batch=batches)
+    updates = (
+        update_batch.override(
+            max_active_tis_per_dag=3,
+            retries=0,
+        )
+        .partial(temp_table_name=temp_table_name, column=column)
+        .expand(batch=batches)
+    )
+
+    total = sum_up_counts(updates)
 
     drop = PGExecuteQueryOperator(
         task_id="drop_temp_tables",
@@ -148,7 +192,21 @@ def catalog_cleaner():
         execution_timeout=timedelta(minutes=1),
     )
 
-    create >> load >> count >> updates >> drop
+    notify_success = notify_slack.override(task_id="notify_success")(
+        f"Upstream cleaning was completed successfully updating column `{column}` for"
+        f" {total} rows.",
+    )
+
+    notify_failure = notify_slack.override(
+        task_id="notify_failure", trigger_rule=TriggerRule.ONE_FAILED
+    )("Upstream cleaning failed. Check the logs for more information.")
+
+    create_table >> load >> create_index >> count
+
+    # Make explicit the dependency from total (sum_up_counts task) to show it in the graph
+    updates >> [drop, total] >> notify_success
+
+    drop >> notify_failure
 
 
 catalog_cleaner()

--- a/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
+++ b/catalog/dags/database/catalog_cleaner/catalog_cleaner.py
@@ -1,0 +1,159 @@
+"""
+Catalog Data Cleaner DAG
+
+Use CSV files created during the clean step of the ingestion process to bring the
+changes into the catalog.
+"""
+
+import logging
+from datetime import timedelta
+from pathlib import Path
+
+from airflow.decorators import dag
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID
+from common.sql import PGExecuteQueryOperator, PostgresHook, RETURN_ROW_COUNT
+
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = "catalog_cleaner"
+pg = PostgresHook()
+
+
+def load_temp_tables(columns: list[str]):
+    copy_sql = (
+        "COPY cleaned_image_{column} (identifier, {column}) FROM STDIN "
+        "DELIMITER E'\t' CSV QUOTE '''' "
+    )
+    for column in columns:
+        file_path = str(Path(__file__).parent / f"{column}.tsv")
+        pg.copy_expert(copy_sql.format(column=column), file_path)
+
+
+def count_dirty_rows(columns: list[str]):
+    count_sql = (
+        "SELECT COUNT(identifier) FROM cleaned_image_{} AS tmp "
+        "WHERE tmp.identifier IN (SELECT identifier FROM image)"
+    )
+    for column in columns:
+        count = pg.get_first(count_sql.format(column))[0]
+        logger.info(f"Dirty rows found for ´{column}´: {count}")
+
+
+def update_batches(column: str, total_row_count: int, batch_size: int):
+    pg_ = PostgresHook(log_sql=False)
+    batch_start = updated_count = 0
+    update_sql = """
+        UPDATE image SET {column} = tmp.{column}, updated_on = NOW()
+        FROM cleaned_image_{column} AS tmp
+        WHERE image.identifier = tmp.identifier AND image.identifier IN (
+            SELECT identifier FROM cleaned_image_{column}
+            WHERE row_id > {batch_start} AND row_id <= {batch_end}
+            FOR UPDATE SKIP LOCKED
+        );
+    """
+
+    while batch_start <= total_row_count:
+        batch_end = batch_start + batch_size
+        logger.info(f"Going through rows with id {batch_start:,} to {batch_end:,}.")
+        query = update_sql.format(
+            column=column, batch_start=batch_start, batch_end=batch_end
+        )
+        count = pg_.run(query, handler=RETURN_ROW_COUNT)
+
+        batch_start += batch_size
+        updated_count += count
+        logger.info(f"Updated {updated_count:,} rows of the ´{column}´ column so far.")
+
+
+def update_from_temp_tables(columns: list[str], batch_size):
+    for column in columns:
+        total_row_count = pg.get_first(
+            f"SELECT COUNT(identifier) FROM cleaned_image_{column}"
+        )[0]
+        logger.info(f"Total rows found for ´{column}´: {total_row_count}")
+        update_batches(column, total_row_count, int(batch_size))
+
+
+@dag(
+    dag_id=DAG_ID,
+    default_args={
+        **DAG_DEFAULT_ARGS,
+        "retries": 0,
+        "execution_timeout": timedelta(days=7),
+    },
+    schedule=None,
+    catchup=False,
+    tags=["database"],
+    doc_md=__doc__,
+    params={
+        "batch_size": Param(
+            default=10000,
+            type="integer",
+            description=("The number of records to update per batch."),
+        ),
+    },
+)
+def catalog_cleaner():
+    columns = {
+        "url": 3000,
+        "creator_url": 2000,
+        # "foreign_landing_url": 1000
+    }
+    create_sql = """
+    DROP TABLE IF EXISTS cleaned_image_{column};
+    CREATE UNLOGGED TABLE cleaned_image_{column} (
+        identifier uuid PRIMARY KEY,
+        {column} character varying({length}) NOT NULL,
+        row_id SERIAL
+    );
+    """
+
+    create = PGExecuteQueryOperator(
+        task_id="create_temporary_tables",
+        postgres_conn_id=POSTGRES_CONN_ID,
+        sql="\n".join(
+            [
+                create_sql.format(column=col, length=length)
+                for col, length in columns.items()
+            ]
+        ),
+        execution_timeout=timedelta(minutes=1),
+    )
+
+    load = PythonOperator(
+        task_id="load_temporary_tables",
+        python_callable=load_temp_tables,
+        op_kwargs={"columns": columns.keys()},
+        execution_timeout=timedelta(hours=1),
+    )
+
+    count = PythonOperator(
+        task_id="count_dirty_rows",
+        python_callable=count_dirty_rows,
+        op_kwargs={"columns": columns.keys()},
+        execution_timeout=timedelta(minutes=15),
+    )
+
+    update = PythonOperator(
+        task_id="update_from_temporary_tables",
+        python_callable=update_from_temp_tables,
+        op_kwargs={"columns": columns.keys(), "batch_size": "{{ params.batch_size }}"},
+        execution_timeout=timedelta(hours=1),
+    )
+
+    # drop = PGExecuteQueryOperator(
+    #     task_id="drop_temp_tables",
+    #     postgres_conn_id=POSTGRES_CONN_ID,
+    #     sql="\n".join(f"DROP TABLE cleaned_image_{column};" for column in columns.keys()),
+    #     execution_timeout=timedelta(minutes=1)
+    # )
+
+    create >> load >> count >> update
+    # update >> drop
+
+
+catalog_cleaner()

--- a/catalog/dags/database/catalog_cleaner/constants.py
+++ b/catalog/dags/database/catalog_cleaner/constants.py
@@ -1,11 +1,13 @@
 DAG_ID = "catalog_cleaner"
+SLACK_USERNAME = "Catalog Cleaner DAG"
+SLACK_ICON = ":disk-cleanup:"
 
-CREATE_SQL = """
+CREATE_TEMP_TABLE_SQL = """
 DROP TABLE IF EXISTS {temp_table_name};
 CREATE UNLOGGED TABLE {temp_table_name} (
     row_id SERIAL,
     identifier uuid NOT NULL,
-    {column} TEXT
+    {column} TEXT NOT NULL
 );
 """
 
@@ -16,6 +18,8 @@ SELECT aws_s3.table_import_from_s3(
     '{bucket}', '{s3_path_to_file}', '{aws_region}'
 );
 """
+
+CREATE_INDEX_SQL = "CREATE INDEX ON {temp_table_name}(row_id);"
 
 UPDATE_SQL = """
 UPDATE image SET {column} = tmp.{column}, updated_on = NOW()

--- a/catalog/dags/database/catalog_cleaner/constants.py
+++ b/catalog/dags/database/catalog_cleaner/constants.py
@@ -1,0 +1,16 @@
+CREATE_SQL = """
+DROP TABLE IF EXISTS {temp_table_name};
+CREATE UNLOGGED TABLE {temp_table_name} (
+    row_id SERIAL,
+    identifier uuid NOT NULL,
+    {column} TEXT
+);
+"""
+
+# See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PostgreSQL.S3Import.html#aws_s3.table_import_from_s3
+IMPORT_SQL = """
+SELECT aws_s3.table_import_from_s3(
+    '{temp_table_name}', 'identifier, {column}', 'DELIMITER E''\t'' CSV',
+    '{bucket}', '{s3_path_to_file}', '{aws_region}'
+);
+"""

--- a/catalog/dags/database/catalog_cleaner/constants.py
+++ b/catalog/dags/database/catalog_cleaner/constants.py
@@ -14,3 +14,15 @@ SELECT aws_s3.table_import_from_s3(
     '{bucket}', '{s3_path_to_file}', '{aws_region}'
 );
 """
+
+UPDATE_SQL = """
+UPDATE image SET {column} = tmp.{column}, updated_on = NOW()
+FROM {temp_table_name} AS tmp
+WHERE image.identifier = tmp.identifier AND image.identifier IN (
+    SELECT identifier FROM {temp_table_name}
+    WHERE row_id > {batch_start} AND row_id <= {batch_end}
+    FOR UPDATE SKIP LOCKED
+);
+"""
+
+DROP_SQL = "DROP TABLE {temp_table_name};"

--- a/catalog/dags/database/catalog_cleaner/constants.py
+++ b/catalog/dags/database/catalog_cleaner/constants.py
@@ -1,3 +1,5 @@
+DAG_ID = "catalog_cleaner"
+
 CREATE_SQL = """
 DROP TABLE IF EXISTS {temp_table_name};
 CREATE UNLOGGED TABLE {temp_table_name} (

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -139,6 +139,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`auckland_museum_workflow`](#auckland_museum_workflow)
 1.  [`automated_batched_update`](#batched_update)
 1.  [`batched_update`](#batched_update)
+1.  [`catalog_cleaner`](#catalog_cleaner)
 1.  [`cc_mixter_workflow`](#cc_mixter_workflow)
 1.  [`check_silenced_dags`](#check_silenced_dags)
 1.  [`create_filtered_audio_index`](#create_filtered_media_type_index)
@@ -202,7 +203,7 @@ is constructed from the `license` and `license_version` columns.
 
 This is a maintenance DAG that should be run once.
 
-----
+---
 
 ### `airflow_log_cleanup`
 
@@ -229,7 +230,7 @@ airflow dags trigger --conf
 - maxLogAgeInDays:<INT> - Optional
 - enableDelete:<BOOLEAN> - Optional
 
-----
+---
 
 ### `auckland_museum_workflow`
 
@@ -249,7 +250,7 @@ Resource: <https://api.aucklandmuseum.com/>
 | /search, /id | 10                  | 1000             |
 | /id/media    | 10                  | 1000             |
 
-----
+---
 
 ### `batched_update`
 
@@ -328,7 +329,7 @@ already created: for example, if there was a problem with the `update_query`
 which caused DAG failures during the `update_batches` step. In this case, verify
 that the `BATCH_START` var is set appropriately for your needs.
 
-----
+---
 
 ### `cc_mixter_workflow`
 
@@ -342,7 +343,7 @@ Notes: Documentation: <https://ccmixter.org/query-api> ccMixter sends bad JSON
 and extremely huge headers, both of which need workarounds that are handled by
 this DAG.
 
-----
+---
 
 ### `check_silenced_dags`
 
@@ -369,7 +370,7 @@ issue has been resolved.
 
 The DAG runs weekly.
 
-----
+---
 
 ### `create_filtered_{media_type}_index`
 
@@ -427,7 +428,7 @@ There are two mechanisms that prevent this from happening:
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
-----
+---
 
 ### `create_new_{environment}_es_index`
 
@@ -540,7 +541,7 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `create_new_staging_es_index` DAG fails immediately if any DAGs tagged with
 `staging-es-concurrency` are running.)
 
-----
+---
 
 ### `create_proportional_by_source_staging_index`
 
@@ -575,7 +576,7 @@ interfere with the production `data_refresh` or `create_filtered_index` DAGs.
 However, it will fail immediately if any of the DAGs tagged as part of the
 `staging-es-concurrency` group are running.
 
-----
+---
 
 ### `decode_and_deduplicate_{media_type}_tags`
 
@@ -647,7 +648,7 @@ that records selected for deletion in this DAG are not also being written to by
 a provider DAG, for instance. The simplest way to do this is to ensure that any
 affected provider DAGs are not currently running.
 
-----
+---
 
 ### `europeana_workflow`
 
@@ -659,7 +660,7 @@ Output: TSV file containing the images and the respective meta-data.
 
 Notes: <https://pro.europeana.eu/page/search>
 
-----
+---
 
 ### `finnish_museums_workflow`
 
@@ -675,7 +676,7 @@ provider script is a dated DAG that ingests all records that were last updated
 in the previous day. Because of this, it is not necessary to run a separate
 reingestion DAG, as updated data will be processed during regular ingestion.
 
-----
+---
 
 ### `flickr_audit_sub_provider_workflow`
 
@@ -685,7 +686,7 @@ Check the list of member institutions of the Flickr Commons for institutions
 that have cc-licensed images and are not already configured as sub-providers for
 the Flickr DAG. Report suggestions for new sub-providers to Slack.
 
-----
+---
 
 ### `flickr_workflow`
 
@@ -699,7 +700,7 @@ Notes: <https://www.flickr.com/help/terms/api>
 
 Rate limit: 3600 requests per hour.
 
-----
+---
 
 ### `freesound_workflow`
 
@@ -714,7 +715,7 @@ Notes: <https://freesound.org/docs/api/>
 Rate limit: No limit for our API key. This script can be run either to ingest
 the full dataset or as a dated DAG.
 
-----
+---
 
 ### `inaturalist_workflow`
 
@@ -734,7 +735,7 @@ We use the table structure defined here,
 <https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql>
 except for adding ancestry tags to the taxa table.
 
-----
+---
 
 ### `jamendo_workflow`
 
@@ -749,7 +750,7 @@ non-commercial apps Jamendo Music has more than 500,000 tracks shared by 40,000
 artists from over 150 countries all over the world. Audio quality: uploaded as
 WAV/ FLAC/ AIFF bit depth: 16/24 sample rate: 44.1 or 48 kHz channels: 1/2
 
-----
+---
 
 ### `justtakeitfree_workflow`
 
@@ -762,7 +763,7 @@ Output: TSV file containing the media and the respective meta-data.
 Notes: <https://justtakeitfree.com/api/api.php> This API requires an API key.
 For more details, see <https://github.com/WordPress/openverse/pull/2793>
 
-----
+---
 
 ### `metropolitan_museum_workflow`
 
@@ -788,7 +789,7 @@ avoid of blocking during local development testing.
                         connect with just date and license.
                         <https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07>
 
-----
+---
 
 ### `nappy_workflow`
 
@@ -801,7 +802,7 @@ Output: TSV file containing the image meta-data.
 Notes: This api was written specially for Openverse. There are no known limits
 or restrictions. <https://nappy.co/>
 
-----
+---
 
 ### `oauth2_authorization`
 
@@ -817,7 +818,7 @@ authorization will create an access/refresh token pair in the
 
 - Freesound
 
-----
+---
 
 ### `oauth2_token_refresh`
 
@@ -831,7 +832,7 @@ will update the tokens stored in the Variable upon successful refresh.
 
 - Freesound
 
-----
+---
 
 ### `phylopic_workflow`
 
@@ -843,7 +844,7 @@ Output: TSV file containing the image, their respective meta-data.
 
 Notes: <http://api-docs.phylopic.org/v2/> No rate limit specified.
 
-----
+---
 
 ### `point_{environment}_es_alias`
 
@@ -868,7 +869,7 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `point_staging_alias` DAG fails immediately if any DAGs tagged with
 `staging-es-concurrency` are running.)
 
-----
+---
 
 ### `pr_review_reminders`
 
@@ -898,7 +899,7 @@ Unfortunately the DAG does not know when someone is on vacation. It is up to the
 author of the PR to re-assign review if one of the randomly selected reviewers
 is unavailable for the time period during which the PR should be reviewed.
 
-----
+---
 
 ### `rawpixel_workflow`
 
@@ -914,7 +915,7 @@ issues. The public API max results range is limited to 100,000 results, although
 the API key we've been given can circumvent this limit.
 <https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100>
 
-----
+---
 
 ### `recreate_full_staging_index`
 
@@ -957,7 +958,7 @@ However, as the DAG operates on the staging API database and ES cluster it will
 exit immediately if any of the DAGs tagged as part of the
 `staging_es_concurrency` group are already running.
 
-----
+---
 
 ### `recreate_{media_type}_popularity_calculation`
 
@@ -973,7 +974,7 @@ popularity constants and standardized popularity scores using the new functions.
 These DAGs are not on a schedule, and should only be run manually when new SQL
 code is deployed for the calculation.
 
-----
+---
 
 ### `report_pending_reported_media`
 
@@ -988,7 +989,7 @@ whether further action (such as deindexing the record) needs to be taken. If a
 record has been reported multiple times, it only needs to be reviewed once and
 so is only counted once in the reporting by this DAG.
 
-----
+---
 
 ### `rotate_db_snapshots`
 
@@ -1007,7 +1008,7 @@ Requires two variables:
 `CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
 `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
 
-----
+---
 
 ### `science_museum_workflow`
 
@@ -1021,7 +1022,7 @@ Notes:
 <https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API>
 Rate limited, no specific rate given.
 
-----
+---
 
 ### `smithsonian_workflow`
 
@@ -1033,7 +1034,7 @@ Output: TSV file containing the images and the respective meta-data.
 
 Notes: <https://api.si.edu/openaccess/api/v1.0/search>
 
-----
+---
 
 ### `smk_workflow`
 
@@ -1045,7 +1046,7 @@ Output: TSV file containing the media metadata.
 
 Notes: <https://www.smk.dk/en/article/smk-api/>
 
-----
+---
 
 ### `staging_database_restore`
 
@@ -1071,7 +1072,7 @@ the RDS operations run using a different hook:
 - `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
   above example, it might be `AIRFLOW_CONN_AWS_RDS`)
 
-----
+---
 
 ### `stocksnap_workflow`
 
@@ -1085,7 +1086,7 @@ Notes: <https://stocksnap.io/api/load-photos/date/desc/1>
 <https://stocksnap.io/faq> All images are licensed under CC0. No rate limits or
 authorization required. API is undocumented.
 
-----
+---
 
 ### `wikimedia_commons_workflow`
 
@@ -1206,7 +1207,7 @@ parameter to avoid this issue on subsequent iterations.
 For these requests, we can remove the `globalusage` property from the `prop`
 parameter entirely and eschew the popularity data for these items.
 
-----
+---
 
 ### `wordpress_workflow`
 
@@ -1219,7 +1220,7 @@ Output: TSV file containing the media metadata.
 Notes: <https://wordpress.org/photos/wp-json/wp/v2> Provide photos, media, users
 and more related resources. No rate limit specified.
 
-----
+---
 
 ### `{environment}_elasticsearch_cluster_healthcheck`
 
@@ -1238,7 +1239,7 @@ it is expected, and occurs whenever shards and replicas are being relocated
 assurance, but we could choose to add logic that ignores yellow cluster health
 during data refresh or other similar operations.
 
-----
+---
 
 ### `{environment}_{media_type}_data_refresh`
 
@@ -1283,7 +1284,7 @@ and related PRs:
 - [[Implementation Plan] Ingestion Server Removal](https://docs.openverse.org/projects/proposals/ingestion_server_removal/20240328-implementation_plan_ingestion_server_removal.html)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
 
-----
+---
 
 ### `{media_type}_data_refresh`
 
@@ -1309,7 +1310,7 @@ and related PRs:
 - [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
 
-----
+---
 
 ### `{media_type}_popularity_refresh`
 

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -49,6 +49,7 @@ The following are DAGs grouped by their primary tag:
 | -------------------------------------------------------------------------------------- | ----------------- |
 | [`automated_batched_update`](#batched_update)                                          | `None`            |
 | [`batched_update`](#batched_update)                                                    | `None`            |
+| [`catalog_cleaner`](#catalog_cleaner)                                                  | `None`            |
 | [`decode_and_deduplicate_image_tags`](#decode_and_deduplicate_media_type_tags)         | `None`            |
 | [`delete_records`](#delete_records)                                                    | `None`            |
 | [`recreate_full_staging_index`](#recreate_full_staging_index)                          | `None`            |
@@ -203,7 +204,7 @@ is constructed from the `license` and `license_version` columns.
 
 This is a maintenance DAG that should be run once.
 
----
+----
 
 ### `airflow_log_cleanup`
 
@@ -230,7 +231,7 @@ airflow dags trigger --conf
 - maxLogAgeInDays:<INT> - Optional
 - enableDelete:<BOOLEAN> - Optional
 
----
+----
 
 ### `auckland_museum_workflow`
 
@@ -250,7 +251,7 @@ Resource: <https://api.aucklandmuseum.com/>
 | /search, /id | 10                  | 1000             |
 | /id/media    | 10                  | 1000             |
 
----
+----
 
 ### `batched_update`
 
@@ -329,7 +330,27 @@ already created: for example, if there was a problem with the `update_query`
 which caused DAG failures during the `update_batches` step. In this case, verify
 that the `BATCH_START` var is set appropriately for your needs.
 
----
+----
+
+### `catalog_cleaner`
+
+Catalog Data Cleaner DAG
+
+Use the TSV files created during the cleaning step of the ingestion process to
+bring the changes into the catalog database and make the updates permanent.
+
+The DAG has a structure similar to the batched_update DAG, but with a few key
+differences:
+
+1. Given the structure of the TSV, it updates a single column at a time.
+2. The batch updates are parallelized to speed up the process. The maximum
+   number of active tasks is limited to 3 (at first to try it out and) to avoid
+   overwhelming the database.
+3. It needs slightly different SQL queries to update the data. One change for
+   example, is that it only works with the `image` table given that is the only
+   one where the cleaning steps are applied to in the ingestion server.
+
+----
 
 ### `cc_mixter_workflow`
 
@@ -343,7 +364,7 @@ Notes: Documentation: <https://ccmixter.org/query-api> ccMixter sends bad JSON
 and extremely huge headers, both of which need workarounds that are handled by
 this DAG.
 
----
+----
 
 ### `check_silenced_dags`
 
@@ -370,7 +391,7 @@ issue has been resolved.
 
 The DAG runs weekly.
 
----
+----
 
 ### `create_filtered_{media_type}_index`
 
@@ -428,7 +449,7 @@ There are two mechanisms that prevent this from happening:
 This ensures that neither are depending on or modifying the origin indexes
 critical for the creation of the filtered indexes.
 
----
+----
 
 ### `create_new_{environment}_es_index`
 
@@ -541,7 +562,7 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `create_new_staging_es_index` DAG fails immediately if any DAGs tagged with
 `staging-es-concurrency` are running.)
 
----
+----
 
 ### `create_proportional_by_source_staging_index`
 
@@ -576,7 +597,7 @@ interfere with the production `data_refresh` or `create_filtered_index` DAGs.
 However, it will fail immediately if any of the DAGs tagged as part of the
 `staging-es-concurrency` group are running.
 
----
+----
 
 ### `decode_and_deduplicate_{media_type}_tags`
 
@@ -648,7 +669,7 @@ that records selected for deletion in this DAG are not also being written to by
 a provider DAG, for instance. The simplest way to do this is to ensure that any
 affected provider DAGs are not currently running.
 
----
+----
 
 ### `europeana_workflow`
 
@@ -660,7 +681,7 @@ Output: TSV file containing the images and the respective meta-data.
 
 Notes: <https://pro.europeana.eu/page/search>
 
----
+----
 
 ### `finnish_museums_workflow`
 
@@ -676,7 +697,7 @@ provider script is a dated DAG that ingests all records that were last updated
 in the previous day. Because of this, it is not necessary to run a separate
 reingestion DAG, as updated data will be processed during regular ingestion.
 
----
+----
 
 ### `flickr_audit_sub_provider_workflow`
 
@@ -686,7 +707,7 @@ Check the list of member institutions of the Flickr Commons for institutions
 that have cc-licensed images and are not already configured as sub-providers for
 the Flickr DAG. Report suggestions for new sub-providers to Slack.
 
----
+----
 
 ### `flickr_workflow`
 
@@ -700,7 +721,7 @@ Notes: <https://www.flickr.com/help/terms/api>
 
 Rate limit: 3600 requests per hour.
 
----
+----
 
 ### `freesound_workflow`
 
@@ -715,7 +736,7 @@ Notes: <https://freesound.org/docs/api/>
 Rate limit: No limit for our API key. This script can be run either to ingest
 the full dataset or as a dated DAG.
 
----
+----
 
 ### `inaturalist_workflow`
 
@@ -735,7 +756,7 @@ We use the table structure defined here,
 <https://github.com/inaturalist/inaturalist-open-data/blob/main/Metadata/structure.sql>
 except for adding ancestry tags to the taxa table.
 
----
+----
 
 ### `jamendo_workflow`
 
@@ -750,7 +771,7 @@ non-commercial apps Jamendo Music has more than 500,000 tracks shared by 40,000
 artists from over 150 countries all over the world. Audio quality: uploaded as
 WAV/ FLAC/ AIFF bit depth: 16/24 sample rate: 44.1 or 48 kHz channels: 1/2
 
----
+----
 
 ### `justtakeitfree_workflow`
 
@@ -763,7 +784,7 @@ Output: TSV file containing the media and the respective meta-data.
 Notes: <https://justtakeitfree.com/api/api.php> This API requires an API key.
 For more details, see <https://github.com/WordPress/openverse/pull/2793>
 
----
+----
 
 ### `metropolitan_museum_workflow`
 
@@ -789,7 +810,7 @@ avoid of blocking during local development testing.
                         connect with just date and license.
                         <https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07>
 
----
+----
 
 ### `nappy_workflow`
 
@@ -802,7 +823,7 @@ Output: TSV file containing the image meta-data.
 Notes: This api was written specially for Openverse. There are no known limits
 or restrictions. <https://nappy.co/>
 
----
+----
 
 ### `oauth2_authorization`
 
@@ -818,7 +839,7 @@ authorization will create an access/refresh token pair in the
 
 - Freesound
 
----
+----
 
 ### `oauth2_token_refresh`
 
@@ -832,7 +853,7 @@ will update the tokens stored in the Variable upon successful refresh.
 
 - Freesound
 
----
+----
 
 ### `phylopic_workflow`
 
@@ -844,7 +865,7 @@ Output: TSV file containing the image, their respective meta-data.
 
 Notes: <http://api-docs.phylopic.org/v2/> No rate limit specified.
 
----
+----
 
 ### `point_{environment}_es_alias`
 
@@ -869,7 +890,7 @@ es-concurrency group for the DAG's environment is running. (E.g., the
 `point_staging_alias` DAG fails immediately if any DAGs tagged with
 `staging-es-concurrency` are running.)
 
----
+----
 
 ### `pr_review_reminders`
 
@@ -899,7 +920,7 @@ Unfortunately the DAG does not know when someone is on vacation. It is up to the
 author of the PR to re-assign review if one of the randomly selected reviewers
 is unavailable for the time period during which the PR should be reviewed.
 
----
+----
 
 ### `rawpixel_workflow`
 
@@ -915,7 +936,7 @@ issues. The public API max results range is limited to 100,000 results, although
 the API key we've been given can circumvent this limit.
 <https://www.rawpixel.com/api/v1/search?tags=$publicdomain&page=1&pagesize=100>
 
----
+----
 
 ### `recreate_full_staging_index`
 
@@ -958,7 +979,7 @@ However, as the DAG operates on the staging API database and ES cluster it will
 exit immediately if any of the DAGs tagged as part of the
 `staging_es_concurrency` group are already running.
 
----
+----
 
 ### `recreate_{media_type}_popularity_calculation`
 
@@ -974,7 +995,7 @@ popularity constants and standardized popularity scores using the new functions.
 These DAGs are not on a schedule, and should only be run manually when new SQL
 code is deployed for the calculation.
 
----
+----
 
 ### `report_pending_reported_media`
 
@@ -989,7 +1010,7 @@ whether further action (such as deindexing the record) needs to be taken. If a
 record has been reported multiple times, it only needs to be reviewed once and
 so is only counted once in the reporting by this DAG.
 
----
+----
 
 ### `rotate_db_snapshots`
 
@@ -1008,7 +1029,7 @@ Requires two variables:
 `CATALOG_RDS_DB_IDENTIFIER`: The "DBIdentifier" of the RDS DB instance.
 `CATALOG_RDS_SNAPSHOTS_TO_RETAIN`: How many historical snapshots to retain.
 
----
+----
 
 ### `science_museum_workflow`
 
@@ -1022,7 +1043,7 @@ Notes:
 <https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API>
 Rate limited, no specific rate given.
 
----
+----
 
 ### `smithsonian_workflow`
 
@@ -1034,7 +1055,7 @@ Output: TSV file containing the images and the respective meta-data.
 
 Notes: <https://api.si.edu/openaccess/api/v1.0/search>
 
----
+----
 
 ### `smk_workflow`
 
@@ -1046,7 +1067,7 @@ Output: TSV file containing the media metadata.
 
 Notes: <https://www.smk.dk/en/article/smk-api/>
 
----
+----
 
 ### `staging_database_restore`
 
@@ -1072,7 +1093,7 @@ the RDS operations run using a different hook:
 - `AIRFLOW_CONN_<ID>`: The connection string to use for RDS operations (per the
   above example, it might be `AIRFLOW_CONN_AWS_RDS`)
 
----
+----
 
 ### `stocksnap_workflow`
 
@@ -1086,7 +1107,7 @@ Notes: <https://stocksnap.io/api/load-photos/date/desc/1>
 <https://stocksnap.io/faq> All images are licensed under CC0. No rate limits or
 authorization required. API is undocumented.
 
----
+----
 
 ### `wikimedia_commons_workflow`
 
@@ -1207,7 +1228,7 @@ parameter to avoid this issue on subsequent iterations.
 For these requests, we can remove the `globalusage` property from the `prop`
 parameter entirely and eschew the popularity data for these items.
 
----
+----
 
 ### `wordpress_workflow`
 
@@ -1220,7 +1241,7 @@ Output: TSV file containing the media metadata.
 Notes: <https://wordpress.org/photos/wp-json/wp/v2> Provide photos, media, users
 and more related resources. No rate limit specified.
 
----
+----
 
 ### `{environment}_elasticsearch_cluster_healthcheck`
 
@@ -1239,7 +1260,7 @@ it is expected, and occurs whenever shards and replicas are being relocated
 assurance, but we could choose to add logic that ignores yellow cluster health
 during data refresh or other similar operations.
 
----
+----
 
 ### `{environment}_{media_type}_data_refresh`
 
@@ -1284,7 +1305,7 @@ and related PRs:
 - [[Implementation Plan] Ingestion Server Removal](https://docs.openverse.org/projects/proposals/ingestion_server_removal/20240328-implementation_plan_ingestion_server_removal.html)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
 
----
+----
 
 ### `{media_type}_data_refresh`
 
@@ -1310,7 +1331,7 @@ and related PRs:
 - [[Feature] Data refresh orchestration DAG](https://github.com/WordPress/openverse-catalog/issues/353)
 - [[Feature] Merge popularity calculations and data refresh into a single DAG](https://github.com/WordPress/openverse-catalog/issues/453)
 
----
+----
 
 ### `{media_type}_popularity_refresh`
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #3415 by @krysal 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a DAG similar to the `bactched_update` but is dedicated to using the files from AWS S3 generated from the ingestion server. I created a new DAG since the `batched_update` would need more tweaks than just loading the data from S3 into a table since the update is performed by joining the newly created table with `image`, and also does the batch updates in parallel using the Dynamic Task Mapping feature of Airflow. Given several `batched_update` runs have been performed with the popularity calculations, it suggests it's possible to parallelize this task as long as the rows to be modified do not overlap. The ingestion server also similarly applies the updates.

This is a proof of concept to see the feasibility of parallelizing the DB updates, making a separate DAG we don't interfere with those that depend on the `batched_update` DAG, and if it's successful (which I don't see why it wouldn't be) we can discuss how to generalize it, whether if modiying the `batched_update` of creating another to use with temporary tables from S3 files.

## Testing Instructions

You will need to have some "dirty" rows in the catalog and their corresponding TSV files containing the correct data to fix them. 

1. To create a TSV, spin up the catalog stack, `./ov just catalog/up`, and if you have `psql` locally try this:
```sh
PGPASSWORD=deploy psql -h localhost -p 50255 openledger deploy -c "COPY (SELECT identifier, url FROM image ORDER BY created_on DESC LIMIT 15) TO STDOUT WITH DELIMITER E'\t' CSV;" >> url.tsv
```
You should then have a file of `<identifier>	<url>` without quotes or a header like the following:
```
3074629a-9934-464b-aca6-b517f4b7cf80	https://pd.w.org/2024/06/8616676f5d15f44f7.79186143-2048x1366.jpg
e3637802-7ff5-4972-b1b4-554e97d921f1	https://pd.w.org/2024/06/85667a9763e32215.10445933-1152x2048.jpg
aec4bdef-6315-4a5d-a997-727891d2f00a	https://pd.w.org/2024/06/121666b021b681b06.28758133-1536x2048.jpg
...
```

2. Then modify the URLs for the same rows. You can use a query like the following to remove the protocol:
```sql
UPDATE image SET url = ltrim(url, 'https://') WHERE identifier IN (
	SELECT identifier FROM image ORDER BY created_on DESC LIMIT 15
);
```
3. Upload your new file to MinIO: http://localhost:5011/. Save the path to the bucket as you'll need it as a setting later.

4. Go to the Airflow U, unpause the `catalog_cleaner` DAG, and trigger it with a configuration that fits your test case. E.g.:
```json
{
    "batch_size": 3,
    "column": "url",
    "s3_bucket": "openverse-catalog",
    "s3_path": "shared/data-refresh-cleaned-data/url_test.tsv"
}
```

5. Verify the changes were applied in the DB to the rows.
```sh
./ov just catalog/pgcli
```

```sql
SELECT identifier, url FROM image ORDER BY created_on DESC LIMIT 15;
```

Try different configurations for `batch_size` and/or the `CLEANER_MAX_CONCURRENT_DB_UPDATE_TASKS` Airflow variable to see how it works. You can add `time.sleep(seconds)`  before returning in the `update_batch` function to better appreciate the concurrency.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`./ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`./ov just catalog/generate-docs media-props` for the catalog or `./ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
