### PR TITLE
Use a separate logger for dead links check that Sentry will ignore

### DIFF
--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -17,7 +17,7 @@ from api.utils.dead_link_mask import get_query_mask, save_query_mask
 
 
 logger = structlog.get_logger(__name__)
-
+head_logger = structlog.get_logger(f"{__name__}._head")
 
 CACHE_PREFIX = "valid:"
 HEADERS = {
@@ -57,7 +57,7 @@ async def _head(
         status = response.status
     except (aiohttp.ClientError, asyncio.TimeoutError) as exception:
         if not isinstance(exception, asyncio.TimeoutError):
-            logger.error("dead_link_validation_error", e=exception)
+            head_logger.error("dead_link_validation_error", e=exception)
             status = _ERROR_STATUS
         else:
             status = _TIMEOUT_STATUS

--- a/api/conf/settings/sentry.py
+++ b/api/conf/settings/sentry.py
@@ -30,3 +30,6 @@ if not DEBUG and SENTRY_DSN:
     # code, which can be registered by Sentry and obscure the underlying reason
     # why 5xx response was returned in the first place.
     ignore_logger("django_structlog.middlewares.request")
+    # These errors can occur in large volumes and so we don't want them to fill
+    # up in Sentry and overwhelm us with Slack notifications.
+    ignore_logger("api.utils.check_dead_links._head")


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR changes the logger used inside the `_head` function in `check_dead_links` to a new one that will be ignored in Sentry.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
