### PR TITLE
Remove env from Airflow alerts, improve ES alert username & icon

### DIFF
--- a/catalog/dags/common/slack.py
+++ b/catalog/dags/common/slack.py
@@ -336,9 +336,8 @@ def send_message(
     ):
         return
 
-    environment = Variable.get("ENVIRONMENT", default_var="local")
     s = SlackMessage(
-        f"{username} | {environment}",
+        username,
         icon_emoji,
         unfurl_links,
         unfurl_media,

--- a/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
+++ b/catalog/dags/elasticsearch_cluster/healthcheck_dag.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 
 
 _DAG_ID = "{env}_elasticsearch_cluster_healthcheck"
+ES_ICON = ":elasticsearch_bad:"
+ES_USERNAME = "{env} ES Cluster (via Airflow)"
 
 EXPECTED_NODE_COUNT = 6
 EXPECTED_DATA_NODE_COUNT = 3
@@ -142,10 +144,16 @@ def compose_notification(
 def notify(env: str, message_type_and_string: tuple[MessageType, str]):
     message_type, message = message_type_and_string
 
+    message_kwargs = {
+        "dag_id": _DAG_ID.format(env=env),
+        "username": ES_USERNAME.format(env=env.title()),
+        "icon_emoji": ES_ICON,
+    }
+
     if message_type == "alert":
-        send_alert(dedent(message), dag_id=_DAG_ID.format(env=env))
+        send_alert(dedent(message), **message_kwargs)
     elif message_type == "notification":
-        send_message(dedent(message), dag_id=_DAG_ID.format(env=env))
+        send_message(dedent(message), **message_kwargs)
     else:
         raise ValueError(
             f"Invalid message_type. Expected 'alert' or 'notification', "

--- a/catalog/tests/dags/common/test_slack.py
+++ b/catalog/tests/dags/common/test_slack.py
@@ -503,23 +503,6 @@ def test_should_silence_message(silenced_notifications, should_silence):
         )
 
 
-@pytest.mark.parametrize("environment", ["local", "production"])
-def test_send_message(environment, http_hook_mock):
-    with mock.patch("common.slack.should_send_message", return_value=True), mock.patch(
-        "common.slack.Variable"
-    ) as MockVariable:
-        MockVariable.get.side_effect = [environment]
-        send_message("Sample text", dag_id="test_workflow", username="DifferentUser")
-        http_hook_mock.run.assert_called_with(
-            endpoint=None,
-            data=f'{{"username": "DifferentUser | {environment}", "unfurl_links": false, "unfurl_media": false,'
-            ' "icon_emoji": ":airflow:", "blocks": [{"type": "section", "text": '
-            '{"type": "mrkdwn", "text": "Sample text"}}], "text": "Sample text"}',
-            headers={"Content-type": "application/json"},
-            extra_options={"verify": True},
-        )
-
-
 def test_send_message_does_not_send_if_checks_fail(http_hook_mock):
     with mock.patch("common.slack.should_send_message", return_value=False):
         send_message("Sample text", dag_id="test_workflow", username="DifferentUser")


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4613 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adjusts the default messaging pattern in Airflow to remove the environment from the username (see the linked issue for rationale).

It also changes the username and icon for Elasticsearch healthcheck related alerts to make the cluster in question more prominent, and the alert itself distinct from other Airflow alerts. Here's a screenshot of the new alert:

![image](https://github.com/user-attachments/assets/ed1c05f0-fda2-47d2-a406-8e8dcd0d5ec7)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Start the catalog and ingestion server stacks with `ov c` and `ov i`
2. Force Slack messages by adding a variable called `SLACK_MESSAGE_OVERRIDE` with the value `true`
3. Kick off either `staging_elasticsearch_cluster_healthcheck` or `production_elasticsearch_cluster_healthcheck`
4. Observe a similar message in Slack

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
