### PR TITLE
Fix HTML creator crediting incorrect image tags

### DIFF
--- a/frontend/src/utils/attribution-html.ts
+++ b/frontend/src/utils/attribution-html.ts
@@ -46,9 +46,31 @@ const h = (
   attrs: Record<string, string>,
   children: string[] | null = null
 ): string => {
+  const selfClosingTags = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+  ]
+
   const map = Object.entries(attrs)
     .map(([key, value]) => `${key}="${value}"`)
     .join(" ")
+
+  if (selfClosingTags.includes(name)) {
+    return map ? `<${name} ${map} />` : `<${name} />`
+  }
+
   const opening = map ? `<${name} ${map}>` : `<${name}>`
   const closing = `</${name}>`
   return `${opening}${(children ?? []).join("\n")}${closing}`


### PR DESCRIPTION
Fixes the incorrect HTML for `<img>` tags in our "Credit the Creator" section HTML. Previously, image tags were rendered as `<img></img>` which is invalid HTML. 

Now, `<img>` and other self-closing HTML tags will be rendered as `<img />` (note the closing "/" at the end of the tag) which is valid. 