### PR TITLE
Remove the single-result endpoints from the robots.txt

### DIFF
--- a/frontend/src/server-middleware/robots.js
+++ b/frontend/src/server-middleware/robots.js
@@ -33,14 +33,10 @@ Crawl-delay: 10
 Disallow: /search/audio/
 Disallow: /search/image/
 Disallow: /search/
-Disallow: /image/
-Disallow: /audio/
 # Disallow the same for all translated routes
 Disallow: /*/search/audio/
 Disallow: /*/search/image/
 Disallow: /*/search/
-Disallow: /*/image/
-Disallow: /*/audio/
 
 ${aiDisallowRules}
       `

--- a/frontend/src/utils/og.ts
+++ b/frontend/src/utils/og.ts
@@ -19,7 +19,7 @@ export const createDetailPageMeta = ({
     {
       hid: "robots",
       name: "robots",
-      content: "noindex",
+      content: "all",
     },
   ] as (MetaPropertyName | MetaPropertyProperty)[]
   if (title) {

--- a/frontend/test/playwright/e2e/seo.spec.ts
+++ b/frontend/test/playwright/e2e/seo.spec.ts
@@ -42,7 +42,7 @@ const pages = {
       "/v1/images/da5cb478-c093-4d62-b721-cda18797e3fb/thumb/"
     ),
     ogTitle: "bird",
-    robots: "noindex",
+    robots: "all",
   },
   audioDetail: {
     url: "/audio/7e063ee6-343f-48e4-a4a5-f436393730f6",
@@ -51,7 +51,7 @@ const pages = {
       "/v1/audio/7e063ee6-343f-48e4-a4a5-f436393730f6/thumb/"
     ),
     ogTitle: "I Love My Dog You Love your Cat",
-    robots: "noindex",
+    robots: "all",
   },
   about: {
     url: "/about",


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4602 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR removes the `/image/` and `/audio/` (and translated versions of both) from the robots.txt to attempt to restore OpenGraph tag-based media unfurling for result links. This was added to attempt to prevent scraping, but we've seen that certain scrapers have proceeded to ignore the robots.txt restrictions anyway. So moving forward, we'll plan on blocking _specific_ crawlers using our network infrastructure rather than attempting to block everything from viewing single results.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Run `ov env DEPLOYMENT_ENV=production just frontend/run dev:only` (environment variable is needed to render the robots.txt)
2. Visit http://localhost:8443/robots.txt and see that the image/audio endpoints are no longer present


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
