### PR TITLE
Fix update query and increase simultaneous tasks of the `add_license_url` DAG

### DIFF
--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -136,7 +136,7 @@ def get_license_conf(license_info) -> dict:
             f"AND meta_data->>'license_url' IS NULL"
         ),
         # Merge existing metadata with the new license_url
-        "update_query": f"SET meta_data = ({Json(license_url_dict)}::jsonb || meta_data), updated_on = now()",
+        "update_query": f"SET updated_on = NOW(), meta_data = ({Json(license_url_dict)}::jsonb || meta_data)",
         "update_timeout": 259200,  # 3 days in seconds
         "dry_run": False,
         "resume_update": False,
@@ -194,7 +194,7 @@ def add_license_url():
         trigger_dag_id=BATCHED_UPDATE_DAG_ID,
         wait_for_completion=True,
         execution_timeout=timedelta(hours=5),
-        max_active_tis_per_dag=1,
+        max_active_tis_per_dag=3,
         map_index_template="""{{ task.conf['query_id'] }}""",
         retries=0,
     ).expand(conf=get_confs(licenses, batch_size="{{ params.batch_size }}"))


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes

Related to #4318.

Since #4460, the `batched_update` DAG requires a strict query update pattern prefixing changes with the update of the `updated_on` timestamp, so despite having been previously included, the `add_license_url` DAG fails due to the order in instructions passed to the `batched_update` DAG.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes this and also takes the opportunity to increase concurrent tasks.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Try to run the DAG in the `main` branch and observe it fails
2. For the happy path, follow the instructions on #4124.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
