### PR TITLE
Replace retry with backoff, add backoff to all Freesound requests

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/catalog/dags/providers/provider_api_scripts/freesound.py
@@ -17,9 +17,9 @@ import functools
 import logging
 from datetime import datetime
 
+import backoff
 from airflow.models import Variable
 from requests.exceptions import ConnectionError, HTTPError, SSLError
-from retry import retry
 
 from common.licenses.licenses import get_license_info
 from common.loader import provider_details as prov
@@ -157,7 +157,7 @@ class FreesoundDataIngester(ProviderDataIngester):
         else:
             return None, None, None
 
-    @retry(flaky_exceptions, tries=3, delay=1, backoff=2)
+    @backoff.on_exception(backoff.expo, flaky_exceptions, max_tries=3)
     def _get_audio_file_size(self, url):
         """
         Get the content length of a provided URL.

--- a/catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -10,9 +10,9 @@ Notes:              <https://api.si.edu/openaccess/api/v1.0/search>
 
 import logging
 
+import backoff
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
-from retry import retry
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
@@ -172,7 +172,7 @@ class SmithsonianDataIngester(ProviderDataIngester):
             images += self._get_associated_images(image_list, shared_image_data)
         return images
 
-    @retry(ValueError, tries=3, delay=1, backoff=2)
+    @backoff.on_exception(backoff.expo, ValueError, max_tries=3)
     def _get_unit_codes_from_api(self) -> set:
         query_params = {"api_key": self.api_key, "q": "online_media_type:Images"}
         response_json = self.get_response_json(

--- a/catalog/requirements-prod.txt
+++ b/catalog/requirements-prod.txt
@@ -3,10 +3,10 @@
 # Note: Unpinned packages have their versions determined by the Airflow constraints file
 
 apache-airflow[amazon,postgres,http,elasticsearch]==2.9.3
+backoff==2.2.1
 lxml
 psycopg2-binary
 requests-file
 requests-oauthlib
-retry==0.9.2
 tabulate==0.9.0
 tldextract==5.1.2


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4594 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

> [!WARNING]
> This **should not** be merged until a deployment can be made immediately after, since it introduces new dependencies.

This PR makes two major changes:
- Replaces the `retry` with `backoff`
- Adds an exponential backoff to all requests made to Freesound during ingestion

The latter change is relatively straightforward: we encounter tons of exceptions during the Freesound ingestion process that seem to be transient and ultimately get resolved when checked later. However this causes significant disruptions in the execution of the DAG itself, since it often requires that maintainers restart the DAG with `SKIP_INGESTION_ERRORS` enabled for it. This change allows requests to be retried with an exponential backoff up to a max time (2 minutes for now) if they match the HTTP codes 400 or 503. On all other codes, the exception is raised and retries (outside of the normal ones for the `DelayedRequester`) are not attempted.

The former change is motivated by the above. [`retry`](https://pypi.org/project/retry/) is a Python library that hasn't been updated since 2016, and only supports fairly basic retry conditions. [`backoff`](https://pypi.org/project/backoff/) on the other hand has been updated as recently as 2022 and supports much more complexity in retry conditions. With the above case, we only wanted to retry on `HTTPErrors` with a specific return code; that was not possible with `retry` but is now possible with `backoff`. This should give us some additional flexibility moving forward too!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I added new tests specifically for the conditions mentioned above. You can also run the `freesound_workflow` DAG locally to ensure everything behaves normally (and maybe encounter one of the above cases if you're lucky!).


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
