### PR TITLE
Preemptively filter out Rekognition tags

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -57,7 +57,7 @@ TAG_CONTAINS_DENYLIST = {
 TAG_MIN_CONFIDENCE = 0.90
 # Filter out tags that match the following providers (either because they haven't
 # been vetted or because they are known to be low-quality).
-TAG_SKIP_PROVIDERS = {"rekognition"}
+FILTERED_TAG_PROVIDERS = {"rekognition"}
 
 # We know that flickr and wikimedia support TLS, so we can add them here
 TLS_CACHE = {
@@ -139,7 +139,7 @@ class CleanupFunctions:
             alt_filtered = False
             if "accuracy" in tag and float(tag["accuracy"]) < TAG_MIN_CONFIDENCE:
                 alt_filtered = True
-            if "provider" in tag and tag["provider"] in TAG_SKIP_PROVIDERS:
+            if "provider" in tag and tag["provider"] in FILTERED_TAG_PROVIDERS:
                 alt_filtered = True
             if "name" in tag and isinstance(tag["name"], str):
                 lower_tag = tag["name"].lower()

--- a/ingestion_server/test/unit_tests/test_cleanup.py
+++ b/ingestion_server/test/unit_tests/test_cleanup.py
@@ -1,13 +1,13 @@
 import pook
 from psycopg2._json import Json
 
-from ingestion_server.cleanup import CleanupFunctions
+from ingestion_server.cleanup import TAG_SKIP_PROVIDERS, CleanupFunctions
 from test.unit_tests.conftest import create_mock_image
 
 
 class TestCleanup:
     @staticmethod
-    def test_tag_blacklist():
+    def test_tag_denylisted():
         tags = [
             {"name": "cc0"},
             {"name": " cc0"},
@@ -38,6 +38,19 @@ class TestCleanup:
         ]
         result = str(CleanupFunctions.cleanup_tags(tags))
         expected = str(Json([{"name": "accurate", "accuracy": 0.999}]))
+        assert result == expected
+
+    @staticmethod
+    def test_provider_filter():
+        tags = [
+            {"name": "valid", "provider": "provider1"},
+            *[
+                {"name": "invalid", "provider": provider}
+                for provider in TAG_SKIP_PROVIDERS
+            ],
+        ]
+        result = str(CleanupFunctions.cleanup_tags(tags))
+        expected = str(Json([{"name": "valid", "provider": "provider1"}]))
         assert result == expected
 
     @staticmethod

--- a/ingestion_server/test/unit_tests/test_cleanup.py
+++ b/ingestion_server/test/unit_tests/test_cleanup.py
@@ -1,7 +1,7 @@
 import pook
 from psycopg2._json import Json
 
-from ingestion_server.cleanup import TAG_SKIP_PROVIDERS, CleanupFunctions
+from ingestion_server.cleanup import FILTERED_TAG_PROVIDERS, CleanupFunctions
 from test.unit_tests.conftest import create_mock_image
 
 
@@ -46,7 +46,7 @@ class TestCleanup:
             {"name": "valid", "provider": "provider1"},
             *[
                 {"name": "invalid", "provider": provider}
-                for provider in TAG_SKIP_PROVIDERS
+                for provider in FILTERED_TAG_PROVIDERS
             ],
         ]
         result = str(CleanupFunctions.cleanup_tags(tags))


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4644 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds an additional layer of filtering during the "tags cleanup" step of the (current) ingestion server which filters out tags that correspond to a specific provider. For the time being, only `rekognition` tags are filtered.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

I have been having some trouble getting `ov` to run these commands, but it might just be my desktop.

Running `just ingestion_server/test-local` should run the tests, which all should pass!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
