### PR TITLE
Init dark mode with feature flag and body class

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -30,6 +30,15 @@
       "description": "Show results marked as sensitive in the results area.",
       "supportsQuery": false,
       "storage": "session"
+    },
+    "force_dark_mode": {
+      "status": {
+        "staging": "switchable",
+        "production": "disabled"
+      },
+      "defaultState": "off",
+      "description": "Force the site to render in dark mode.",
+      "storage": "session"
     }
   },
   "groups": [

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -32,12 +32,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, useLocaleHead } from "#imports"
+import { computed, onMounted, useLocaleHead, useHead } from "#imports"
 
 import { useUiStore } from "~/stores/ui"
 import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 import { useLayout } from "~/composables/use-layout"
+import { useDarkMode } from "~/composables/use-dark-mode"
 
 import VSkipToContentButton from "~/components/VSkipToContentButton.vue"
 
@@ -45,6 +46,8 @@ const { updateBreakpoint } = useLayout()
 
 const featureFlagStore = useFeatureFlagStore()
 const uiStore = useUiStore()
+
+const darkMode = useDarkMode()
 
 /* UI store */
 const isDesktopLayout = computed(() => uiStore.isDesktopLayout)
@@ -54,6 +57,10 @@ const head = useLocaleHead({
   addDirAttribute: true,
   identifierAttribute: "id",
   addSeoAttributes: true,
+})
+
+useHead({
+  bodyAttrs: { class: darkMode.cssClass },
 })
 
 /**

--- a/frontend/src/composables/use-dark-mode.ts
+++ b/frontend/src/composables/use-dark-mode.ts
@@ -1,0 +1,26 @@
+import { computed } from "#imports"
+
+import { useFeatureFlagStore } from "~/stores/feature-flag"
+
+export const DARK_MODE_CLASS = "dark-mode"
+export const LIGHT_MODE_CLASS = "light-mode"
+
+/**
+ * TODO: Replace with the user's actual dark mode preference.
+ * Dark mode detection will be based on user preference,
+ * overwritten by the "force_dark_mode" feature flag.
+ */
+export function useDarkMode() {
+  const featureFlagStore = useFeatureFlagStore()
+
+  const isDarkMode = computed(() => featureFlagStore.isOn("force_dark_mode"))
+  const cssClass = computed(() =>
+    isDarkMode.value ? DARK_MODE_CLASS : LIGHT_MODE_CLASS
+  )
+
+  return {
+    isDarkMode,
+    /** The CSS class representing the current color mode. */
+    cssClass,
+  }
+}

--- a/frontend/test/unit/specs/composables/use-dark-mode.spec.ts
+++ b/frontend/test/unit/specs/composables/use-dark-mode.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  DARK_MODE_CLASS,
+  LIGHT_MODE_CLASS,
+  useDarkMode,
+} from "~/composables/use-dark-mode"
+import { OFF, ON } from "~/constants/feature-flag"
+import { useFeatureFlagStore } from "~/stores/feature-flag"
+
+describe("useDarkMode", () => {
+  it(`should report isDarkMode as true and cssClass as ${DARK_MODE_CLASS} when the feature flag is enabled`, () => {
+    const featureFlagStore = useFeatureFlagStore()
+    featureFlagStore.toggleFeature("force_dark_mode", ON)
+
+    // Call the composable
+    const { isDarkMode, cssClass } = useDarkMode()
+
+    // Assert the computed properties
+    expect(isDarkMode.value).toBe(true)
+    expect(cssClass.value).toBe(DARK_MODE_CLASS)
+  })
+
+  it(`should report isDarkMode as false and cssClass as ${LIGHT_MODE_CLASS} when the feature flag is disabled`, () => {
+    const featureFlagStore = useFeatureFlagStore()
+    featureFlagStore.toggleFeature("force_dark_mode", OFF)
+
+    // Call the composable
+    const { isDarkMode, cssClass } = useDarkMode()
+
+    // Assert the computed properties
+    expect(isDarkMode.value).toBe(false)
+    expect(cssClass.value).toBe(LIGHT_MODE_CLASS)
+  })
+})


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4303 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a `FORCE_DARK_MODE` feature flag.

It also adds a new `useDarkMode` composable which provides the current state of dark mode and some related metadata, currently the css class which should be applied to the body. This composable is read in the setup script of `src/app.vue` and passed to the Nuxt built-in "useHead" composable to set a reactive body class whenever the dark mode state changes.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. `j f` in the repository root to run the frontend dev server.
2. Visit localhost:8443/preferences
3. Inspect the page with developer tools and observe that the body element has a `.light-mode` class. Enable the `FORCE_DARK_MODE` feature flag and observe that this reactively changes to `.dark-mode.
4. Review the code for quality and sufficient test coverage.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
