### PR TITLE
Decrease thumbnail upstream timeout and add timing logs for thumbnail requests

### DIFF
--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -52,7 +52,11 @@ async def _head(
 
     try:
         response = await session.head(
-            url, allow_redirects=False, headers=HEADERS, timeout=_timeout
+            url,
+            allow_redirects=False,
+            headers=HEADERS,
+            timeout=_timeout,
+            raise_for_status=True,
         )
         status = response.status
     except (aiohttp.ClientError, asyncio.TimeoutError) as exception:

--- a/api/api/utils/check_dead_links/__init__.py
+++ b/api/api/utils/check_dead_links/__init__.py
@@ -17,7 +17,6 @@ from api.utils.dead_link_mask import get_query_mask, save_query_mask
 
 
 logger = structlog.get_logger(__name__)
-head_logger = structlog.get_logger(f"{__name__}._head")
 
 CACHE_PREFIX = "valid:"
 HEADERS = {
@@ -41,15 +40,13 @@ def _get_expiry(status, default):
 
 
 _timeout = aiohttp.ClientTimeout(total=settings.LINK_VALIDATION_TIMEOUT_SECONDS)
-_TIMEOUT_STATUS = -2
+
 _ERROR_STATUS = -1
 
 
 async def _head(
     url: str, session: aiohttp.ClientSession, provider: str
 ) -> tuple[str, int]:
-    start_time = time.perf_counter()
-
     try:
         response = await session.head(
             url,
@@ -57,23 +54,17 @@ async def _head(
             headers=HEADERS,
             timeout=_timeout,
             raise_for_status=True,
+            trace_request_ctx={
+                "timing_event_name": "dead_link_validation_timing",
+                "timing_event_ctx": {
+                    "provider": provider,
+                },
+            },
         )
         status = response.status
     except (aiohttp.ClientError, asyncio.TimeoutError) as exception:
-        if not isinstance(exception, asyncio.TimeoutError):
-            head_logger.error("dead_link_validation_error", e=exception)
-            status = _ERROR_STATUS
-        else:
-            status = _TIMEOUT_STATUS
-
-    end_time = time.perf_counter()
-    logger.info(
-        "dead_link_validation_timing",
-        url=url,
-        status=status,
-        time=end_time - start_time,
-        provider=provider,
-    )
+        logger.error("dead_link_validation_error", e=exception)
+        status = _ERROR_STATUS
 
     return url, status
 
@@ -144,7 +135,7 @@ def check_dead_links(query_hash: str, start_slice: int, results: list[Hit]) -> N
     for key, status in to_cache.items():
         if status == 200:
             logger.debug(f"healthy link key={key}")
-        elif status == _TIMEOUT_STATUS or status == _ERROR_STATUS:
+        elif status == _ERROR_STATUS:
             logger.debug(f"no response from provider key={key}")
         else:
             logger.debug(f"broken link key={key}")

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -200,7 +200,7 @@ def _cache_repeated_failures(_get):
     return do_cache
 
 
-_UPSTREAM_TIMEOUT = aiohttp.ClientTimeout(15)
+_UPSTREAM_TIMEOUT = aiohttp.ClientTimeout(settings.THUMBNAIL_UPSTREAM_TIMEOUT)
 
 
 @_cache_repeated_failures

--- a/api/api/utils/image_proxy/__init__.py
+++ b/api/api/utils/image_proxy/__init__.py
@@ -90,7 +90,7 @@ def _tally_response(
     response: aiohttp.ClientResponse,
 ):
     """
-    Tally image proxy response without waiting for Redis to respond.
+    Tally image proxy response.
 
     Pulled into a separate function to help reduce overload when skimming
     the `get` function, which is complex enough as is.

--- a/api/api/utils/image_proxy/dataclasses.py
+++ b/api/api/utils/image_proxy/dataclasses.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass
+class MediaInfo:
+    media_provider: str
+    media_identifier: UUID
+    image_url: str
+
+
+@dataclass
+class RequestConfig:
+    accept_header: str = "image/*"
+    is_full_size: bool = False
+    is_compressed: bool = True

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -2,6 +2,8 @@ import mimetypes
 from os.path import splitext
 from urllib.parse import urlparse
 
+from django.conf import settings
+
 import aiohttp
 import django_redis
 import sentry_sdk
@@ -10,18 +12,21 @@ from asgiref.sync import sync_to_async
 from redis.exceptions import ConnectionError
 
 from api.utils.aiohttp import get_aiohttp_session
+from api.utils.image_proxy.dataclasses import MediaInfo
 from api.utils.image_proxy.exception import UpstreamThumbnailException
 
 
 logger = structlog.get_logger(__name__)
 
 
-_HEAD_TIMEOUT = aiohttp.ClientTimeout(10)
+_HEAD_TIMEOUT = aiohttp.ClientTimeout(settings.THUMBNAIL_EXTENSION_REQUEST_TIMEOUT)
 
 
-async def get_image_extension(image_url: str, media_identifier) -> str | None:
+async def get_image_extension(media_info: MediaInfo) -> str | None:
+    image_url = media_info.image_url
+
     cache = django_redis.get_redis_connection("default")
-    key = f"media:{media_identifier}:thumb_type"
+    key = f"media:{media_info.media_identifier}:thumb_type"
 
     ext = _get_file_extension_from_url(image_url)
 
@@ -37,8 +42,16 @@ async def get_image_extension(image_url: str, media_identifier) -> str | None:
         # If the extension is still not present, try getting it from the content type
         try:
             session = await get_aiohttp_session()
-            response = await session.head(image_url, timeout=_HEAD_TIMEOUT)
-            response.raise_for_status()
+            response = await session.head(
+                image_url,
+                raise_for_status=True,
+                timeout=_HEAD_TIMEOUT,
+                trace_request_ctx={
+                    "timing_event_name": "thumbnail_extension_request_timing",
+                    "timing_event_ctx": {"provider": media_info.media_provider},
+                },
+            )
+
             if response.headers and "Content-Type" in response.headers:
                 content_type = response.headers["Content-Type"]
                 ext = _get_file_extension_from_content_type(content_type)

--- a/api/compose.yml
+++ b/api/compose.yml
@@ -53,3 +53,12 @@ services:
       DJANGO_NGINX_UPSTREAM_URL: web:50280
     depends_on:
       - web
+
+  httpbin:
+    profiles:
+      - api
+    # Use go-httpbin because it's only 15 MB compared to upstream HTTPBin's 204 MB
+    # That helps reduce the network burden of spinning up a development environment
+    image: docker.io/mccutchen/go-httpbin:v2.14.0
+    expose:
+      - "8080"

--- a/api/compose.yml
+++ b/api/compose.yml
@@ -54,6 +54,7 @@ services:
     depends_on:
       - web
 
+  # Used in API unit tests
   httpbin:
     profiles:
       - api

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -32,3 +32,8 @@ THUMBNAIL_FAILURE_CACHE_TOLERANCE = config(
 
 # Timeout when requesting the thumbnail from the upstream image proxy
 THUMBNAIL_UPSTREAM_TIMEOUT = config("THUMBNAIL_UPSTREAM_TIMEOUT", default=4, cast=int)
+
+# Timeout when trying to determine the filetype based on a HEAD request to the upstream image provider
+THUMBNAIL_EXTENSION_REQUEST_TIMEOUT = config(
+    "THUMBNAIL_EXTENSION_REQUEST_TIMEOUT", default=4, cast=int
+)

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -29,3 +29,6 @@ THUMBNAIL_FAILURE_CACHE_WINDOW_SECONDS = config(
 THUMBNAIL_FAILURE_CACHE_TOLERANCE = config(
     "THUMBNAIL_FAILURE_CACHE_TOLERANCE", default=2, cast=int
 )
+
+# Timeout when requesting the thumbnail from the upstream image proxy
+THUMBNAIL_UPSTREAM_TIMEOUT = config("THUMBNAIL_UPSTREAM_TIMEOUT", default=4, cast=int)

--- a/api/test/unit/utils/test_aiohttp.py
+++ b/api/test/unit/utils/test_aiohttp.py
@@ -1,3 +1,5 @@
+from structlog.testing import capture_logs
+
 from api.utils.aiohttp import get_aiohttp_session
 
 
@@ -31,3 +33,83 @@ def test_multiple_loops_reuse_separate_sessions(get_new_loop):
 
     assert loop_1_session_1 is loop_1_session_2
     assert loop_2_session_1 is loop_2_session_2
+
+
+def test_log_timing_trace_config_ignored_if_event_name_undefined(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get("http://localhost:50280/v1/images/")
+        )
+
+    assert len(logs) == 0
+
+
+_EXPECTED_BASE_CTX = {"url", "status", "time"}
+
+
+def test_log_timing_trace_config_no_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "no_request_ctx_timing_event_test"
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://localhost:50280/v1/images/",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+
+
+def test_log_timing_trace_config_empty_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "empty_request_ctx_timing_event_test"
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://localhost:50280/v1/images/",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                    "timing_event_ctx": {},
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+
+
+def test_log_timing_trace_config_with_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "empty_request_ctx_timing_event_test"
+    event_ctx = {
+        "amazing_info": "hello_test",
+        "helpful_info": "so cool",
+    }
+
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://localhost:50280/v1/images/",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                    "timing_event_ctx": event_ctx,
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+
+    log_event_items = log_event.items()
+    for event_ctx_item in event_ctx.items():
+        assert event_ctx_item in log_event_items


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4570 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR decreases the thumbnail upstream request timeout as discussed in the linked issue. It also decreases the timeout for the HEAD request for the extension to the same default value. Finally, it adds timing logs for both these requests so we can further evaluate appropriate timeouts for each. For example, hopefully we can decrease the HEAD request timeout significantly (like 0.5 seconds at least). But, because the analysis in the linked issue was done with timings of the entire thumbnail request, it's not possible to know which part of the request actually takes 4 seconds. Therefore, the total timeout of outbound requests is now 8 seconds, which is still way lower than the 25 total seconds and still a good improvement in line with the goals of the issue.

To facilitate request timing in any circumstance we might want it, I've created an [aiohttp `TraceConfig` to log timing with context variables we've used so far](https://docs.aiohttp.org/en/stable/client_advanced.html#client-tracing). This only affects requests that configure themselves to activate the timing logs, as verified in the unit tests for the new trace config. This generalises the functionality added in #4508 for dead link checks, and therefore is able to replace that original implementation. As such, you'll see the code to manually time those requests is gone now, replaced by the trace config version. Because of that, I've also removed the separate timeout status we were caching before. This is safe for existing data because we check for specific _live_ status codes when using the cached data, and never actually referred to the difference between the timeout and general error statuses returned from `_head` except when inserting them into the cache.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
All existing unit tests must continue to pass without modification.

Run the API locally with `ov just api/up`. Open the logs with `ov just logs web` and make thumbnail requests and see the timing logs are present. Follow the testing instructions from #4508 and confirm they still work. The logs produced in this PR should be identical to the ones described in the linked PR, including the same contextual information, as well as `provider`, which was added later in #4598.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
