### PR TITLE
Bump the minimum required PDM version for the API

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     python3-dev \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install pdm~=2.14
+  && pip install pdm~=2.17
 
 # Copy subpackages from additional build-context 'packages'
 # hadolint ignore=DL3022


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

I was seeing an issue on `main` where when I tried to run `ov just build`, I got the following error:

```
------
 > [web builder 5/5] RUN pdm install --check --frozen-lockfile --dev:
1.475 WARNING: Lockfile is not compatible with PDM
1.476 Please run `pdm lock` to update the lock file
------
failed to solve: process "/bin/sh -c pdm install --check --frozen-lockfile $PDM_INSTALL_ARGS" did not complete successfully: exit code: 1
error: Recipe `dc` failed on line 209 with exit code 17
error: Recipe `build` failed on line 213 with exit code 17
```

@dhruvkb pointed out that this version might need to be bumped, and indeed it helped resolve the issue on my end!


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Check out this branch and run `ov just build`, ensure that everything works as expected.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
