### PR TITLE
Convert iNaturalist vernacular VARCHAR columns to TEXT

### DIFF
--- a/catalog/dags/providers/provider_csv_load_scripts/inaturalist/create_schema.sql
+++ b/catalog/dags/providers/provider_csv_load_scripts/inaturalist/create_schema.sql
@@ -58,14 +58,14 @@ COMMIT;
    https://github.com/CatalogueOfLife/coldp/blob/master/README.md#vernacularname
 */
 CREATE TABLE inaturalist.col_vernacular (
-    taxonID varchar(5),
+    taxonID text,
     sourceID decimal,
-    taxon_name varchar(2000),
+    taxon_name text,
     transliteration text,
     name_language varchar(3),
     preferred boolean,
     country varchar(3),
-    area varchar(2000),
+    area text,
     sex decimal,
     referenceID decimal,
     remarks text


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the schema for iNaturalist's taxonomy/vernacular table.

We received the following exception on the iNaturalist run this quarter:

```
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(5)
CONTEXT:  COPY col_vernacular, line 451211, column taxonid: "45b65465-9c79-4936-bde1-a14f96dc77eb"
```

I SSH'd into the Airflow container to look at the `VernacularName.tsv` file and indeed at line 451211 there were longer IDs used for taxonomies. I checked the [Catalog of Life schema](https://github.com/CatalogueOfLife/coldp/blob/master/README.md#schema) and a number of columns for `Vernacular` use `text` rather than `varchar`. I changed a number of columns to `text` and verified that this would load correctly locally.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Check out this branch and run the `inaturalist_workflow`. It will take some time to download the COL data, but the DAG should succeed once it does!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
