### PR TITLE
Fix audio collection page SSR error

### DIFF
--- a/frontend/src/components/VSearchResultsGrid/VCollectionResults.vue
+++ b/frontend/src/components/VSearchResultsGrid/VCollectionResults.vue
@@ -12,6 +12,7 @@
         class="mb-2 md:mb-3"
         :media-type="results.type"
         :collection-params="collectionParams"
+        :creator-url="creatorUrl"
       />
     </template>
 
@@ -67,6 +68,9 @@ export default defineComponent({
     searchTerm: {
       type: String,
       required: true,
+    },
+    creatorUrl: {
+      type: String,
     },
   },
   emits: {

--- a/frontend/src/composables/use-collection.ts
+++ b/frontend/src/composables/use-collection.ts
@@ -1,0 +1,77 @@
+import { useCollectionMeta, useI18n, useRoute } from "#imports"
+
+import { computed, ref, watch } from "vue"
+
+import { SupportedMediaType } from "~/constants/media"
+import { useMediaStore } from "~/stores/media"
+import { useSearchStore } from "~/stores/search"
+import type { AudioDetail, ImageDetail } from "~/types/media"
+
+export const useCollection = <T extends SupportedMediaType>({
+  mediaType,
+}: {
+  mediaType: T
+}) => {
+  type ResultType = T extends "image" ? ImageDetail : AudioDetail
+
+  const mediaStore = useMediaStore()
+  const searchStore = useSearchStore()
+
+  const collectionParams = computed(() => searchStore.collectionParams)
+  const isFetching = computed(() => mediaStore.fetchState.isFetching)
+
+  const media = ref<ResultType[]>(
+    mediaStore.resultItems[mediaType] as ResultType[]
+  )
+  const creatorUrl = ref<string>()
+
+  const i18n = useI18n({ useScope: "global" })
+
+  const collectionLabel = computed(() => {
+    if (!collectionParams.value) {
+      return ""
+    }
+    const { collection, ...params } = collectionParams.value
+    return i18n.t(`collection.ariaLabel.${collection}.image`, { ...params })
+  })
+
+  const fetchMedia = async (
+    { shouldPersistMedia }: { shouldPersistMedia: boolean } = {
+      shouldPersistMedia: false,
+    }
+  ) => {
+    media.value = (await mediaStore.fetchMedia({
+      shouldPersistMedia,
+    })) as ResultType[]
+    creatorUrl.value =
+      media.value.length > 0 ? media.value[0].creator_url : undefined
+    return media.value
+  }
+  // `useAsyncData` is not triggered when the query changes, e.g. when the user navigates from
+  // a creator collection page to a source collection page.
+  const route = useRoute()
+  const routeQuery = computed(() => route.query)
+  watch(routeQuery, async () => {
+    await fetchMedia()
+  })
+
+  const loadMore = async () => {
+    await fetchMedia({ shouldPersistMedia: true })
+  }
+  const { pageTitle } = useCollectionMeta({
+    collectionParams,
+    mediaType,
+    i18n,
+  })
+
+  return {
+    collectionParams,
+    pageTitle,
+    collectionLabel,
+    creatorUrl,
+    isFetching,
+    media,
+    fetchMedia,
+    loadMore,
+  }
+}

--- a/frontend/src/pages/image/collection.vue
+++ b/frontend/src/pages/image/collection.vue
@@ -1,20 +1,11 @@
 <script setup lang="ts">
-import {
-  definePageMeta,
-  useAsyncData,
-  useHead,
-  useI18n,
-  useRoute,
-} from "#imports"
-
-import { computed, ref, watch } from "vue"
+import { definePageMeta, useAsyncData, useHead } from "#imports"
 
 import { collectionMiddleware } from "~/middleware/collection"
-import { useMediaStore } from "~/stores/media"
-import { useSearchStore } from "~/stores/search"
-import { useCollectionMeta } from "~/composables/use-collection-meta"
 import { skipToContentTargetId } from "~/constants/window"
-import type { ImageDetail } from "~/types/media"
+
+import { useCollection } from "~/composables/use-collection"
+import { IMAGE } from "~/constants/media"
 
 import VCollectionResults from "~/components/VSearchResultsGrid/VCollectionResults.vue"
 
@@ -27,59 +18,21 @@ definePageMeta({
   middleware: collectionMiddleware,
 })
 
-const mediaStore = useMediaStore()
-const searchStore = useSearchStore()
-
-const collectionParams = computed(() => searchStore.collectionParams)
-const isFetching = computed(() => mediaStore.fetchState.isFetching)
-
-const media = ref<ImageDetail[]>(mediaStore.resultItems.image)
-const creatorUrl = ref<string>()
-
-const i18n = useI18n({ useScope: "global" })
-
-const collectionLabel = computed(() => {
-  if (!collectionParams.value) {
-    return ""
-  }
-  const { collection, ...params } = collectionParams.value
-  return i18n.t(`collection.ariaLabel.${collection}.image`, { ...params })
-})
-
-const fetchMedia = async (
-  { shouldPersistMedia }: { shouldPersistMedia: boolean } = {
-    shouldPersistMedia: false,
-  }
-) => {
-  media.value = (await mediaStore.fetchMedia({
-    shouldPersistMedia,
-  })) as ImageDetail[]
-  creatorUrl.value =
-    media.value.length > 0 ? media.value[0].creator_url : undefined
-  return media.value
-}
-const loadMore = () => {
-  fetchMedia({ shouldPersistMedia: true })
-}
-
-const { pageTitle } = useCollectionMeta({
+const {
   collectionParams,
-  mediaType: "image",
-  i18n,
-})
+  isFetching,
+  media,
+  creatorUrl,
+  collectionLabel,
+  fetchMedia,
+  loadMore,
+  pageTitle,
+} = useCollection({ mediaType: IMAGE })
 
 useHead(() => ({
   meta: [{ hid: "og:title", property: "og:title", content: pageTitle.value }],
   title: pageTitle.value,
 }))
-
-// `useAsyncData` is not triggered when the query changes, e.g. when the user navigates from
-// a creator collection page to a source collection page.
-const route = useRoute()
-const routeQuery = computed(() => route.query)
-watch(routeQuery, async () => {
-  await fetchMedia()
-})
 
 /**
  * Media is not empty when we navigate back to this page, so we don't need
@@ -105,6 +58,7 @@ await useAsyncData(
       :results="{ type: 'image', items: media }"
       :collection-label="collectionLabel"
       :collection-params="collectionParams"
+      :creator-url="creatorUrl"
       @load-more="loadMore"
     />
   </div>


### PR DESCRIPTION
Extract common functionality to a composable

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4721 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the audio collection SSR by setting the media to the media from the store (instead of the empty array).

It also extracts the collection functionality into a composable. This reduces the code duplication between the audio/image collection pages.
Another fix in this PR is the re-addition of the `creatorUrl` prop. This prop was lost when migrating to Nuxt 3, and the creator collections did not have the link to their landing pages on source websites.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app.

Search for something in audio, and then click on one of the tags. Refresh the page to see how SSR page looks. On `main` and in production, the page does not show any results, and there is an error logged in the console. In this PR, the page works correctly. Note that the image collections work well both in production and here.

Check a creator collection page. On `main` and in production, the page does not have a creator link button in the header. In this PR, the link is shown (both in the image and in the audio page)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
