### PR TITLE
Fix mobile recent searches modal with banners

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -29,6 +29,9 @@ const darkMode = useDarkMode()
 /* UI store */
 const isDesktopLayout = computed(() => uiStore.isDesktopLayout)
 const breakpoint = computed(() => uiStore.breakpoint)
+const headerHeight = computed(() => {
+  return `--header-height: ${uiStore.headerHeight}px`
+})
 
 const head = useLocaleHead({
   addDirAttribute: true,
@@ -114,7 +117,7 @@ onMounted(() => {
           />
         </template>
       </Head>
-      <Body>
+      <Body :style="headerHeight">
         <div :class="[isDesktopLayout ? 'desktop' : 'mobile', breakpoint]">
           <VSkipToContentButton />
           <NuxtLayout>

--- a/frontend/src/components/VModal/VModalContent.vue
+++ b/frontend/src/components/VModal/VModalContent.vue
@@ -97,13 +97,12 @@ defineExpose({
   <Teleport to="#teleports">
     <div
       v-show="visible"
-      class="h-dyn-screen min-h-dyn-screen fixed inset-0 z-40 flex justify-center overflow-y-auto"
+      class="backdrop h-dyn-screen min-h-dyn-screen fixed inset-0 z-40 flex justify-center overflow-y-auto"
       :class="[
         { 'flex-col items-center': variant === 'centered' },
-        variant === 'mobile-input'
-          ? 'top-20 h-[calc(100dvh-80px)] bg-tx'
-          : 'bg-dark-charcoal bg-opacity-75',
+        variant === 'mobile-input' ? 'bg-tx' : 'bg-dark-charcoal bg-opacity-75',
         contentClasses,
+        variant,
       ]"
     >
       <!-- re: disabled static element interactions rule https://github.com/WordPress/openverse/issues/2906 -->
@@ -182,6 +181,10 @@ defineExpose({
 </template>
 
 <style scoped>
+.backdrop.mobile-input {
+  height: calc(100dvh - var(--header-height, 80px));
+  top: var(--header-height, 80px);
+}
 /*
 For mobiles that do not support dvh units, we add a fallback padding
 to the modal content to make sure that no clickable elements are hidden

--- a/frontend/src/layouts/search-layout.vue
+++ b/frontend/src/layouts/search-layout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, provide, ref, watch } from "vue"
-import { useScroll } from "@vueuse/core"
+import { useElementSize, useScroll } from "@vueuse/core"
 
 import { useUiStore } from "~/stores/ui"
 import { isSearchTypeSupported, useSearchStore } from "~/stores/search"
@@ -45,6 +45,7 @@ const showScrollButton = ref(false)
  * Note: template refs do not work in a Nuxt layout, so we get the `main-page` element using `document.getElementById`.
  */
 let mainPageElement = ref<HTMLElement | null>(null)
+let headerElement = ref<HTMLElement | null>(null)
 
 const { y: mainPageY } = useScroll(mainPageElement)
 watch(mainPageY, (y) => {
@@ -54,6 +55,14 @@ watch(mainPageY, (y) => {
 
 onMounted(() => {
   mainPageElement.value = document.getElementById("main-page")
+  headerElement.value = document.getElementsByClassName(
+    "header-el"
+  )[0] as HTMLElement
+})
+
+const { height } = useElementSize(headerElement)
+watch(height, (height) => {
+  uiStore.setHeaderHeight(height)
 })
 
 provide(IsHeaderScrolledKey, isHeaderScrolled)

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -52,6 +52,7 @@ export interface UiState {
   shouldBlurSensitive: boolean
   /* A list of sensitive single result UUIDs the user has opted-into seeing */
   revealedSensitiveResults: string[]
+  headerHeight: number
 }
 
 export const breakpoints = Object.keys(ALL_SCREEN_SIZES)
@@ -66,6 +67,7 @@ export const useUiStore = defineStore("ui", {
     dismissedBanners: [],
     shouldBlurSensitive: true,
     revealedSensitiveResults: [],
+    headerHeight: 80,
   }),
 
   getters: {
@@ -254,6 +256,9 @@ export const useUiStore = defineStore("ui", {
     setShouldBlurSensitive(value: boolean) {
       this.shouldBlurSensitive = value
       this.revealedSensitiveResults = []
+    },
+    setHeaderHeight(height: number) {
+      this.headerHeight = Math.max(height, 80)
     },
   },
 })


### PR DESCRIPTION
_Marked as critical because this issue does not allow search on mobile when the banner is not dismissed_

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4729 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a `--header-height` CSS variable that is then used to compute the height of the modal backdrop, and the modal offset from the top to make sure that any banners inside the header element are taken into account.

I tried to also fix #2603 in this PR, but because clicking "Skip to content" _navigates_ to a `#content` hash route, it requires a [router options](https://nuxt.com/docs/guide/recipes/custom-routing#router-options) [scroll behavior changes](https://router.vuejs.org/guide/advanced/scroll-behavior).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Clear the `ui` cookies in your browser, or use _incognito_ mode.
2. Use the _mobile, narrow_ screen width.
3. Run the app and go to `http://localhost:8443/search?q=cat` or `http://localhost:8443/ru/search?q=cat`
4. You should see a banner or two banners at the top.
5. Click on the search bar. The recent searches modal should open, and it should not hide any part of the search bar.

Now do the same in production: on https://openverse.org/ru/search?q=cat you should see 2 banners, and the recent searches modal hides the bottom banner as well as the search bar.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
