### PR TITLE
Fix Playwright test failures when Nuxt context is not available

### DIFF
--- a/frontend/src/composables/use-api-client.ts
+++ b/frontend/src/composables/use-api-client.ts
@@ -1,0 +1,15 @@
+import { useNuxtApp } from "#imports"
+
+import { useFeatureFlagStore } from "~/stores/feature-flag"
+import { createApiClient } from "~/data/api-service"
+
+export function useApiClient() {
+  const { $openverseApiToken: accessToken } = useNuxtApp()
+  const featureFlagStore = useFeatureFlagStore()
+
+  const fakeSensitive =
+    featureFlagStore.isOn("fake_sensitive") &&
+    featureFlagStore.isOn("fetch_sensitive")
+
+  return createApiClient({ accessToken, fakeSensitive })
+}

--- a/frontend/src/data/api-service.ts
+++ b/frontend/src/data/api-service.ts
@@ -53,17 +53,19 @@ const userAgent =
  * objects into an object with media id as keys.
  * @param mediaType - the media type of the search query
  * @param data - search result data
+ * @param fakeSensitive - whether to fake sensitive data for testing
  */
 function transformResults<T extends Media>(
   mediaType: SupportedMediaType,
-  data: MediaResult<T[]>
+  data: MediaResult<T[]>,
+  fakeSensitive: boolean
 ): MediaResult<Record<string, T>> {
   const mediaResults = <T[]>data.results ?? []
   return {
     ...data,
     results: mediaResults.reduce(
       (acc, item) => {
-        acc[item.id] = decodeMediaData(item, mediaType)
+        acc[item.id] = decodeMediaData(item, mediaType, fakeSensitive)
         return acc
       },
       {} as Record<string, T>
@@ -131,11 +133,14 @@ export interface ApiServiceConfig {
   accessToken?: string
   /** whether to use the `'v1/'` prefix after the base URL */
   isVersioned?: boolean
+  /** whether to use fake sensitivity data for testing */
+  fakeSensitive?: boolean
 }
 
 export const createApiClient = ({
   accessToken = undefined,
   isVersioned = true,
+  fakeSensitive = false,
 }: ApiServiceConfig = {}) => {
   const baseUrl =
     useRuntimeConfig().public.apiUrl ?? "https://api.openverse.org/"
@@ -202,7 +207,7 @@ export const createApiClient = ({
 
     return {
       eventPayload,
-      data: transformResults(mediaType, res.data),
+      data: transformResults(mediaType, res.data, fakeSensitive),
     }
   }
 

--- a/frontend/src/plugins/02. init-stores.ts
+++ b/frontend/src/plugins/02. init-stores.ts
@@ -18,8 +18,6 @@ export default defineNuxtPlugin(async () => {
   // is not available` error is thrown.
   const featureFlagStore = useFeatureFlagStore()
 
-  featureFlagStore.syncAnalyticsWithLocalStorage()
-
   const featureCookies = useCookie<OpenverseCookieState["features"]>("features")
   featureFlagStore.initFromCookies(featureCookies.value ?? {})
 

--- a/frontend/src/plugins/02. init-stores.ts
+++ b/frontend/src/plugins/02. init-stores.ts
@@ -7,10 +7,15 @@ import { useProviderStore } from "~/stores/provider"
 import type { OpenverseCookieState } from "~/types/cookies"
 
 /**
- * Initialize the feature flag and UI stores from cookies and query parameters.
+ * Initialize the feature flag, ui and provider stores.
+ * This plugin should run before all other plugins to
+ * ensure that the store states are ready for other plugins.
  */
 export default defineNuxtPlugin(async () => {
   /* Feature flag store */
+  // Feature flag store uses deploymentEnv variable from the runtimeContext,
+  // and should be the first to initialize. Otherwise, the `[nuxt]` context
+  // is not available` error is thrown.
   const featureFlagStore = useFeatureFlagStore()
 
   featureFlagStore.syncAnalyticsWithLocalStorage()

--- a/frontend/src/plugins/02. init-stores.ts
+++ b/frontend/src/plugins/02. init-stores.ts
@@ -10,17 +10,21 @@ import type { OpenverseCookieState } from "~/types/cookies"
  * Initialize the feature flag and UI stores from cookies and query parameters.
  */
 export default defineNuxtPlugin(async () => {
-  /* Provider store */
-  const providerStore = useProviderStore()
-  await providerStore.fetchProviders()
-
   /* Feature flag store */
   const featureFlagStore = useFeatureFlagStore()
+
+  featureFlagStore.syncAnalyticsWithLocalStorage()
+
   const featureCookies = useCookie<OpenverseCookieState["features"]>("features")
   featureFlagStore.initFromCookies(featureCookies.value ?? {})
+
   const sessionFeatures =
     useCookie<OpenverseCookieState["sessionFeatures"]>("sessionFeatures")
   featureFlagStore.initFromCookies(sessionFeatures.value ?? {})
+
+  /* Provider store */
+  const providerStore = useProviderStore()
+  await providerStore.fetchProviders()
 
   /* UI store */
   const uiStore = useUiStore()

--- a/frontend/src/plugins/03. analytics.ts
+++ b/frontend/src/plugins/03. analytics.ts
@@ -2,7 +2,6 @@ import { defineNuxtPlugin, useTrackEvent } from "#imports"
 
 import type { Events, EventName } from "~/types/analytics"
 import { useUiStore } from "~/stores/ui"
-import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 type SendCustomEvent = <T extends EventName>(
   name: T,
@@ -20,9 +19,6 @@ export default defineNuxtPlugin(() => {
   }
 
   const uiStore = useUiStore()
-  const featureFlagStore = useFeatureFlagStore()
-
-  featureFlagStore.syncAnalyticsWithLocalStorage()
 
   const sendCustomEvent: SendCustomEvent = (name, payload) => {
     useTrackEvent(name, {

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -1,4 +1,4 @@
-import { useCookie, useRuntimeConfig } from "#imports"
+import { tryUseNuxtApp, useCookie } from "#imports"
 
 import { defineStore } from "pinia"
 import { useStorage } from "@vueuse/core"
@@ -131,8 +131,20 @@ const FEATURE_FLAG = "feature_flag"
 
 export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
   state: () => {
-    const deploymentEnv = useRuntimeConfig().public.deploymentEnv as DeployEnv
-    return initializeFlagState(deploymentEnv)
+    const nuxtApp = tryUseNuxtApp()
+    if (nuxtApp) {
+      return initializeFlagState(
+        nuxtApp.$config.public.deploymentEnv as DeployEnv
+      )
+    }
+    if (!process.env.NUXT_PUBLIC_DEPLOYMENT_ENV) {
+      throw new Error(
+        "Cannot initialize feature flags store. Deployment environment not set in the Nuxt app context and the env variable is unavailable."
+      )
+    }
+    return initializeFlagState(
+      process.env.NUXT_PUBLIC_DEPLOYMENT_ENV as DeployEnv
+    )
   },
   getters: {
     /**

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -1,4 +1,4 @@
-import { tryUseNuxtApp, useCookie } from "#imports"
+import { useCookie, useRuntimeConfig } from "#imports"
 
 import { defineStore } from "pinia"
 import { useStorage } from "@vueuse/core"
@@ -131,23 +131,8 @@ const FEATURE_FLAG = "feature_flag"
 
 export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
   state: () => {
-    const nuxtApp = tryUseNuxtApp()
-    if (nuxtApp) {
-      return initializeFlagState(
-        nuxtApp.$config.public.deploymentEnv as DeployEnv
-      )
-    }
-    throw new Error(
-      "Cannot initialize feature flags store. Nuxt app context is unavailable."
-    )
-    // if (!process.env.NUXT_PUBLIC_DEPLOYMENT_ENV) {
-    //   throw new Error(
-    //     "Cannot initialize feature flags store. Deployment environment not set in the Nuxt app context and the env variable is unavailable."
-    //   )
-    // }
-    // return initializeFlagState(
-    //   process.env.NUXT_PUBLIC_DEPLOYMENT_ENV as DeployEnv
-    // )
+    const deploymentEnv = useRuntimeConfig().public.deploymentEnv as DeployEnv
+    return initializeFlagState(deploymentEnv)
   },
   getters: {
     /**

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -137,14 +137,17 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
         nuxtApp.$config.public.deploymentEnv as DeployEnv
       )
     }
-    if (!process.env.NUXT_PUBLIC_DEPLOYMENT_ENV) {
-      throw new Error(
-        "Cannot initialize feature flags store. Deployment environment not set in the Nuxt app context and the env variable is unavailable."
-      )
-    }
-    return initializeFlagState(
-      process.env.NUXT_PUBLIC_DEPLOYMENT_ENV as DeployEnv
+    throw new Error(
+      "Cannot initialize feature flags store. Nuxt app context is unavailable."
     )
+    // if (!process.env.NUXT_PUBLIC_DEPLOYMENT_ENV) {
+    //   throw new Error(
+    //     "Cannot initialize feature flags store. Deployment environment not set in the Nuxt app context and the env variable is unavailable."
+    //   )
+    // }
+    // return initializeFlagState(
+    //   process.env.NUXT_PUBLIC_DEPLOYMENT_ENV as DeployEnv
+    // )
   },
   getters: {
     /**

--- a/frontend/src/stores/feature-flag.ts
+++ b/frontend/src/stores/feature-flag.ts
@@ -138,15 +138,8 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
       )
     }
 
-    const deploymentEnv = process.env.NUXT_PUBLIC_DEPLOYMENT_ENV as DeployEnv
-    if (deploymentEnv) {
-      console.warn(
-        "Nuxt app is not available in feature flag store setup. Using the environment variable instead."
-      )
-      return initializeFlagState(deploymentEnv)
-    }
     throw new Error(
-      "Could not set up feature flag store. Neither Nuxt app nor environment variable is available."
+      "Could not set up feature flag store because Nuxt content isn't available."
     )
   },
   getters: {

--- a/frontend/src/stores/media/index.ts
+++ b/frontend/src/stores/media/index.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from "#imports"
+import { useFeatureFlagStore, useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -466,12 +466,19 @@ export const useMediaStore = defineStore("media", {
 
       this._updateFetchState(mediaType, "start")
 
-      const { $processFetchingError } = useNuxtApp()
-      try {
-        const { $openverseApiToken: accessToken, $sendCustomEvent } =
-          useNuxtApp()
+      const {
+        $openverseApiToken: accessToken,
+        $sendCustomEvent,
+        $processFetchingError,
+      } = useNuxtApp()
 
-        const client = createApiClient({ accessToken })
+      const featureFlagStore = useFeatureFlagStore()
+      const fakeSensitive =
+        featureFlagStore.isOn("fake_sensitive") &&
+        featureFlagStore.isOn("fetch_sensitive")
+
+      try {
+        const client = createApiClient({ accessToken, fakeSensitive })
 
         const { eventPayload, data } = await client.search(
           mediaType,

--- a/frontend/src/stores/media/index.ts
+++ b/frontend/src/stores/media/index.ts
@@ -1,4 +1,4 @@
-import { useFeatureFlagStore, useNuxtApp } from "#imports"
+import { useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -25,7 +25,7 @@ import { isSearchTypeSupported, useSearchStore } from "~/stores/search"
 import { useRelatedMediaStore } from "~/stores/media/related-media"
 import { deepFreeze } from "~/utils/deep-freeze"
 
-import { createApiClient } from "~/data/api-service"
+import { useApiClient } from "~/composables/use-api-client"
 
 interface SearchFetchState extends Omit<FetchState, "hasStarted"> {
   hasStarted: boolean
@@ -466,20 +466,11 @@ export const useMediaStore = defineStore("media", {
 
       this._updateFetchState(mediaType, "start")
 
-      const {
-        $openverseApiToken: accessToken,
-        $sendCustomEvent,
-        $processFetchingError,
-      } = useNuxtApp()
+      const { $sendCustomEvent, $processFetchingError } = useNuxtApp()
 
-      const featureFlagStore = useFeatureFlagStore()
-      const fakeSensitive =
-        featureFlagStore.isOn("fake_sensitive") &&
-        featureFlagStore.isOn("fetch_sensitive")
+      const client = useApiClient()
 
       try {
-        const client = createApiClient({ accessToken, fakeSensitive })
-
         const { eventPayload, data } = await client.search(
           mediaType,
           queryParams

--- a/frontend/src/stores/media/related-media.ts
+++ b/frontend/src/stores/media/related-media.ts
@@ -1,4 +1,4 @@
-import { useFeatureFlagStore, useNuxtApp } from "#imports"
+import { useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -52,16 +52,9 @@ export const useRelatedMediaStore = defineStore("related-media", {
       this.mainMediaId = id
       this._startFetching()
       this.media = []
-      const { $openverseApiToken: accessToken } = useNuxtApp()
-
-      const featureFlagStore = useFeatureFlagStore()
-      const fakeSensitive =
-        featureFlagStore.isOn("fake_sensitive") &&
-        featureFlagStore.isOn("fetch_sensitive")
+      const client = createApiClient()
 
       try {
-        const client = createApiClient({ accessToken, fakeSensitive })
-
         this.media = await client.getRelatedMedia(mediaType, id)
         this._endFetching()
 

--- a/frontend/src/stores/media/related-media.ts
+++ b/frontend/src/stores/media/related-media.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from "#imports"
+import { useFeatureFlagStore, useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -52,10 +52,15 @@ export const useRelatedMediaStore = defineStore("related-media", {
       this.mainMediaId = id
       this._startFetching()
       this.media = []
-      try {
-        const { $openverseApiToken: accessToken } = useNuxtApp()
+      const { $openverseApiToken: accessToken } = useNuxtApp()
 
-        const client = createApiClient({ accessToken })
+      const featureFlagStore = useFeatureFlagStore()
+      const fakeSensitive =
+        featureFlagStore.isOn("fake_sensitive") &&
+        featureFlagStore.isOn("fetch_sensitive")
+
+      try {
+        const client = createApiClient({ accessToken, fakeSensitive })
 
         this.media = await client.getRelatedMedia(mediaType, id)
         this._endFetching()

--- a/frontend/src/stores/media/single-result.ts
+++ b/frontend/src/stores/media/single-result.ts
@@ -1,4 +1,4 @@
-import { useFeatureFlagStore, useNuxtApp } from "#imports"
+import { useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -15,7 +15,7 @@ import { useMediaStore } from "~/stores/media/index"
 import { validateUUID } from "~/utils/query-utils"
 
 import { FetchingError, FetchState } from "~/types/fetch-state"
-import { createApiClient } from "~/data/api-service"
+import { useApiClient } from "~/composables/use-api-client"
 
 export type MediaItemState = {
   mediaType: SupportedMediaType | null
@@ -142,17 +142,11 @@ export const useSingleResultStore = defineStore("single-result", {
 
       // When fetch is called by the middleware, the app context is not available during the error handling,
       // so we need to use the `useNuxtApp` here, outside the catch clause, to access the app context.
-      const { $processFetchingError, $openverseApiToken: accessToken } =
-        useNuxtApp()
+      const { $processFetchingError } = useNuxtApp()
 
-      const featureFlagStore = useFeatureFlagStore()
-      const fakeSensitive =
-        featureFlagStore.isOn("fake_sensitive") &&
-        featureFlagStore.isOn("fetch_sensitive")
+      const client = useApiClient()
 
       try {
-        const client = createApiClient({ accessToken, fakeSensitive })
-
         const item = await client.getSingleMedia(type, id)
 
         this.setMediaItem(item)

--- a/frontend/src/stores/media/single-result.ts
+++ b/frontend/src/stores/media/single-result.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from "#imports"
+import { useFeatureFlagStore, useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -142,11 +142,16 @@ export const useSingleResultStore = defineStore("single-result", {
 
       // When fetch is called by the middleware, the app context is not available during the error handling,
       // so we need to use the `useNuxtApp` here, outside the catch clause, to access the app context.
-      const { $processFetchingError } = useNuxtApp()
+      const { $processFetchingError, $openverseApiToken: accessToken } =
+        useNuxtApp()
+
+      const featureFlagStore = useFeatureFlagStore()
+      const fakeSensitive =
+        featureFlagStore.isOn("fake_sensitive") &&
+        featureFlagStore.isOn("fetch_sensitive")
 
       try {
-        const { $openverseApiToken: accessToken } = useNuxtApp()
-        const client = createApiClient({ accessToken })
+        const client = createApiClient({ accessToken, fakeSensitive })
 
         const item = await client.getSingleMedia(type, id)
 

--- a/frontend/src/stores/provider.ts
+++ b/frontend/src/stores/provider.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from "#imports"
+import { useFeatureFlagStore, useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -130,9 +130,16 @@ export const useProviderStore = defineStore("provider", {
     ): Promise<void> {
       this._updateFetchState(mediaType, "start")
       let sortedProviders = [] as MediaProvider[]
+
+      const featureFlagStore = useFeatureFlagStore()
+      const fakeSensitive =
+        featureFlagStore.isOn("fake_sensitive") &&
+        featureFlagStore.isOn("fetch_sensitive")
+
+      const { $openverseApiToken: accessToken } = useNuxtApp()
+
       try {
-        const { $openverseApiToken: accessToken } = useNuxtApp()
-        const client = createApiClient({ accessToken })
+        const client = createApiClient({ accessToken, fakeSensitive })
         const res = await client.stats(mediaType)
         sortedProviders = sortProviders(res ?? [])
         this._updateFetchState(mediaType, "end")

--- a/frontend/src/stores/provider.ts
+++ b/frontend/src/stores/provider.ts
@@ -1,4 +1,4 @@
-import { useFeatureFlagStore, useNuxtApp } from "#imports"
+import { useNuxtApp } from "#imports"
 
 import { defineStore } from "pinia"
 
@@ -13,7 +13,7 @@ import {
 import type { MediaProvider } from "~/types/media-provider"
 import type { FetchingError, FetchState } from "~/types/fetch-state"
 
-import { createApiClient } from "~/data/api-service"
+import { useApiClient } from "~/composables/use-api-client"
 
 export interface ProviderState {
   providers: {
@@ -131,15 +131,9 @@ export const useProviderStore = defineStore("provider", {
       this._updateFetchState(mediaType, "start")
       let sortedProviders = [] as MediaProvider[]
 
-      const featureFlagStore = useFeatureFlagStore()
-      const fakeSensitive =
-        featureFlagStore.isOn("fake_sensitive") &&
-        featureFlagStore.isOn("fetch_sensitive")
-
-      const { $openverseApiToken: accessToken } = useNuxtApp()
+      const client = useApiClient()
 
       try {
-        const client = createApiClient({ accessToken, fakeSensitive })
         const res = await client.stats(mediaType)
         sortedProviders = sortProviders(res ?? [])
         this._updateFetchState(mediaType, "end")

--- a/frontend/src/utils/decode-media-data.ts
+++ b/frontend/src/utils/decode-media-data.ts
@@ -3,7 +3,6 @@ import { SENSITIVITY_RESPONSE_PARAM } from "~/constants/content-safety"
 import { AUDIO, IMAGE, MODEL_3D, VIDEO } from "~/constants/media"
 import type { ApiMedia, Media, Tag } from "~/types/media"
 import type { MediaType } from "~/constants/media"
-import { useFeatureFlagStore } from "~/stores/feature-flag"
 import { useProviderStore } from "~/stores/provider"
 import { capitalCase } from "~/utils/case"
 import { getFakeSensitivities } from "~/utils/content-safety"
@@ -110,22 +109,21 @@ const parseTags = (tags: Tag[]) => {
  *
  * @param media - the media object of which to decode attributes
  * @param mediaType - the type of the media
+ * @param fakeSensitive - whether to fake sensitive data for testing
  * @returns the given media object with the text fields decoded
  */
 export const decodeMediaData = <T extends Media>(
   media: ApiMedia | undefined | null,
-  mediaType: T["frontendMediaType"]
+  mediaType: T["frontendMediaType"],
+  fakeSensitive = false
 ): T => {
   if (!media) {
     throw new Error("Media is undefined or null")
   }
   // Fake ~50% of results as sensitive.
-  const featureFlagStore = useFeatureFlagStore()
-  const sensitivity =
-    featureFlagStore.isOn("fake_sensitive") &&
-    featureFlagStore.isOn("fetch_sensitive")
-      ? getFakeSensitivities(media.id)
-      : (media[SENSITIVITY_RESPONSE_PARAM] ?? [])
+  const sensitivity = fakeSensitive
+    ? getFakeSensitivities(media.id)
+    : (media[SENSITIVITY_RESPONSE_PARAM] ?? [])
   sensitivity.sort()
   const isSensitive = sensitivity.length > 0
 

--- a/frontend/test/playwright/e2e/recent-searches.spec.ts
+++ b/frontend/test/playwright/e2e/recent-searches.spec.ts
@@ -86,8 +86,9 @@ breakpoints.describeMobileXsAndDesktop(({ breakpoint }) => {
       .locator(`[aria-label="${recentLabel}"]`)
       .getByRole("option", { name: "honey" })
       .click()
+
+    await page.waitForURL(/search\?q=honey/)
     await expect(getH1(page, /honey/i)).toBeVisible()
-    expect(page.url()).toContain("?q=honey")
   })
 
   test("clicking Clear clears the recent searches", async ({ page }) => {

--- a/frontend/test/playwright/utils/page.ts
+++ b/frontend/test/playwright/utils/page.ts
@@ -4,18 +4,6 @@
 
 import type { Page } from "@playwright/test"
 
-export const removeHiddenOverflow = async (page: Page) => {
-  const mainElement = await page.$(".main.embedded.overflow-x-hidden")
-  await mainElement?.evaluate((node) =>
-    node.classList.remove("main", "embedded", "overflow-x-hidden")
-  )
-  mainElement?.dispose()
-
-  const appElement = await page.$(".app.grid.h-screen.overflow-hidden.relative")
-  await appElement?.evaluate((node) => node.classList.remove("overflow-hidden"))
-  appElement?.dispose()
-}
-
 export const hideInputCursors = (page: Page) => {
   return page.addStyleTag({
     content: "* { caret-color: transparent !important; }",

--- a/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
@@ -14,7 +14,7 @@ breakpoints.describeEvery(({ breakpoint, expectSnapshot }) => {
       dismissBanners: false,
       dismissFilter: false,
     })
-    await page.goto("/ru/search/?q=birds&referrer=creativecommons.org")
+    await page.goto("/ru/search?q=birds&referrer=creativecommons.org")
     await ensureSearchPageHydrated(page)
   })
 

--- a/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
@@ -14,7 +14,7 @@ breakpoints.describeEvery(({ breakpoint, expectSnapshot }) => {
       dismissBanners: false,
       dismissFilter: false,
     })
-    await page.goto("/ru/search?q=birds&referrer=creativecommons.org")
+    await page.goto("/ru/search?q=birds")
     await ensureSearchPageHydrated(page)
   })
 

--- a/frontend/test/unit/specs/stores/media-store-fetching.spec.js
+++ b/frontend/test/unit/specs/stores/media-store-fetching.spec.js
@@ -100,6 +100,7 @@ describe("fetchMedia", () => {
 
     expect(mocks.createApiClient).toHaveBeenCalledWith({
       accessToken: undefined,
+      fakeSensitive: false,
     })
     expect(imageSearchMock).toHaveBeenCalledWith(IMAGE, { q: "cat" })
     expect(audioSearchMock).toHaveBeenCalledWith(AUDIO, { q: "cat" })

--- a/frontend/test/unit/specs/stores/media-store-fetching.spec.js
+++ b/frontend/test/unit/specs/stores/media-store-fetching.spec.js
@@ -51,13 +51,16 @@ vi.mock("#app/nuxt", async () => {
   const original = await import("#app/nuxt")
   return {
     ...original,
-    useRuntimeConfig: vi.fn(() => ({ public: { deploymentEnv: "local" } })),
+    useRuntimeConfig: vi.fn(() => ({ public: {} })),
     useNuxtApp: vi.fn(() => ({
       $sentry: {
         captureException: vi.fn(),
       },
       $sendCustomEvent: vi.fn(),
       $processFetchingError: vi.fn(),
+    })),
+    tryUseNuxtApp: vi.fn(() => ({
+      $config: { public: { deploymentEnv: "staging" } },
     })),
   }
 })

--- a/frontend/test/unit/specs/stores/media-store-fetching.spec.js
+++ b/frontend/test/unit/specs/stores/media-store-fetching.spec.js
@@ -51,16 +51,13 @@ vi.mock("#app/nuxt", async () => {
   const original = await import("#app/nuxt")
   return {
     ...original,
-    useRuntimeConfig: vi.fn(() => ({ public: {} })),
+    useRuntimeConfig: vi.fn(() => ({ public: { deploymentEnv: "local" } })),
     useNuxtApp: vi.fn(() => ({
       $sentry: {
         captureException: vi.fn(),
       },
       $sendCustomEvent: vi.fn(),
       $processFetchingError: vi.fn(),
-    })),
-    tryUseNuxtApp: vi.fn(() => ({
-      $config: { public: { deploymentEnv: "staging" } },
     })),
   }
 })

--- a/frontend/test/unit/specs/stores/media-store-fetching.spec.js
+++ b/frontend/test/unit/specs/stores/media-store-fetching.spec.js
@@ -51,13 +51,20 @@ vi.mock("#app/nuxt", async () => {
   const original = await import("#app/nuxt")
   return {
     ...original,
-    useRuntimeConfig: vi.fn(() => ({ public: { deploymentEnv: "local" } })),
+    useRuntimeConfig: vi.fn(() => ({ public: { deploymentEnv: "staging" } })),
     useNuxtApp: vi.fn(() => ({
       $sentry: {
         captureException: vi.fn(),
       },
       $sendCustomEvent: vi.fn(),
       $processFetchingError: vi.fn(),
+    })),
+    tryUseNuxtApp: vi.fn(() => ({
+      $config: {
+        public: {
+          deploymentEnv: "staging",
+        },
+      },
     })),
   }
 })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4737 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The failures were caused by race conditions when setting up the feature flag store. 

When setting up the state, we need the `runtimeConfig`'s `deploymentEnv` to compute the feature flag statuses and states. Sometimes it was called when the Nuxt context necessary for `useRuntimeConfig` wasn't available, and this caused errors down the line. This only happened on the server.

This PR adds a check if the Nuxt app context is available to the feature flags store. If it's not available, it is possible to get the `deploymentEnv` from the runtime env variable (`NUXT_PUBLIC_DEPLOYMENT_ENV`). It also throws an error when the env variable is not available - but that should never happen.

Some code is also refactored to avoid calling feature flag store from deeply nested functions (e.g., function that is called by the function returned from `createApiService`, which is called by the media store) as that could cause loss of Nuxt context (more on this in the [Nuxt docs](https://nuxt.com/docs/guide/concepts/auto-imports#vue-and-nuxt-composables))

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
See that the latest Playwright CI runs in this PR ran successfully. I will run the tests several times.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
