### PR TITLE
Generate Wikimedia thumbnail URLs on the fly

### DIFF
--- a/api/api/utils/image_proxy/dataclasses.py
+++ b/api/api/utils/image_proxy/dataclasses.py
@@ -7,6 +7,7 @@ class MediaInfo:
     media_provider: str
     media_identifier: UUID
     image_url: str
+    width: int | None = None
 
 
 @dataclass

--- a/api/api/utils/image_proxy/wikimedia.py
+++ b/api/api/utils/image_proxy/wikimedia.py
@@ -1,0 +1,50 @@
+import re
+from math import inf
+from urllib.parse import ParseResult
+
+from django.conf import settings
+
+from api.utils.image_proxy.dataclasses import MediaInfo, RequestConfig
+
+
+# e.g.:
+# https://upload.wikimedia.org/wikipedia/commons/9/9e/Color_icon_yellow.svg
+# https://upload.wikimedia.org/wikipedia/commons/f/f3/Open_book_01.svg
+# The length of the hashes is constant
+# For each example, the thumbnail URL is:
+# https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Color_icon_yellow.svg/<WIDTH>px-Color_icon_yellow.svg.jpg
+# https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Open_book_01.svg/<WIDTH>px-Open_book_01.svg.jpg
+# A regex is slightly more reliable for this in case for some reason wikipedia/commons is not a constant prefix
+# or the filename somehow has an additional `/` in it (though that does not appear to be possible)
+WIKIMEDIA_PATH_PARSE = re.compile(
+    r"^(?P<path_prefix>.*?)(?P<hash>/[a-z0-9]{1}/[a-z0-9]{2}/)(?P<filename>.*)$"
+)
+
+
+def get_wikimedia_thumbnail_url(
+    media_info: MediaInfo, url: ParseResult, request_config: RequestConfig
+) -> ParseResult | None:
+    path_match = WIKIMEDIA_PATH_PARSE.match(url.path)
+    if path_match is None:
+        return None
+
+    groups = path_match.groupdict()
+
+    if request_config.is_full_size and media_info.width:
+        width = media_info.width
+    else:
+        # either not full size or there is no width defined
+        # if no width is defined, use the default thumbnail size (by falling back to infinity for the media_info.width)
+        # otherwise, use whichever is smallest, so that Wikimedia does not upscale the image
+        # Wikimedia _requires_ sending a width, so there's no other fallback than the default thumbnail size
+        width = min(settings.THUMBNAIL_WIDTH_PX, media_info.width or inf)
+
+    params = f"{width}px"
+
+    if request_config.is_compressed:
+        params = f"lossy-{params}"
+
+    # always retrieve a PNG, and Site Accelerator will convert it as necessary based on the accept headers
+    return url._replace(
+        path=f"{groups['path_prefix']}/thumb{groups['hash']}{groups['filename']}/{params}-{groups['filename']}.png"
+    )

--- a/api/api/utils/image_proxy/wikimedia.py
+++ b/api/api/utils/image_proxy/wikimedia.py
@@ -30,12 +30,11 @@ def get_wikimedia_thumbnail_url(
 
     groups = path_match.groupdict()
 
-    if request_config.is_full_size and media_info.width:
-        width = media_info.width
+    if request_config.is_full_size:
+        width = media_info.width or settings.THUMBNAIL_WIDTH_PX
     else:
-        # either not full size or there is no width defined
-        # if no width is defined, use the default thumbnail size (by falling back to infinity for the media_info.width)
-        # otherwise, use whichever is smallest, so that Wikimedia does not upscale the image
+        # If not full size, prevent Wikimedia from upscaling the image by using the smaller of
+        # the default thumbnail size or media_info.width
         # Wikimedia _requires_ sending a width, so there's no other fallback than the default thumbnail size
         width = min(settings.THUMBNAIL_WIDTH_PX, media_info.width or inf)
 

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -110,6 +110,7 @@ class ImageViewSet(MediaViewSet):
             media_identifier=image.identifier,
             media_provider=image.provider,
             image_url=image_url,
+            width=image.width,
         )
 
     @thumbnail_docs

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -15,7 +15,7 @@ PHOTON_ENDPOINT = config("PHOTON_ENDPOINT", default="https://i0.wp.com/")
 # they're just passed through to Photon's API
 # Keeping them as strings makes the tests slightly less verbose (for not needing
 # to cast them in assertions to match the parsed param types)
-THUMBNAIL_WIDTH_PX = config("THUMBNAIL_WIDTH_PX", default="600")
+THUMBNAIL_WIDTH_PX = config("THUMBNAIL_WIDTH_PX", default="600", cast=int)
 THUMBNAIL_QUALITY = config("THUMBNAIL_JPG_QUALITY", default="80")
 
 # The length of time to cache repeated thumbnail failures
@@ -36,4 +36,9 @@ THUMBNAIL_UPSTREAM_TIMEOUT = config("THUMBNAIL_UPSTREAM_TIMEOUT", default=4, cas
 # Timeout when trying to determine the filetype based on a HEAD request to the upstream image provider
 THUMBNAIL_EXTENSION_REQUEST_TIMEOUT = config(
     "THUMBNAIL_EXTENSION_REQUEST_TIMEOUT", default=4, cast=int
+)
+
+# Use Wikimedia's thumbnail endpoint when requesting thumbnails from Site Accelerator (formerly Photon)
+USE_WIKIMEDIA_THUMBNAIL_ENDPOINT = config(
+    "USE_WIKIMEDIA_THUMBNAIL_ENDPOINT", default=True, cast=bool
 )

--- a/api/test/factory/models/image.py
+++ b/api/test/factory/models/image.py
@@ -2,6 +2,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from api.models.image import DeletedImage, Image, ImageReport, SensitiveImage
+from test.factory.faker import Faker
 from test.factory.models.media import MediaFactory, MediaReportFactory
 
 
@@ -24,6 +25,9 @@ class ImageFactory(MediaFactory):
 
     class Meta:
         model = Image
+
+    width = Faker("random_element", elements=(100, 1200, 2500))
+    height = Faker("random_element", elements=(100, 1200, 2500))
 
 
 class ImageReportFactory(MediaReportFactory):

--- a/api/test/factory/models/media.py
+++ b/api/test/factory/models/media.py
@@ -53,7 +53,7 @@ class MediaFactory(DjangoModelFactory):
     """The foreign identifier isn't necessarily a UUID but for test purposes it's fine if it looks like one"""
 
     license = Faker("random_element", elements=ALL_LICENSES)
-    provider = Faker("random_element", elements=("wikimedia", "flickr"))
+    provider = Faker("random_element", elements=("flickr", "stocksnap"))
 
     foreign_landing_url = Faker("globally_unique_url")
     url = Faker("globally_unique_url")

--- a/api/test/unit/views/test_image_views.py
+++ b/api/test/unit/views/test_image_views.py
@@ -43,6 +43,7 @@ def test_thumbnail_uses_upstream_thumb_for_smk(
 ):
     thumb_url = "http://iip.smk.dk/thumb.jpg" if smk_has_thumb else None
     image = ImageFactory.create(
+        provider="smk",
         url="http://iip.smk.dk/image.jpg",
         thumbnail=thumb_url,
     )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #3075 by @krysal  and #2442 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Wikimedia's thumbnail service supports all file types (as far as I can tell). Therefore, we can use it to generate thumbnails, and then use Site Accel. to proxy and cache the images (to relieve Wikimedia's servers from future thumbnail requests, though they operate their own cache, for what its worth).

The concept behind this PR is to dynamically generate the thumbnail URL to retrieve from Wikimedia, and then pass _that_ to Site Accel. instead of the real URL.

The rationale behind doing this in the API is because these thumbnail URLs need to be constructed at runtime for us to manipulate the parameters for compression and size to fit our needs.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run the API and Airflow locally. You'll use Airflow to ingest some wikimedia images to your local data set so you can test things: `ov j api/init && ov j catalog/init`
2. Open Airflow at localhost:9090 and login in with "airflow" as the username and password.
3. Enable the `wikimedia_commons_workflow`, which should automatically run and let it run until the logs for the `pull_mixed_data` task says it has ingested at least a few hundred records (usually this is pretty quick).
4. Then enable the `image_data_refresh` DAG, which should automatically run
5. You should now have wikimedia works in your API data set. However, you need to enable Wikimedia source for images first. Open the Django admin at localhost:50280/admin and login with "deploy" as username and password. Visit <http://localhost:50280/admin/api/contentsource/add/?source_identifier=wikimedia&source_name=Wikimedia&notes=whatever&media_type=image&domain_name=wikimedia.org> and click "today" and "now" for the time (these aren't setable via the URL params), and save it.
6. Now visit your API image search for wikimedia images and you should see some images: localhost:50280/v1/images/?source=wikimedia
  - Note: if you have used your API before, you may have cached sources. You can flush these by running `ov j api/ipython` and running: `import django_redis; django_redis.get_redis_connection("default").flushall()`.
8. Open the Django logs with `ov j logs web` and visit some of the thumbnail links for the wikimedia images. Confirm you get a thumbnail back, and confirm that in the logs you see `thumbnail_upstream_timing` events with the image_url for the images you are requesting but with `url` set to the site accelerator link with the correctly formatted Wikimedia thumbnail URL according to the pattern outlined in the comments in the `wikimedia.py` module:
  - `web-1  | 2024-08-12T14:48:15.489819Z [info     ] thumbnail_upstream_timing      [api.utils.aiohttp] filename=aiohttp.py func_name=_log_timing image_extension=jpg image_url=https://upload.wikimedia.org/wikipedia/commons/0/05/Antigua_Guatemala_-_Views_33.jpg ip=172.18.0.1 lineno=131 provider=wikimedia request_id=da8e529d-f8b1-4ed4-aaa1-466277ca23b6 status=403 time=0.32870358799846144 url=https://i0.wp.com/upload.wikimedia.org/wikimedia/commons/thumb/0/05/Antigua_Guatemala_-_Views_33.jpg/lossy-600px-Antigua_Guatemala_-_Views_33.jpg.png?ssl=true`
10. Make thumbnail requests with different thumbnail parameters, `full_size=True` and/or `compressed=False` and confirm it works as expected.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
