### PR TITLE
Correct response handling for checking dead links

### DIFF
--- a/api/api/utils/aiohttp.py
+++ b/api/api/utils/aiohttp.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import weakref
 
 import aiohttp
@@ -73,7 +74,64 @@ async def get_aiohttp_session() -> aiohttp.ClientSession:
         logger.info(msg)
 
         if create_session:
-            session = aiohttp.ClientSession()
+            session = aiohttp.ClientSession(trace_configs=[LogTiming()])
             _SESSIONS[loop] = session
 
         return _SESSIONS[loop]
+
+
+class LogTiming(aiohttp.TraceConfig):
+    TIMEOUT_STATUS = -2
+    ERROR_STATUS = -1
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.on_request_start.append(self._start_timing)
+        self.on_request_end.append(self._log_timing)
+        self.on_request_exception.append(self._log_timing)
+
+    async def _start_timing(
+        self,
+        session: aiohttp.ClientSession,
+        trace_config_ctx,
+        params: aiohttp.TraceRequestStartParams,
+    ):
+        trace_config_ctx.start_time = time.perf_counter()
+
+    async def _log_timing(
+        self,
+        session: aiohttp.ClientSession,
+        trace_config_ctx,
+        params: aiohttp.TraceRequestEndParams | aiohttp.TraceRequestExceptionParams,
+    ):
+        """Log timing at end of request or when request results in an exception."""
+
+        if not (
+            trace_config_ctx.trace_request_ctx
+            and "timing_event_name" in trace_config_ctx.trace_request_ctx
+        ):
+            return
+
+        end_time = time.perf_counter()
+        start_time = trace_config_ctx.start_time
+
+        request_ctx = trace_config_ctx.trace_request_ctx
+
+        if hasattr(params, "response"):
+            # request end
+            status = params.response.status
+        elif isinstance(params.exception, aiohttp.ClientResponseError):
+            status = params.exception.status
+        elif isinstance(params.exception, asyncio.TimeoutError):
+            status = self.TIMEOUT_STATUS
+        else:
+            status = self.ERROR_STATUS
+
+        logger.info(
+            request_ctx["timing_event_name"],
+            status=status,
+            time=end_time - start_time,
+            url=str(params.url),
+            **request_ctx.get("timing_event_ctx", {}),
+        )

--- a/api/api/utils/image_proxy/dataclasses.py
+++ b/api/api/utils/image_proxy/dataclasses.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass
+class MediaInfo:
+    media_provider: str
+    media_identifier: UUID
+    image_url: str
+
+
+@dataclass
+class RequestConfig:
+    accept_header: str = "image/*"
+    is_full_size: bool = False
+    is_compressed: bool = True

--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -2,6 +2,8 @@ import mimetypes
 from os.path import splitext
 from urllib.parse import urlparse
 
+from django.conf import settings
+
 import aiohttp
 import django_redis
 import sentry_sdk
@@ -10,18 +12,21 @@ from asgiref.sync import sync_to_async
 from redis.exceptions import ConnectionError
 
 from api.utils.aiohttp import get_aiohttp_session
+from api.utils.image_proxy.dataclasses import MediaInfo
 from api.utils.image_proxy.exception import UpstreamThumbnailException
 
 
 logger = structlog.get_logger(__name__)
 
 
-_HEAD_TIMEOUT = aiohttp.ClientTimeout(10)
+_HEAD_TIMEOUT = aiohttp.ClientTimeout(settings.THUMBNAIL_EXTENSION_REQUEST_TIMEOUT)
 
 
-async def get_image_extension(image_url: str, media_identifier) -> str | None:
+async def get_image_extension(media_info: MediaInfo) -> str | None:
+    image_url = media_info.image_url
+
     cache = django_redis.get_redis_connection("default")
-    key = f"media:{media_identifier}:thumb_type"
+    key = f"media:{media_info.media_identifier}:thumb_type"
 
     ext = _get_file_extension_from_url(image_url)
 
@@ -37,8 +42,16 @@ async def get_image_extension(image_url: str, media_identifier) -> str | None:
         # If the extension is still not present, try getting it from the content type
         try:
             session = await get_aiohttp_session()
-            response = await session.head(image_url, timeout=_HEAD_TIMEOUT)
-            response.raise_for_status()
+            response = await session.head(
+                image_url,
+                raise_for_status=True,
+                timeout=_HEAD_TIMEOUT,
+                trace_request_ctx={
+                    "timing_event_name": "thumbnail_extension_request_timing",
+                    "timing_event_ctx": {"provider": media_info.media_provider},
+                },
+            )
+
             if response.headers and "Content-Type" in response.headers:
                 content_type = response.headers["Content-Type"]
                 ext = _get_file_extension_from_content_type(content_type)

--- a/api/compose.yml
+++ b/api/compose.yml
@@ -53,3 +53,13 @@ services:
       DJANGO_NGINX_UPSTREAM_URL: web:50280
     depends_on:
       - web
+
+  # Used in API unit tests
+  httpbin:
+    profiles:
+      - api
+    # Use go-httpbin because it's only 15 MB compared to upstream HTTPBin's 204 MB
+    # That helps reduce the network burden of spinning up a development environment
+    image: docker.io/mccutchen/go-httpbin:v2.14.0
+    expose:
+      - "8080"

--- a/api/conf/settings/thumbnails.py
+++ b/api/conf/settings/thumbnails.py
@@ -29,3 +29,11 @@ THUMBNAIL_FAILURE_CACHE_WINDOW_SECONDS = config(
 THUMBNAIL_FAILURE_CACHE_TOLERANCE = config(
     "THUMBNAIL_FAILURE_CACHE_TOLERANCE", default=2, cast=int
 )
+
+# Timeout when requesting the thumbnail from the upstream image proxy
+THUMBNAIL_UPSTREAM_TIMEOUT = config("THUMBNAIL_UPSTREAM_TIMEOUT", default=4, cast=int)
+
+# Timeout when trying to determine the filetype based on a HEAD request to the upstream image provider
+THUMBNAIL_EXTENSION_REQUEST_TIMEOUT = config(
+    "THUMBNAIL_EXTENSION_REQUEST_TIMEOUT", default=4, cast=int
+)

--- a/api/test/unit/utils/test_aiohttp.py
+++ b/api/test/unit/utils/test_aiohttp.py
@@ -1,3 +1,9 @@
+import asyncio
+
+import aiohttp
+import pytest
+from structlog.testing import capture_logs
+
 from api.utils.aiohttp import get_aiohttp_session
 
 
@@ -31,3 +37,165 @@ def test_multiple_loops_reuse_separate_sessions(get_new_loop):
 
     assert loop_1_session_1 is loop_1_session_2
     assert loop_2_session_1 is loop_2_session_2
+
+
+def test_log_timing_trace_config_ignored_if_event_name_undefined(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get("http://httpbin:8080/status/202")
+        )
+
+    assert len(logs) == 0
+
+
+_EXPECTED_BASE_CTX = {"url", "status", "time"}
+
+
+def test_log_timing_trace_config_no_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "no_request_ctx_timing_event_test"
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://httpbin:8080/status/202",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == 202
+    assert log_event["url"] == "http://httpbin:8080/status/202"
+
+
+def test_log_timing_trace_config_empty_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "empty_request_ctx_timing_event_test"
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://httpbin:8080/status/202",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                    "timing_event_ctx": {},
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == 202
+    assert log_event["url"] == "http://httpbin:8080/status/202"
+
+
+def test_log_timing_trace_config_with_request_ctx(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "empty_request_ctx_timing_event_test"
+    event_ctx = {
+        "amazing_info": "hello_test",
+        "helpful_info": "so cool",
+    }
+
+    with capture_logs() as logs:
+        session_loop.run_until_complete(
+            aiohttp_session.get(
+                "http://httpbin:8080/status/202",
+                trace_request_ctx={
+                    "timing_event_name": event_name,
+                    "timing_event_ctx": event_ctx,
+                },
+            )
+        )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == 202
+    assert log_event["url"] == "http://httpbin:8080/status/202"
+
+    log_event_items = log_event.items()
+    for event_ctx_item in event_ctx.items():
+        assert event_ctx_item in log_event_items
+
+
+def test_log_timing_trace_config_response_exception(session_loop, monkeypatch):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "response_exception_timing_event_test"
+
+    with capture_logs() as logs:
+        with pytest.raises(aiohttp.ClientResponseError):
+            session_loop.run_until_complete(
+                aiohttp_session.get(
+                    "http://httpbin:8080/status/400",
+                    # raise for status coerces a client response error within the tracing context
+                    raise_for_status=True,
+                    trace_request_ctx={
+                        "timing_event_name": event_name,
+                    },
+                )
+            )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == 400
+    assert log_event["url"] == "http://httpbin:8080/status/400"
+
+
+def test_log_timing_trace_config_runtime_exception(session_loop, monkeypatch):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "runtime_exception_timing_event_test"
+
+    with capture_logs() as logs:
+        with pytest.raises(aiohttp.InvalidURL):
+            session_loop.run_until_complete(
+                aiohttp_session.get(
+                    # The malformed URL will raise an error when the client tries to parse
+                    # the URL to redirect to
+                    "http://httpbin:8080/redirect-to",
+                    params={"url": "//:@/"},
+                    allow_redirects=True,
+                    trace_request_ctx={
+                        "timing_event_name": event_name,
+                    },
+                )
+            )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == -1
+    assert log_event["url"] == "http://httpbin:8080/redirect-to?url=//:@/"
+
+
+def test_log_timing_trace_config_timeout(session_loop):
+    aiohttp_session = session_loop.run_until_complete(get_aiohttp_session())
+
+    event_name = "empty_request_ctx_timing_event_test"
+
+    with capture_logs() as logs:
+        with pytest.raises(asyncio.TimeoutError):
+            session_loop.run_until_complete(
+                aiohttp_session.get(
+                    "http://httpbin:8080/delay/4",
+                    timeout=aiohttp.ClientTimeout(1),
+                    trace_request_ctx={
+                        "timing_event_name": event_name,
+                    },
+                )
+            )
+
+    log_event = next(log for log in logs if log["event"] == event_name)
+
+    assert _EXPECTED_BASE_CTX & log_event.keys() == _EXPECTED_BASE_CTX
+    assert log_event["status"] == -2
+    assert log_event["url"] == "http://httpbin:8080/delay/4"


### PR DESCRIPTION
Reverts WordPress/openverse#4746

I'll copy my explanation of why `raise_for_status` caused the issue from our incident report here:

> As [Staci] noted, we added `raise_for_status` in the check dead links HEAD request. This caused non 2xx responses to raise a ClientResponseError. These are caught with ClientError. But the except block in the function calls logger.error with the exception object. Adding raise_for_status incorrectly classified dead link responses as errors rather than expected responses that we wanted to catch. The except block is only written to handle unintentional errors, i.e., errors in making the request at the networking level, rather than the response we receive. That’s why it catches ClientError instead of specifically ClientResponseError. The latter is raised for “bad” status codes when raise_for_status=True. We don’t want that, so we shouldn’t have set raise_for_status=True, and we missed the significance of this change during review. Simply removing raise_for_status=True will resolve the issue so that any response from upstream has their status code used regardless of if it’s a “bad” one, and only errors in making the request will raise when calling head.

This PR removes that line and adds an explanation for how to understand the error handling of that particular method. It comes down to the fact that any status code from upstream is useful information for dead link checking, but broken networking is something we need to be made aware of in the error logs.

As noted in the incident report, the issue with multiple Sentry issues created for this has the same root cause addressed by https://github.com/WordPress/openverse/pull/4704, which we should also prioritise reviewing and getting merged.