### PR TITLE
Switch to locally available prettier for pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,18 +53,6 @@ repos:
           - --fix
       - id: ruff-format # replaces Black
 
-  # Use the `.prettierignore` and `.prettier.config.js` files to configure project-specific requirements.
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        # Must include any plugins defined in prettier.config.js, along with TypeScript and Prettier themselves
-        # Versions must be manually kept in sync with those in the pnpm-lock.yaml file to prevent drift.
-        additional_dependencies:
-          - prettier@3.3.3
-          - prettier-plugin-tailwindcss@0.6.5
-          - typescript@5.5.4
-
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.10.0
     hooks:
@@ -122,6 +110,13 @@ repos:
         entry: bash -c 'pnpm run prepare:nuxt && pnpm run -r types'
         language: system
         pass_filenames: false
+
+      - id: prettier
+        name: prettier
+        "types": [text]
+        language: system
+        pass_filenames: true
+        entry: pnpm exec prettier --write --ignore-unknown
 
       - id: eslint
         name: eslint

--- a/justfile
+++ b/justfile
@@ -77,6 +77,8 @@ install:
 # Install `ov`-based git hooks
 @install-hooks:
     bash -c "cp ./docker/dev_env/hooks/* ./.git/hooks"
+    # Run pnpm install to ensure eslint and prettier are available
+    pnpm install
 
 # Create an `.ov_profile.json` as a starting point for development environment customisation. Does not make changes if the file already exists.
 init-ov-profile:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4256 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
As discussed in the linked issue, this PR switches to using the locally available prettier for the pre-commit check.

I've configured it to match how the pre-commit hook worked, including `--ignore-unknown` so that prettier doesn't complain about being passed files it doesn't have a parser for.

Incidentally, we no longer need to reproduce the list of prettier dependencies in the pre-commit file, so I really think this is better overall for the maintainability of our prettier usage anyway.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass of course.

Checkout the branch and make changes to markdown files or JavaScript files, any file Prettier should format. Then try to commit those and confirm that the pre-commit hook works as expected: it prevents the commit and writes the changes to disk, just like the old hook did.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
