### PR TITLE
Add dependencies necessary for cffi installation to dev environment

### DIFF
--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -31,6 +31,8 @@ ENV PATH="${PNPM_BIN}:${N_PREFIX}/bin:${PDM_PYTHONS}:${HOME}/.local/bin:${PATH}"
 # - just: command runner
 # - jq: JSON processor
 # - which: locate a program file in `PATH`
+# - python*: required by some Python libraries for compilation during installation
+# - libffi*: required for the Python package cffi
 # - pipx: Python CLI app installer
 # - nodejs: language runtime (includes npm but not Corepack)
 # - docker*: used to interact with host Docker socket
@@ -55,7 +57,8 @@ RUN mkdir /pipx \
     jq \
     which \
     nodejs npm \
-    python3.12 pipx \
+    python3.12 python3.12-devel pipx \
+    libffi-devel \
     docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
     unzip \
     postgresql postgresql-devel \


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This PR addresses an issue where `ov just install` was unable to complete successfully due to missing libraries within `ov`:

```
INFO: python.use_venv is on, creating a virtualenv for this project...
Virtualenv is created successfully at /opt/.local/share/pdm/venvs/python-pdZ_qQeR-3.12
Synchronizing working set with resolved packages: 37 to add, 0 to update, 0 to remove

  ✔ Install idna 3.7 successful
  ✔ Install asttokens 2.4.1 successful
  ✔ Install pexpect 4.9.0 successful
  ✔ Install pure-eval 0.2.2 successful
  ✔ Install matplotlib-inline 0.1.7 successful
  ✔ Install pycparser 2.22 successful
  ✔ Install mechanize 0.4.10 successful
  ✔ Install decorator 5.1.1 successful
  ✔ Install ptyprocess 0.7.0 successful
  ✔ Install parso 0.8.4 successful
  ✔ Install pyjwt 2.8.0 successful
  ✔ Install prompt-toolkit 3.0.47 successful
  ✔ Install deprecated 1.2.14 successful
  ✔ Install charset-normalizer 3.3.2 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install six 1.16.0 successful
  ✔ Install beautifulsoup4 4.12.3 successful
  ✔ Install soupsieve 2.5 successful
  ✔ Install ipython 8.26.0 successful
  ✔ Install cryptography 42.0.8 successful
  ✔ Install webencodings 0.5.1 successful
  ✔ Install wcwidth 0.2.13 successful
  ✔ Install stack-data 0.6.3 successful
  ✔ Install traitlets 5.14.3 successful
  ✔ Install pyotp 2.9.0 successful
  ✔ Install certifi 2024.7.4 successful
  ✔ Install html5lib 1.1 successful
  ✔ Install pygithub 2.3.0 successful
  ✔ Install wrapt 1.16.0 successful
  ✔ Install jedi 0.19.1 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install urllib3 2.2.2 successful
  ✔ Install pynacl 1.5.0 successful
  ✔ Install executing 2.0.1 successful
  ✔ Install pygments 2.18.0 successful
  ✖ Install cffi 1.16.0 failed
  ✔ Install pyyaml 6.0.1 successful
  ✖ Install cffi 1.16.0 failed

ERRORS:
add cffi failed:
Traceback (most recent call last):
  File "/usr/lib64/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/installers/synchronizers.py", line 228, in install_candidate
    self.manager.install(can)
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/installers/manager.py", line 33, in install
    prepared.build(),
    ^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/models/candidates.py", line 406, in build
    self._cached = Path(builder.build(build_dir, metadata_directory=self._metadata_dir))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/builders/base.py", line 84, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/builders/wheel.py", line 26, in build
    filename = self._hook.build_wheel(out_dir, self.config_settings, metadata_directory)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pyproject_hooks/_impl.py", line 256, in build_wheel
    return self._call_hook(
           ^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pyproject_hooks/_impl.py", line 392, in _call_hook
    self._subprocess_runner(
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/builders/base.py", line 281, in subprocess_runner
    return log_subprocessor(cmd, cwd, extra_environ=env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pipx/venvs/pdm/lib64/python3.12/site-packages/pdm/builders/base.py", line 128, in log_subprocessor
    raise build_error(e) from None
pdm.exceptions.BuildError: Build backend raised error: Showing the last 10 lines of the build output:
running build
running build_py
running build_ext
building '_cffi_backend' extension
gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -fPIC -DFFI_BUILDING=1 -DUSE__THREAD 
-DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/opt/.local/share/pdm/venvs/python-pdZ_qQeR-3.12/include -I/usr/include/python3.12 -c src/c/_cffi_backend.c -o 
build/temp.linux-x86_64-cpython-312/src/c/_cffi_backend.o
src/c/_cffi_backend.c:2:10: fatal error: Python.h: No such file or directory
    2 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
error: command '/usr/bin/gcc' failed with exit code 1

  ✖ Some package operations failed. 1/1 0:00:09
See /opt/.local/state/pdm/log/pdm-install-jbyqh0ix.log for detailed debug log.
[InstallationError]: Some package operations failed.
WARNING: Add '-v' to see the detailed traceback
error: Recipe `install` failed on line 15 with exit code 1
error: Recipe `py-install` failed on line 69 with exit code 1
error: Recipe `install` failed on line 75 with exit code 1
```

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds the necessary libraries (`python3.12-devel` and `libffi-devel`) to the `ov` image in order to allow installation to run successfully.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run `ov build` then `ov just install` and ensure that the `pipx` install command completes successfully.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
