### PR TITLE
Do not logger.error timeout errors in dead link checks

### DIFF
--- a/api/test/unit/utils/test_check_dead_links.py
+++ b/api/test/unit/utils/test_check_dead_links.py
@@ -82,7 +82,7 @@ def test_handles_error(monkeypatch):
     # so should not appear in the final list of results.
     assert len(results) == 0
 
-    # A timeout should not get logged as an error
+    # A non-timeout exception should get logged as an error
     log_event = next((log for log in logs if log["log_level"] == "error"), None)
     assert log_event is not None
 

--- a/api/test/unit/utils/test_check_dead_links.py
+++ b/api/test/unit/utils/test_check_dead_links.py
@@ -2,9 +2,9 @@ import asyncio
 from collections.abc import Callable
 from typing import Any
 
+import aiohttp
 import pook
 import pytest
-from aiohttp.client import ClientSession
 from elasticsearch_dsl.response import Hit
 from structlog.testing import capture_logs
 
@@ -44,12 +44,6 @@ def test_sends_user_agent():
 
 
 def test_handles_timeout(monkeypatch):
-    """
-    Test that case where timeout occurs.
-
-    Note: This test takes just over 3 seconds to run as it simulates network delay of
-    3 seconds.
-    """
     query_hash = "test_handles_timeout"
     results = _make_hits(1)
     start_slice = 0
@@ -57,13 +51,40 @@ def test_handles_timeout(monkeypatch):
     async def raise_timeout_error(*args, **kwargs):
         raise asyncio.TimeoutError()
 
-    monkeypatch.setattr(ClientSession, "_request", raise_timeout_error)
-    check_dead_links(query_hash, start_slice, results)
+    monkeypatch.setattr(aiohttp.ClientSession, "_request", raise_timeout_error)
+    with capture_logs() as logs:
+        check_dead_links(query_hash, start_slice, results)
 
     # `check_dead_links` directly modifies the results list
     # if the results are timing out then they're considered dead and discarded
     # so should not appear in the final list of results.
     assert len(results) == 0
+
+    # A timeout should not get logged as an error
+    log_event = next((log for log in logs if log["log_level"] == "error"), None)
+    assert log_event is None
+
+
+def test_handles_error(monkeypatch):
+    query_hash = "test_handles_timeout"
+    results = _make_hits(1)
+    start_slice = 0
+
+    async def raise_nontimeout_error(*args, **kwargs):
+        raise aiohttp.InvalidURL("https://invalid-url")
+
+    monkeypatch.setattr(aiohttp.ClientSession, "_request", raise_nontimeout_error)
+    with capture_logs() as logs:
+        check_dead_links(query_hash, start_slice, results)
+
+    # `check_dead_links` directly modifies the results list
+    # if the results are erroring out then they're considered dead and discarded
+    # so should not appear in the final list of results.
+    assert len(results) == 0
+
+    # A timeout should not get logged as an error
+    log_event = next((log for log in logs if log["log_level"] == "error"), None)
+    assert log_event is not None
 
 
 @pook.on


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse/pull/4748

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
https://github.com/WordPress/openverse/pull/4748 missed another critical issue in the error handling of the dead link validation routine, which is that we only want to log non-timeout errors. As explained in the comment I've added, timeouts are somewhat expected, and are not errors we can do anything about and do not need to be reported to Sentry. We have other methods of visibility into them (especially with the new timing logs).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Unit tests should pass.

If you lower the timeout for dead link checks by setting `LINK_VALIDATION_TIMEOUT_SECONDS` to something like 0.2 seconds, and then run a query locally with `filter_dead=True`, you should _not_ see errors logged for those timeouts, just the timing logs.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
