### PR TITLE
Fix DAG docstrings so they no longer produce improper HTML

### DIFF
--- a/catalog/dags/maintenance/airflow_log_cleanup_workflow.py
+++ b/catalog/dags/maintenance/airflow_log_cleanup_workflow.py
@@ -16,8 +16,8 @@ airflow dags trigger --conf
 '{"maxLogAgeInDays":-1, "enableDelete": "false"}' airflow_log_cleanup
 ```
 `--conf` options:
-- maxLogAgeInDays:<INT> - Optional
-- enableDelete:<BOOLEAN> - Optional
+- maxLogAgeInDays: int, optional
+- enableDelete: bool, optional
 """
 
 from datetime import datetime, timedelta

--- a/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -42,8 +42,8 @@ the property sub-pages using the "continue" token
 Depending on the kind of property data that's being returned, it's possible for the API
 to iterate extensively on a specific media item. What Wikimedia is iterating over in
 these cases can be gleaned from the "continue" token. Those tokens take the form of,
-as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
-"<XX>continue" value for the property being iterated over. For example, if we're
+as I understand it, `<primary-iterator>||<next-iteration-prop>`, paired with an
+`<XX>continue` value for the property being iterated over. For example, if we're
 were iterating over a set of image properties, the token might look like:
 
 ```

--- a/documentation/catalog/reference/DAGs.md
+++ b/documentation/catalog/reference/DAGs.md
@@ -228,8 +228,8 @@ airflow dags trigger --conf
 
 `--conf` options:
 
-- maxLogAgeInDays:<INT> - Optional
-- enableDelete:<BOOLEAN> - Optional
+- maxLogAgeInDays: int, optional
+- enableDelete: bool, optional
 
 ----
 
@@ -1159,7 +1159,7 @@ Depending on the kind of property data that's being returned, it's possible for
 the API to iterate extensively on a specific media item. What Wikimedia is
 iterating over in these cases can be gleaned from the "continue" token. Those
 tokens take the form of, as I understand it,
-"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
+`<primary-iterator>||<next-iteration-prop>`, paired with an `<XX>continue` value
 for the property being iterated over. For example, if we're were iterating over
 a set of image properties, the token might look like:
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4750 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes a few instances of brackets within the DAG docstrings that would produce invalid HTML in the resulting document that gets rendered for the documentation site.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the following, and HTML should be output (without raising any errors):

1. `ov just documentation/live`
1. `ov pnpm exec prettier documentation/_serve/catalog/reference/DAGs.html`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
