### PR TITLE
Fix or ignore deprecation warnings in the catalog

### DIFF
--- a/catalog/dags/common/storage/columns.py
+++ b/catalog/dags/common/storage/columns.py
@@ -31,7 +31,7 @@ class UpsertStrategy(Enum):
     merge_jsonb_arrays = auto()
     merge_array = auto()
     merge_tags = auto()
-    no_change = ()
+    no_change = auto()
     calculate_value = auto()
 
 

--- a/catalog/pytest.ini
+++ b/catalog/pytest.ini
@@ -33,7 +33,7 @@ addopts =
 filterwarnings=
     ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning
     ignore:datetime.datetime.utcnow:DeprecationWarning:botocore
-    ignore:__version__:DeprecationWarning:marshmallow_sqlalchemy
+    ignore::DeprecationWarning:marshmallow.*
 
 # Change the pytest cache location since Docker cannot write within the module file
 # structure due to permissions issues

--- a/catalog/pytest.ini
+++ b/catalog/pytest.ini
@@ -23,11 +23,17 @@ addopts =
 #   https://docs.sqlalchemy.org/en/20/errors.html#error-b8d9
 #   Warning in dependency, nothing we can do
 #   "removed"/"remoevd" is due to https://github.com/pallets/flask
-# distutils
+# botocore
+#   https://github.com/boto/boto3/issues/3889
 #   Warning in dependency, nothing we can do
+# marshmallow_sqlalchemy
+#   https://github.com/marshmallow-code/marshmallow/issues/2227
+#   Upstream dependency is fixed but Airflow constraints are keeping us on an
+#   older version
 filterwarnings=
     ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning
-    ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
+    ignore:datetime.datetime.utcnow:DeprecationWarning:botocore
+    ignore:__version__:DeprecationWarning:marshmallow_sqlalchemy
 
 # Change the pytest cache location since Docker cannot write within the module file
 # structure due to permissions issues


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR addresses the following deprecation warnings that appear when running the catalog's tests.

```
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
dags/common/storage/columns.py:33
  /opt/airflow/catalog/dags/common/storage/columns.py:33: DeprecationWarning: In 3.13 the default `auto()`/`_generate_next_value_` will require all values to be sortable and support adding +1
  and the value returned will be the largest value in the enum incremented by 1
    calculate_value = auto()

tests/dags/common/loader/test_sql.py: 87 warnings
tests/dags/providers/provider_api_scripts/test_inaturalist.py: 1 warning
tests/dags/common/loader/test_s3.py: 34 warnings
  /home/airflow/.local/lib/python3.12/site-packages/botocore/auth.py:419: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

tests/dags/common/loader/test_s3.py::test_get_staged_s3_object_finds_object_with_defaults
tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_fails_if_external_dag_missing_sensor_task
  /home/airflow/.local/lib/python3.12/site-packages/marshmallow_sqlalchemy/convert.py:17: DeprecationWarning: The '__version__' attribute is deprecated and will be removed in in a future version. Use feature detection or 'importlib.metadata.version("marshmallow")' instead.
    _META_KWARGS_DEPRECATED = Version(ma.__version__) >= Version("3.10.0")
```

The first one is actually resolvable, the latter two just need to be ignored for now.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out `main` and run `ov just catalog/test` and observe the warnings at the end of the output
1. Check out this branch and run the same and observe that they are no longer present


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
