### PR TITLE
fix: Reduce timeouts for batched update

### DIFF
--- a/catalog/dags/database/batched_update/constants.py
+++ b/catalog/dags/database/batched_update/constants.py
@@ -8,9 +8,9 @@ SLACK_USERNAME = "Upstream Batched Update"
 SLACK_ICON = ":database:"
 
 DEFAULT_BATCH_SIZE = 10_000
-DAGRUN_TIMEOUT = timedelta(days=31 * 3)
 SELECT_TIMEOUT = timedelta(hours=24)
-UPDATE_TIMEOUT = timedelta(days=30 * 3)  # 3 months
+UPDATE_TIMEOUT = timedelta(days=30)  # 1 month
+DAGRUN_TIMEOUT = UPDATE_TIMEOUT + SELECT_TIMEOUT
 
 # Task IDs used for branching operator
 GET_EXPECTED_COUNT_TASK_ID = "get_expected_update_count"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4814 by @AetherUnbound 

## Description
This PR reduces `UPDATE_TIMEOUT` to 30 days and sets `DAGRUN_TIMEOUT` to the sum of `UPDATE_TIMEOUT` and `SELECT_TIMEOUT`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [X] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [X] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
