### PR TITLE
Fix `add_license_url` DAG for last items

### DIFF
--- a/catalog/dags/maintenance/add_license_url.py
+++ b/catalog/dags/maintenance/add_license_url.py
@@ -136,7 +136,7 @@ def get_license_conf(license_info) -> dict:
             f"AND meta_data->>'license_url' IS NULL"
         ),
         # Merge existing metadata with the new license_url
-        "update_query": f"SET updated_on = NOW(), meta_data = ({Json(license_url_dict)}::jsonb || meta_data)",
+        "update_query": f"SET updated_on = NOW(), meta_data = (meta_data || {Json(license_url_dict)}::jsonb)",
         "update_timeout": 259200,  # 3 days in seconds
         "dry_run": False,
         "resume_update": False,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4318 by @krysal 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
When checking on a few items remaining, I noticed the `license_url` was already present in the `meta_data` column with the value of `NULL`. These caused the DAG to have virtually no effect on how the update statement was written; at the merge, the `NULL` value replaced the actual value. Fortunately, this has an easy fix.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Download [this CSV](https://gist.github.com/krysal/1ccc4c2f4c963596581638758d69bdf1)  of sample rows
2. Load it into the catalog DB 
	1. Copy the file into the upstream DB container: `docker cp /path/to/images_missing_md_license_url.csv [container-id]:/tmp/sample_rows.csv`
	2. Connect with pgcli: `just catalog/pgcli`
	3. Import the file into the table: `COPY image FROM '/tmp/sample_rows.csv' DELIMITER ',' CSV HEADER;`
4. Enable the `batched_update` DAG and run the `add_license_url` DAG
5. Wait for completion and check the DB, the returned number should be 0:
```sql
SELECT COUNT(*) FROM image WHERE meta_data->>'license_url' IS NULL;
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`ov just catalog/generate-docs media-props` for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
