### PR TITLE
Fix handful of networking issues including silence errors

### DIFF
--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -87,9 +87,15 @@ class ImageViewSet(MediaViewSet):
 
         if not (image.height and image.width):
             session = await get_aiohttp_session()
-            image_file = await session.get(image.url, headers=self.OEMBED_HEADERS)
-            image_content = await image_file.content.read()
-            width, height = PILImage.open(io.BytesIO(image_content)).size
+
+            async with session.get(
+                image.url, headers=self.OEMBED_HEADERS
+            ) as image_file:
+                image_content = await image_file.content.read()
+
+            with PILImage.open(io.BytesIO(image_content)) as image_file:
+                width, height = image_file.size
+
             context |= {
                 "width": width,
                 "height": height,
@@ -209,3 +215,5 @@ class ImageViewSet(MediaViewSet):
             pil_img.save(destination, "jpeg", exif=exif_bytes)
         else:
             pil_img.save(destination, "jpeg")
+
+        pil_img.close()

--- a/api/test/unit/utils/test_check_dead_links.py
+++ b/api/test/unit/utils/test_check_dead_links.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -49,7 +48,7 @@ def test_handles_timeout(monkeypatch):
     start_slice = 0
 
     async def raise_timeout_error(*args, **kwargs):
-        raise asyncio.TimeoutError()
+        raise aiohttp.ServerTimeoutError()
 
     monkeypatch.setattr(aiohttp.ClientSession, "_request", raise_timeout_error)
     with capture_logs() as logs:

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import replace
 from urllib.parse import urlencode
 from uuid import uuid4
@@ -263,8 +264,11 @@ def test_get_successful_forward_query_params(mock_image_data):
 @pytest.fixture
 def setup_request_exception(monkeypatch):
     def do(exc):
+        # ClientSession.get returns a context manager
+        @contextlib.asynccontextmanager
         async def raise_exc(*args, **kwargs):
             raise exc
+            yield
 
         monkeypatch.setattr(aiohttp.ClientSession, "get", raise_exc)
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4774 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Okay, this is a bit of a big one. We can split it up, but I'm running out of time before I need to end working for the week, and I needed to get this all down at least somewhere. The changes here (except the PIL ones) are all related to the linked issue, either by just ignoring the errors as non-actionable the way we discussed, or by actually fixing some of them (hopefully).

The main difference there being the refactor to treat aiohttp client responses as async context managers. This, apparently, is necessary when using aiohttp. I wrote the original code that introduced aiohttp, and I don't know how I missed this, or how the application was able to keep working so long with it missed, especially in such heavily trafficked endpoints like the thumbnail. In any case, I believe this is the root cause of the RuntimeErrors we've seen persistently. They "went away" for a while, but only because we stopped logging them. I was really worried about silencing them again, so spent some time pouring over the issues list for aiohttp, uvloop, uvicorn, httpx (to compare), asgiref, and django. I came up with nothing, and then sort of _randomly_ read some of the aiohttp code trying to understand the request flow better... and yeah, noticed that it returns a context manager from `get` (et co). The docs also say this rather clearly if you read the client reference, but do _not_ on the quickstart (and some instances of network calls just use await without closing).

[This section, for example, does not use async with, just await](https://docs.aiohttp.org/en/v3.9.1/client_quickstart.html#post-a-multipart-encoded-file).

[But if you look here, on the actual `get` method's docs, it's clear about returning a context manager that needs closing](https://docs.aiohttp.org/en/v3.9.1/client_reference.html#aiohttp.ClientSession.get).

So anyway, we got away with it for a long time, but hopefully this fixes it! It certainly makes sense that not using the context manager there would cause weird state issues with the client session being open but the underlying transport being closed and not recycled.

The rest of the changes around the aiohttp code are to get at the rest of the errors described by the issue, the ones we feel are non-actionable. I'm not entirely sure I agree with the list, and if we had more time, I would like to spend it looking at `ClientOSError` in particular. But we don't have time, and considering we're hopefully fixing a large portion of errors that otherwise did not need to happen, I'm fine going forward with this list as "non-actionable". I've made it clear in the comments on the lists of non-actionable exception classes that we might change how we approach this in the future. So this isn't closing any doors.

Finally, when looking at the context manager bits, I realised there were PIL Image objects never getting closed. They are only used in the oembed and watermark endpoints, both of which are known to be underused. Nevertheless, this should fix whatever small potential memory leak might have come about through that.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass. It took a while to get tests in a good state again, but only because the tests themselves are somewhat complex and obscure the underlying errors. The image_proxy.get function's tendency to just swallow errors makes debugging failing tests really difficult.

Test the following routes by visiting them on your local computer, after running `ov just api/up`:

- image and audio search (test with and without `filter_dead=true`)
- thumbnails
- watermark
- oembed

All of these should return correct responses without errors.

Lastly, try to think of places where there might be dangling context managers, not necessarily to add to this PR, but to open issues to follow up for. If you search the codebase and find any aiohttp references that aren't doing this correctly, we should include them here, I think.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
