### PR TITLE
Create S3 client for smart_open from session

### DIFF
--- a/catalog/dags/data_augmentation/rekognition/add_rekognition_labels.py
+++ b/catalog/dags/data_augmentation/rekognition/add_rekognition_labels.py
@@ -76,7 +76,9 @@ def parse_and_insert_labels(
         deserialize_json=True,
     )
 
-    s3_client = S3Hook(aws_conn_id=AWS_CONN_ID).get_client_type("s3")
+    # Create the client from the session so that Airflow doesn't override any
+    # defaults we want on the S3 client
+    s3_client = S3Hook(aws_conn_id=AWS_CONN_ID).get_session().client("s3")
     with smart_open.open(
         f"{s3_bucket}/{s3_prefix}",
         transport_params={"buffer_size": file_buffer_size, "client": s3_client},

--- a/catalog/dags/data_augmentation/rekognition/add_rekognition_labels.py
+++ b/catalog/dags/data_augmentation/rekognition/add_rekognition_labels.py
@@ -55,7 +55,12 @@ def _insert_tags(tags_buffer: types.TagsBuffer, postgres_conn_id: str):
         postgres_conn_id=postgres_conn_id,
         default_statement_timeout=constants.INSERT_TIMEOUT,
     )
-    postgres.insert_rows(constants.TEMP_TABLE_NAME, tags_buffer, executemany=True)
+    postgres.insert_rows(
+        constants.TEMP_TABLE_NAME,
+        tags_buffer,
+        executemany=True,
+        replace=True,
+    )
 
 
 @task(trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Problem
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

When I kicked of the Rekognition DAG in production, we saw the following exception:

```
botocore.exceptions.SSLError: SSL validation failed for https://migrated-cccatalog-archives.s3.s3.amazonaws.com/kafka/image_analysis_labels-2020-12-17.txt hostname 'migrated-cccatalog-archives.s3.s3.amazonaws.com' doesn't match either of '*.s3.amazonaws.com', 's3.amazonaws.com'
```

Upon investigating the internals of the `S3Hook`, it looked like the `get_client_type` call was explicitly setting the `endpoint_url` for the `s3` client to be `s3.amazonaws.com`, which something (either `smart_open` or `boto3` itself) was _also_ tacking on another `s3` after the bucket name. 

https://github.com/apache/airflow/blob/1da4b146e954f78280dbe7bbbef452d58c8f728c/airflow/providers/amazon/aws/hooks/base_aws.py#L704

We didn't identify this sooner because we weren't using the production URL and didn't have any trouble when interacting with Minio on this front.

## Description

This PR fixes this issue by using the `S3Hook::get_session` method and creating the `s3` client _from that instead_, without explicitly setting any extra defaults. I tested this locally with the production S3 file and I was able to reproduce the original error, then verity that this change fixed the issue.

In local testing I also ran into an issue where there appeared to be multiple labels for a single ID:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "rekognition_label_insertion_identifier_idx"
DETAIL:  Key (identifier)=(262c626a-a714-4cd3-8159-abc54305d26e) already exists.
```

I've changed the insert SQL to use `replace=True` so that these conflicts are just replaced wholesale rather than raising an exception.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

**Maintainers only**

1. Set up a new AWS connection in your `.env` which points to production (I had mine set to `AIRFLOW_CONN_AWS_PROD`)
2. Remove any override you have in your `.env` for `AIRFLOW_VAR_REKOGNITION_DATASET_PREFIX` (so the prod default is used)
3. Alter the connection ID on L79 to use `"aws_prod"` rather than `AWS_CONN_ID`
4. Kick off the `add_rekognition_labels` DAG - if you're on `main`, this should fail with the above exception, if you're on this branch it should pass and processing should continue! (you can also add an `if total_processed > 2000: break` line in the `while` loop to prevent processing from running away)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
