### PR TITLE
Fix unbound access of `log` (when the captured exception is a timeout)

### DIFF
--- a/api/api/utils/image_proxy/extension.py
+++ b/api/api/utils/image_proxy/extension.py
@@ -91,7 +91,7 @@ async def get_image_extension(media_info: MediaInfo) -> str | None:
                 else:
                     log = logger.error
 
-            log("upstream_thumbnail_exception", exc=exc, exc_info=True)
+                log("upstream_thumbnail_exception", exc=exc, exc_info=True)
 
             raise UpstreamThumbnailException(
                 "Failed to render thumbnail due to inability to check media "

--- a/api/test/unit/utils/test_image_proxy.py
+++ b/api/test/unit/utils/test_image_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 from dataclasses import replace
 from urllib.parse import urlencode
@@ -336,8 +337,8 @@ MOCK_CONNECTION_KEY = ConnectionKey(
             "aiohttp.client_exceptions.ClientConnectionError",
         ),
         (
-            client_exceptions.ServerTimeoutError("whoops"),
-            "aiohttp.client_exceptions.ServerTimeoutError",
+            asyncio.TimeoutError("whoops"),
+            "builtins.TimeoutError",
         ),
         (
             client_exceptions.ClientSSLError(MOCK_CONNECTION_KEY, OSError()),


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/4888

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
`log` will be unbound if the exception is a timeout error. We intentionally do not log timeouts, as noted in the code comment in this block, so the fix is to ensure `log` is only used when it is bound, which is inside the block guarded by the exception being anything but a timeout error.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Cause a timeout locally by lowering `THUMBNAIL_EXTENSION_REQUEST_TIMEOUT` to something very low, and request a thumbnail. You should not see an exception about the unbound local `log`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
