### PR TITLE
Sign k6 requests with HMAC to enable WAF bypass

### DIFF
--- a/packages/js/k6/package.json
+++ b/packages/js/k6/package.json
@@ -11,8 +11,11 @@
   "author": "Openverse Contributors <openverse@wordpress.org>",
   "license": "MIT",
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/k6": "^0.53.1",
+    "core-js": "^3.37.1",
     "glob": "^11.0.0",
     "rollup": "^4.21.1",
     "typescript": "^5.6.2"

--- a/packages/js/k6/rollup.config.ts
+++ b/packages/js/k6/rollup.config.ts
@@ -7,6 +7,8 @@ import { defineConfig } from "rollup"
 import { glob } from "glob"
 
 import typescript from "@rollup/plugin-typescript"
+import { nodeResolve } from "@rollup/plugin-node-resolve"
+import commonjs from "@rollup/plugin-commonjs"
 
 function getConfig(testFile: string) {
   return defineConfig({
@@ -18,7 +20,7 @@ function getConfig(testFile: string) {
       preserveModules: true,
       preserveModulesRoot: "src",
     },
-    plugins: [typescript()],
+    plugins: [typescript(), nodeResolve(), commonjs()],
   })
 }
 

--- a/packages/js/k6/src/crypto.ts
+++ b/packages/js/k6/src/crypto.ts
@@ -1,0 +1,15 @@
+// Courtesy of @mbforbes via https://gist.github.com/robingustafsson/7dd6463d85efdddbb0e4bcd3ecc706e1?permalink_comment_id=4884925#gistcomment-4884925
+
+import { createHMAC } from "k6/crypto"
+
+import type { Algorithm } from "k6/crypto"
+
+export function sign(
+  data: string | ArrayBuffer,
+  hashAlg: Algorithm,
+  secret: string | ArrayBuffer
+) {
+  const hasher = createHMAC(hashAlg, secret)
+  hasher.update(data)
+  return hasher.digest("base64rawurl")
+}

--- a/packages/js/k6/src/frontend/constants.ts
+++ b/packages/js/k6/src/frontend/constants.ts
@@ -1,2 +1,3 @@
 export const PROJECT_ID = 3713375
-export const FRONTEND_URL = __ENV.FRONTEND_URL || "https://openverse.org/"
+// Default to location of `ov j p frontend prod`
+export const FRONTEND_URL = __ENV.FRONTEND_URL || "http://127.0.0.1:8443/"

--- a/packages/js/k6/src/http.ts
+++ b/packages/js/k6/src/http.ts
@@ -1,0 +1,83 @@
+/**
+ * Wrap k6/http functions to sign requests to allow firewall bypass.
+ */
+
+import {
+  get,
+  post,
+  del,
+  options,
+  head,
+  patch,
+  put,
+  type RequestBody,
+  type RefinedParams,
+  type ResponseType,
+} from "k6/http"
+import { HttpURL } from "k6/experimental/tracing"
+
+// Polyfills URL
+import "core-js/web/url"
+import "core-js/web/url-search-params"
+
+import { sign } from "./crypto"
+
+const signingSecret = __ENV.signing_secret
+
+function getSignedParams<
+  RT extends ResponseType | undefined,
+  P extends RefinedParams<RT>,
+>(url: string | HttpURL, params: P): P {
+  if (!signingSecret) {
+    return params
+  }
+
+  const _url = new URL(url.toString())
+
+  const timestamp = Math.floor(Date.now() / 1000)
+  const resource = `${_url.pathname}${_url.search}${timestamp}`
+  const mac = sign(resource, "sha256", signingSecret)
+
+  return {
+    ...params,
+    headers: {
+      ...(params.headers ?? {}),
+      "x-ov-cf-mac": mac,
+      "x-ov-cf-timestamp": timestamp.toString(),
+    },
+  }
+}
+
+type BodylessHttpFn = typeof get
+type BodiedHttpFn = typeof post
+
+function wrapHttpFunction<F extends BodylessHttpFn | BodiedHttpFn>(fn: F): F {
+  // url is always the first argument, params is always the last argument
+  const urlIdx = 0
+  const paramsIdx = fn.length - 1
+
+  return (<RT extends ResponseType | undefined>(...args: Parameters<F>) => {
+    const signedParams = getSignedParams(
+      args[urlIdx],
+      (args[paramsIdx] as RefinedParams<RT>) ?? {}
+    )
+
+    return paramsIdx === 1
+      ? (fn as BodylessHttpFn)(args[urlIdx], signedParams)
+      : (fn as BodiedHttpFn)(args[urlIdx], args[1] as RequestBody, signedParams)
+  }) as F
+}
+
+/**
+ * Wrapper around k6/http that signs requests with Openverse's
+ * HMAC shared secret, enabling firewall bypass for load testing.
+ */
+export const http = {
+  get: wrapHttpFunction(get),
+  post: wrapHttpFunction(post),
+  del: wrapHttpFunction(del),
+  options: wrapHttpFunction(options),
+  head: wrapHttpFunction(head),
+  put: wrapHttpFunction(put),
+  patch: wrapHttpFunction(patch),
+}

--- a/packages/js/k6/src/utils.ts
+++ b/packages/js/k6/src/utils.ts
@@ -1,6 +1,3 @@
-import { check } from "k6"
-import { type Response } from "k6/http"
-
 // @ts-expect-error https://github.com/grafana/k6-template-typescript/issues/16
 // eslint-disable-next-line import/extensions, import/no-unresolved
 import { randomItem } from "https://jslib.k6.io/k6-utils/1.2.0/index.js"
@@ -13,18 +10,3 @@ const WORDS = open("/usr/share/dict/words")
   .filter((w) => !w.endsWith("'s"))
 
 export const getRandomWord = () => randomItem(WORDS)
-
-export const makeResponseFailedCheck = (param: string, page: string) => {
-  return (response: Response, action: string) => {
-    const requestDetail = `${param ? `for param "${param} "` : ""}at page ${page} for ${action}`
-    if (check(response, { "status was 200": (r) => r.status === 200 })) {
-      console.log(`Checked status 200 ✓ ${requestDetail}.`)
-      return false
-    } else {
-      console.error(
-        `Request failed ⨯ ${requestDetail}: ${response.status}\n${response.body}`
-      )
-      return true
-    }
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,12 +344,21 @@ importers:
 
   packages/js/k6:
     devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^26.0.1
+        version: 26.0.1(rollup@4.21.2)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.21.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.21.2)(tslib@2.6.2)(typescript@5.6.2)
       '@types/k6':
         specifier: ^0.53.1
         version: 0.53.1
+      core-js:
+        specifier: ^3.37.1
+        version: 3.37.1
       glob:
         specifier: ^11.0.0
         version: 11.0.0
@@ -2199,6 +2208,15 @@ packages:
   '@rollup/plugin-commonjs@25.0.8':
     resolution: {integrity: sha512-ZEZWTK5n6Qde0to4vS9Mr5x/0UZoqCxPVR9KRUjU4kA2sO7GEUn1fop0DAwpO6z0Nw/kJON9bDmSxdWxO/TT1A==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-commonjs@26.0.1':
+    resolution: {integrity: sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
@@ -10592,6 +10610,17 @@ snapshots:
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.30.11
+    optionalDependencies:
+      rollup: 4.21.2
+
+  '@rollup/plugin-commonjs@26.0.1(rollup@4.21.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 10.4.5
       is-reference: 1.2.1
       magic-string: 0.30.11
     optionalDependencies:


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse-infrastructure/issues/1031 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds signing requests with an HMAC to enable bypassing WAF rules, so that k6 requests do not get rate limited.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Follow the test instructions in this infrastructure PR: https://github.com/WordPress/openverse-infrastructure/pull/1048

These must be tested together.

You should also be able to run the k6 tests against your local frontend, without passing `-e signing_secret`. Run your frontend with `ov j p frontend prod` and then in another terminal, run the k6 tests:

```shell
ov j k6 frontend static-en -e FRONTEND_URL=https://staging.openverse.org/ -e scenario_vus=1 -e scenario_iterations=1
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
