### PR TITLE
Specify `amd64` platform to fix `ov` builds on macOS

### DIFF
--- a/docker/dev_env/run.sh
+++ b/docker/dev_env/run.sh
@@ -26,6 +26,9 @@ shared_args=(
 run_args=(
   -d
   --name "$container_name"
+  # Since we have build an amd64 image, we must specify the platform to
+  # suppress warnings about platform mismatch.
+  --platform linux/amd64
   # Use host network so things like Sphinx and the frontend that run directly in `ov`
   # will have ports available on the host (and this way we don't have to manually map each one)
   --network host

--- a/ov
+++ b/ov
@@ -92,7 +92,8 @@ init)
   ;;
 
 build)
-  docker build "${@:2}" -t openverse-dev_env:latest "$dev_env"
+  # k6 does not install on aarch64, so we must specify the platform on macOS.
+  docker build "${@:2}" --platform linux/amd64 -t openverse-dev_env:latest "$dev_env"
   ;;
 
 setup-env)


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4931 by @d3jawu

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR specifies `ov` to build and run a Linux amd64 image. This fixes builds breaking on macOS because the k6 RPM repo does not supply aarch64 builds which is the default architecture used unless specified with the `--platform` flag.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Check out the PR.
2. Try to build `ov`: `ov build`
3. Try to initialize `ov`: `ov init`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
