### PR TITLE
Fix content switcher in the search page header

### DIFF
--- a/frontend/src/components/VHeader/VHeaderDesktop.vue
+++ b/frontend/src/components/VHeader/VHeaderDesktop.vue
@@ -98,7 +98,7 @@ const { doneHydrating } = useHydrating()
       </span>
     </VSearchBar>
 
-    <VSearchTypePopover :show-label="isXl" placement="header" />
+    <VSearchTypePopover :show-label="isXl" />
 
     <VFilterButton
       ref="filterButtonRef"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4925 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the bug where the content switcher would keep opening and closing once you click on it.

The cause of this bug is interesting. The `VHeaderDesktop` set the `placement` prop to `VSearchTypePopover` to `header` or `searchbar` to compute whether we should use links or buttons for the different search types. Then, in #4841, the prop was removed from the child `VSearchTypePopover` component as unnecessary. However, it wasn't removed from the parent, `VHeaderDesktop`. This means, that the parent was still passing the `placement`, but now as an `attr`. And in Vue3, an attr will override the prop set in the child component [^1]. The child component was using the same name, `placement`, for the prop to pass to the `floating-ui` library to position the search type popover. The overriden value, `header`, was, however, invalid for the `floating-ui`, so it was causing the constant repositioning of the popover.

[^1]: https://github.com/vuejs/core/issues/9039

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Go to staging, https://staging.openverse.org/search?q=cat and try to open the content switcher in the header. You will see the flickering from the related issue.
Run the app in this branch, and open the content switcher. It will open and close correctly.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
