### PR TITLE
Fix `VSelectField` focus ring

### DIFF
--- a/frontend/src/components/VSelectField/VSelectField.vue
+++ b/frontend/src/components/VSelectField/VSelectField.vue
@@ -84,7 +84,7 @@ const splitAttrs = computed(() => {
     <select
       :id="fieldId"
       v-model="selectValue"
-      class="flex h-[calc(theme(spacing.10)_-_2_*_theme(borderWidth.DEFAULT))] appearance-none truncate bg-tx pe-10"
+      class="outline-style-none flex h-[calc(theme(spacing.10)_-_2_*_theme(borderWidth.DEFAULT))] appearance-none truncate bg-tx pe-10"
       :class="[
         showSelected ? 'w-full' : 'w-0 max-w-0',
         hasStartContent ? 'ps-10' : 'ps-2',

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -328,6 +328,11 @@
   input[type="search"]::-webkit-search-results-decoration {
     -webkit-appearance: none;
   }
+
+  /* Completely remove the outline; to be replaced with a different focus ring */
+  .outline-style-none {
+    outline-style: none;
+  }
 }
 /*
 Text styles from Figma, @see


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #4911 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Fixes the extra white halo around the focus ring in `VSelectField` (used by the theme switcher and the language switcher).

This was caused by the browser's default styles: they add an outline by default when a `select` element is focused. We remove some of the default styles, but the outline style is still set to `auto`, and that adds a visible white outline in Chrome (but not in Firefox).

### Chrome screenshot 
<img width="345" alt="Screenshot 2024-09-17 at 7 22 25 AM" src="https://github.com/user-attachments/assets/eee9d165-2a42-41a3-a1b0-375a5f186b25">

### Firefox screenshot
<img width="294" alt="Screenshot 2024-09-17 at 7 22 46 AM" src="https://github.com/user-attachments/assets/c68adfa8-87a1-4ff9-846c-139ec2ec9e1a">

We cannot use Tailwind's `outline-none` class here to remove the outline because it does not actually remove the outline, it adds the following styles instead:
```
outline: 2px solid transparent;
outline-offset: 2px;
```

That's why I added a new utility class, `outline-style-none` here.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and use the keyboard to navigate to the theme or language switcher in the footer. You should only see the pink/yellow border, and not a white outline around them.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
