### PR TITLE
Simplify audiowaveform installation in API Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,27 +4,6 @@
 ARG API_PY_VERSION
 
 ##################
-# Audio waveform #
-##################
-
-# Pull image `realies/audiowaveform` from Docker Hub and alias as `awf`
-FROM docker.io/realies/audiowaveform:1.10.1 AS awf
-
-# Identify dependencies of the `audiowaveform` binary and move them to `/deps`,
-# while retaining their folder structure
-
-# Enable pipefail before `RUN` that contains pipes
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-
-# The script is intentionally single quoted below so that it is not
-# expanded too eagerly and in the wrong context.
-# hadolint ignore=SC2016
-RUN ldd /usr/local/bin/audiowaveform \
-    | tr -s '[:blank:]' '\n' \
-    | grep '^/' \
-    | xargs -I % sh -c 'mkdir -p $(dirname deps%); cp % deps%;'
-
-##################
 # Python builder #
 ##################
 
@@ -81,28 +60,25 @@ COPY api/utils/fonts/SourceSansPro-Bold.ttf /usr/share/fonts/truetype/SourceSans
 # Copy virtualenv from the builder image
 COPY --from=builder /.venv /.venv
 
-# Copy `audiowaveform` dependencies. This is unreliable as we use
-# The `latest` version of the audiowaveform image which may introduce
-# dependency changes which *could* have a different directory structure.
-# If this step is failing, try adding the logging in this commit to help
-# update the dependency paths:
-# https://github.com/WordPress/openverse/commit/6cd8e3944a1d4ba7a3e80705b969a6a50eb75b5a
-COPY --from=awf /deps/lib/ /lib/
-COPY --from=awf /deps/usr/ /usr/
-
-# Copy `audiowaveform` binary
-COPY --from=awf /usr/local/bin/audiowaveform /usr/local/bin
+ARG BUILDARCH
+ARG AUDIOWAVEFORM_RELEASE=1.10.1
+ARG AUDIOWAVEFORM_DEB=audiowaveform_${AUDIOWAVEFORM_RELEASE}-1-12_${BUILDARCH}.deb
 
 # - Install system packages needed for running Python dependencies
 #   - libexempi8: required for watermarking
 # - Create directory for dumping API logs
+# - apt --fix-broken install required to install missing dependencies for audiowaveform and audiowaveform itself
+#   dpkg -i marks the dependencies for installation, apt-get installs them
+#   we need to ignore error output from dpkg -i for this reason
 RUN apt-get update \
   && apt-get install -yqq --no-install-recommends \
     curl \
     libexempi8 \
     postgresql-client \
+  && curl -sLO https://github.com/bbc/audiowaveform/releases/download/${AUDIOWAVEFORM_RELEASE}/${AUDIOWAVEFORM_DEB} \
+  && (dpkg -i ${AUDIOWAVEFORM_DEB} || apt-get --fix-broken -y --no-install-recommends install) \
   && apt-get autoremove -y \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* ${AUDIOWAVEFORM_DEB} \
   && mkdir -p /var/log/openverse_api/openverse_api.log
 
 # Create a folder for placing static files


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4680 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Simplify the audiowaveform installation in the API Dockerfile by using audiowaveform's published deb packages from their GitHub releases, as discussed in the linked issue.

Pinging @dhruvkb for review because of his familiarity with this to begin with, plus I need to make sure that someone on macOS (an arm64 computer, really) tests this.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and run `ov j build web && ov j up --force-recreate`. Then `ov j api/dj generatewaveforms --max_records=2` and confirm that waveforms are successfully generated for 2 audio files. If you already have waveforms for all audio files, you'll need to remove them manually (left up to you) or start over with API test data using `ov j down -v && ov j api/init`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
