### PR TITLE
Address deprecations, make DeprecationWarning and RemovedInAirflow3Warning raise error

### DIFF
--- a/catalog/pytest.ini
+++ b/catalog/pytest.ini
@@ -38,7 +38,8 @@ addopts =
 #   Upstream dependency is fixed but Airflow constraints are keeping us on an
 #   older version
 # elasticsearch
-#   Warning in upstream Airflow hook, ignoring for now
+#   https://github.com/apache/airflow/pull/41871
+#   Warning in upstream Airflow hook, fixed in the next version
 filterwarnings=
     error::DeprecationWarning
     error::airflow.exceptions.RemovedInAirflow3Warning

--- a/catalog/pytest.ini
+++ b/catalog/pytest.ini
@@ -30,10 +30,13 @@ addopts =
 #   https://github.com/marshmallow-code/marshmallow/issues/2227
 #   Upstream dependency is fixed but Airflow constraints are keeping us on an
 #   older version
+# elasticsearch
+#   Warning in upstream Airflow hook, ignoring for now
 filterwarnings=
     ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning
     ignore:datetime.datetime.utcnow:DeprecationWarning:botocore
     ignore::DeprecationWarning:marshmallow.*
+    ignore:Importing from the 'elasticsearch.client' module is deprecated:DeprecationWarning:airflow.providers.elasticsearch.hooks.elasticsearch
 
 # Change the pytest cache location since Docker cannot write within the module file
 # structure due to permissions issues

--- a/catalog/pytest.ini
+++ b/catalog/pytest.ini
@@ -19,6 +19,13 @@ addopts =
     --allow-unix-socket
 
 
+
+# ==ERRORS==
+# Deprecation warnings and Airflow 3 warnings should be treated as errors so we
+# can address them as soon as possible
+# ==IGNORATIONS==
+# The following warnings are due to upstream dependencies and are not within our
+# control to fix. We will ignore them for now.
 # flask
 #   https://docs.sqlalchemy.org/en/20/errors.html#error-b8d9
 #   Warning in dependency, nothing we can do
@@ -33,6 +40,8 @@ addopts =
 # elasticsearch
 #   Warning in upstream Airflow hook, ignoring for now
 filterwarnings=
+    error::DeprecationWarning
+    error::airflow.exceptions.RemovedInAirflow3Warning
     ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning
     ignore:datetime.datetime.utcnow:DeprecationWarning:botocore
     ignore::DeprecationWarning:marshmallow.*

--- a/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
+++ b/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
@@ -37,6 +37,7 @@ def create_dag(
 ):
     with DAG(
         f"{sample_dag_id_fixture}_{dag_id}",
+        schedule=None,
         default_args={
             "owner": "airflow",
             "start_date": DEFAULT_DATE,
@@ -91,6 +92,7 @@ def test_fails_if_external_dag_does_not_exist(clean_db, setup_pool):
     ):
         dag = DAG(
             "test_missing_dag_error",
+            schedule=None,
             default_args={
                 "owner": "airflow",
                 "start_date": DEFAULT_DATE,
@@ -134,6 +136,7 @@ def test_fails_if_external_dag_missing_sensor_task(clean_db, setup_pool):
     with pytest.raises(AirflowException, match=error_msg):
         dag = DAG(
             "test_missing_task_error",
+            schedule=None,
             default_args={
                 "owner": "airflow",
                 "start_date": DEFAULT_DATE,
@@ -182,6 +185,7 @@ def test_succeeds_if_no_running_dags(
     # Create the Test DAG and sensor with dependent dag Ids
     dag = DAG(
         "test_dag_success",
+        schedule=None,
         default_args={
             "owner": "airflow",
             "start_date": DEFAULT_DATE,
@@ -233,6 +237,7 @@ def test_retries_if_running_dags_with_completed_sensor_task(
     # Create the Test DAG and sensor and set up dependent dag Ids
     dag = DAG(
         "test_dag_failure",
+        schedule=None,
         default_args={
             "owner": "airflow",
             "start_date": DEFAULT_DATE,

--- a/catalog/tests/dags/common/sensors/test_utils.py
+++ b/catalog/tests/dags/common/sensors/test_utils.py
@@ -9,11 +9,13 @@ from common.sensors.utils import _get_most_recent_dag_run
 
 
 TEST_DAG_ID = "data_refresh_dag_factory_test_dag"
-TEST_DAG = DAG(TEST_DAG_ID, default_args={"owner": "airflow"})
+TEST_DAG = DAG(TEST_DAG_ID, schedule=None, default_args={"owner": "airflow"})
 
 
 def _create_dagrun(start_date, sample_dag_id_fixture, conf={}):
-    return DAG(sample_dag_id_fixture, default_args={"owner": "airflow"}).create_dagrun(
+    return DAG(
+        sample_dag_id_fixture, schedule=None, default_args={"owner": "airflow"}
+    ).create_dagrun(
         start_date=start_date,
         execution_date=start_date,
         data_interval=(start_date, start_date),

--- a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
+++ b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
@@ -104,7 +104,7 @@ def test_get_staging_db_details(details, mock_rds_hook):
 
 def test_make_rename_task_group():
     rule = TriggerRule.NONE_FAILED
-    with DAG(dag_id="test_make_rename_task_group", start_date=datetime(1970, 1, 1)):
+    with DAG(dag_id="test_make_rename_task_group", schedule=None):
         group = staging_database_restore.make_rename_task_group("dibble", "crim", rule)
     assert group.group_id == "rename_dibble_to_crim"
     rename, await_rename = list(group)

--- a/catalog/tests/dags/providers/test_provider_dag_factory.py
+++ b/catalog/tests/dags/providers/test_provider_dag_factory.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -131,7 +131,7 @@ def test_apply_configuration_overrides():
     # Create a mock DAG
     dag = DAG(
         dag_id="test_dag",
-        start_date=datetime(1970, 1, 1),
+        schedule=None,
         default_args={"execution_timeout": timedelta(hours=1)},
     )
     with dag:


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

When running `ov just catalog/test` recently, I noticed that we had a few new deprecation errors:

```
================================================================================================= warnings summary =================================================================================================
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
tests/dags/common/sensors/test_utils.py:12
  /opt/airflow/catalog/tests/dags/common/sensors/test_utils.py:12: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    TEST_DAG = DAG(TEST_DAG_ID, default_args={"owner": "airflow"})

../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
../../../home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26
  /home/airflow/.local/lib/python3.12/site-packages/airflow/providers/elasticsearch/hooks/elasticsearch.py:26: DeprecationWarning: Importing from the 'elasticsearch.client' module is deprecated. Instead use 'elasticsearch' module for importing the client.
    from elasticsearch.client import SqlClient

tests/dags/providers/test_provider_dag_factory.py::test_apply_configuration_overrides
tests/dags/database/staging_database_restore/test_staging_database_restore.py::test_make_rename_task_group
tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_fails_if_external_dag_does_not_exist
tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_fails_if_external_dag_missing_sensor_task
tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_succeeds_if_no_running_dags
tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_retries_if_running_dags_with_completed_sensor_task
  /home/airflow/.local/lib/python3.12/site-packages/_pytest/python.py:159: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    result = testfunction(**testargs)

tests/dags/common/sensors/test_utils.py::test_get_most_recent_dag_run_returns_most_recent_execution_date
tests/dags/common/sensors/test_utils.py::test_get_most_recent_dag_run_returns_most_recent_execution_date
tests/dags/common/sensors/test_utils.py::test_get_most_recent_dag_run_returns_most_recent_execution_date
  /opt/airflow/catalog/tests/dags/common/sensors/test_utils.py:31: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    _create_dagrun(most_recent - timedelta(days=i), sample_dag_id_fixture)

tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_succeeds_if_no_running_dags
  /opt/airflow/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py:171: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    successful_dag = create_dag(

tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_succeeds_if_no_running_dags
  /opt/airflow/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py:175: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    failed_dag = create_dag("failed_dag", sample_dag_id_fixture, sample_pool_fixture)

tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_succeeds_if_no_running_dags
  /opt/airflow/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py:179: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    queued_dag = create_dag("queued_dag", sample_dag_id_fixture, sample_pool_fixture)

tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_retries_if_running_dags_with_completed_sensor_task
  /opt/airflow/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py:215: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    running_dag = create_dag("running_dag", sample_dag_id_fixture, sample_pool_fixture)

tests/dags/common/sensors/test_single_run_external_dags_sensor.py::test_retries_if_running_dags_with_completed_sensor_task
  /opt/airflow/catalog/tests/dags/common/sensors/test_single_run_external_dags_sensor.py:228: RemovedInAirflow3Warning: Creating a DAG with an implicit schedule is deprecated, and will stop working in a future release. Set `schedule=datetime.timedelta(days=1)` explicitly.
    successful_dependent_dag = create_dag(
```

This PR:

1. Addresses the `RemovedInAirflow3Warning` by adding an enforced `schedule` to all the DAGs which are referenced in the warning
2. Ignores the Elasticsearch `DeprecationWarning`, since that's an upstream issue within Airflow's providers
3. Sets `DeprecationWarning` and `RemovedInAirflow3Warning` to **raise an error** when they occur

I believe this was the result of #4897, but by default we don't have a whole lot of visibility into deprecation warnings (since they don't show up as an error on CI). This PR changes the warnings so we _have_ to address them as part of any version upgrades we're doing for the catalog. Because of the Airflow constraints file, we shouldn't run into out-of-band deprecation warnings on unrelated PRs; most of the versions of our packages & dependencies are pinned and won't change unless we're updating the version of Airflow itself.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Make the following change locally:

```diff
diff --git a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
index 5443c9a62..defe225a7 100644
--- a/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
+++ b/catalog/tests/dags/database/staging_database_restore/test_staging_database_restore.py
@@ -104,7 +104,7 @@ def test_get_staging_db_details(details, mock_rds_hook):
 
 def test_make_rename_task_group():
     rule = TriggerRule.NONE_FAILED
-    with DAG(dag_id="test_make_rename_task_group", schedule=None):
+    with DAG(dag_id="test_make_rename_task_group"):
         group = staging_database_restore.make_rename_task_group("dibble", "crim", rule)
     assert group.group_id == "rename_dibble_to_crim"
     rename, await_rename = list(group)
```

2. Run `ov just catalog/test`
3. Observe that the `RemovedInAirflow3Warning` now becomes a test failure rather than appearing in the warnings summary.



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
