### PR TITLE
Add envfile rotation DAG

### DIFF
--- a/catalog/dags/maintenance/rotate_envfiles.py
+++ b/catalog/dags/maintenance/rotate_envfiles.py
@@ -1,0 +1,249 @@
+"""
+Check daily for envfiles in need of removal, following standard criteria for each service.
+
+Manages envfiles based on references in tags of task definitions and launch templates.
+Envfiles are deleted from S3 if they are not referenced by the 3 most recent task definitions or launch templates for a given service.
+
+It does this by constructing a list of "recent" envfiles, and then deleting objects from the envfile buckets
+that are not in the list of recent envfiles.
+
+Resources that reference envfiles are tagged in the form `envfile:<container>` with the value
+set to the hash of the envfile referenced by that resource/version.
+
+For the sake of brevity, this module uses "lt" as an abbreviation for launch template and "task def" as an abbreviation for task definition.
+"""
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
+from airflow.providers.amazon.aws.hooks.ecs import EcsHook
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+from common.constants import AWS_CONN_ID, DAG_DEFAULT_ARGS
+
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = "rotate_envfiles"
+MAX_ACTIVE = 1
+
+ENVFILE_TAG_PREFIX = "envfile:"
+TEMPLATE_LAUNCH_TEMPLATE_SUFFIX = "-tpl"
+TEMPLATE_TASK_DEF_SUFFIX = "-template"
+
+
+@task
+def retrieve_recent_launch_template_envfiles() -> dict[str, set[str]]:
+    ec2_hook = EC2Hook(aws_conn_id=AWS_CONN_ID, api_type="client_type")
+
+    lt_response = ec2_hook.conn.describe_launch_templates()
+
+    all_launch_templates: dict[str, dict] = {
+        lt["LaunchTemplateName"]: lt for lt in lt_response["LaunchTemplates"]
+    }
+
+    real_launch_templates: dict[str, dict] = {
+        lt_name: lt
+        for lt_name, lt in all_launch_templates.items()
+        if not (
+            lt_name.endswith(TEMPLATE_LAUNCH_TEMPLATE_SUFFIX)
+            and lt_name[: -len(TEMPLATE_LAUNCH_TEMPLATE_SUFFIX)] in all_launch_templates
+        )
+    }
+
+    logger.info(
+        "Found %s 'real' launch templates to check for envfiles",
+        len(real_launch_templates),
+    )
+
+    recent_envfiles: dict[str, set[str]] = defaultdict(set)
+    for lt_name, lt in real_launch_templates.items():
+        latest_lt_version = lt["LatestVersionNumber"]
+        # min should be either 3 less than the latest, but never
+        # less than 1 which is the absolute minimum version
+        min_for_range = max(1, latest_lt_version - 3)
+
+        lt_versions = ec2_hook.conn.describe_launch_template_versions(
+            LaunchTemplateName=lt_name,
+            MinVersion=str(min_for_range),
+            MaxVersion=str(latest_lt_version),
+        )
+
+        lt_tags = {tag["Key"]: tag["Value"] for tag in lt["Tags"]}
+        service_name = lt_tags["ServiceName"]
+        environment = lt_tags["Environment"]
+
+        for lt_version in lt_versions["LaunchTemplateVersions"]:
+            instance_tag_spec = next(
+                (
+                    tag_spec
+                    for tag_spec in lt_version["TagSpecifications"]
+                    if tag_spec["ResourceType"] == "instance"
+                ),
+                None,
+            )
+            if instance_tag_spec is None:
+                raise ValueError(
+                    f"Unable to find instance tags for launch template {lt_name}"
+                )
+
+            tags = {tag["Key"]: tag["Value"] for tag in instance_tag_spec["Tags"]}
+            for key, value in tags.items():
+                if key.startswith(ENVFILE_TAG_PREFIX):
+                    container = key[len(ENVFILE_TAG_PREFIX) :]
+                    envfile = f"{service_name}/{container}/{value}.env"
+                    logger.info(
+                        "Found recent envfile %s for launch template %s",
+                        envfile,
+                        lt_name,
+                    )
+                    recent_envfiles[environment].add(envfile)
+
+    return recent_envfiles
+
+
+@task
+def retrieve_recent_task_definition_envfiles() -> dict[str, set[str]]:
+    ecs_hook = EcsHook(aws_conn_id=AWS_CONN_ID, api_type="client_type")
+
+    all_families = ecs_hook.conn.list_task_definition_families()["families"]
+
+    # "real" task def families are those actually used for deployments
+    # these are the ones we should check
+    real_families = [
+        family
+        for family in all_families
+        if not (
+            family.endswith(TEMPLATE_TASK_DEF_SUFFIX)
+            and family[: -len(TEMPLATE_TASK_DEF_SUFFIX)] in all_families
+        )
+    ]
+
+    logger.info(
+        "Found %s 'real' task definition families to check for envfiles",
+        len(real_families),
+    )
+
+    latest_task_def_arns = []
+    for family in real_families:
+        latest_of_family = ecs_hook.conn.list_task_definitions(
+            familyPrefix=family,
+            # Get the 3 most recent active task definitions
+            status="ACTIVE",
+            sort="DESC",
+            maxResults=3,
+        )
+
+        latest_task_def_arns += latest_of_family["taskDefinitionArns"]
+
+    recent_envfiles: dict[str, set[str]] = defaultdict(set)
+    for task_def_arn in latest_task_def_arns:
+        task_def_response = ecs_hook.conn.describe_task_definition(
+            taskDefinition=task_def_arn,
+            include=["TAGS"],
+        )
+
+        tags = {tag["key"]: tag["value"] for tag in task_def_response["tags"]}
+        service_name = tags["ServiceName"]
+        environment = tags["Environment"]
+
+        for key, value in tags.items():
+            if key.startswith(ENVFILE_TAG_PREFIX):
+                container = key[len(ENVFILE_TAG_PREFIX) :]
+                envfile = f"{service_name}/{container}/{value}.env"
+                logger.info(
+                    "Found envfile %s for %s %s", envfile, environment, service_name
+                )
+                recent_envfiles[environment].add(envfile)
+
+    return recent_envfiles
+
+
+@task
+def identify_stale_envfiles(
+    lt_envfiles_to_keep: dict[str, set[str]],
+    task_def_envfiles_to_keep: dict[str, set[str]],
+) -> dict[str, set[str]]:
+    """
+    Retrieve the envfiles in the environment's environment file bucket
+    that are NOT included in the ``envfiles_to_keep`` list.
+    """
+    s3_hook = S3Hook(aws_conn_id=AWS_CONN_ID, api_type="client_type")
+
+    stale_envfiles = defaultdict(set)
+    for env in ("staging", "production"):
+        bucket = f"openverse-{env}-environment-files"
+        envfiles_to_keep = lt_envfiles_to_keep[env] | task_def_envfiles_to_keep[env]
+        objects = s3_hook.conn.list_objects_v2(Bucket=bucket)
+
+        for obj in objects["Contents"]:
+            if obj["Key"] not in envfiles_to_keep:
+                stale_envfiles[env].add(obj["Key"])
+
+        logger.info(
+            "Found %s stale %s envfiles: %s",
+            len(stale_envfiles[env]),
+            env,
+            ", ".join(stale_envfiles[env]),
+        )
+
+    return stale_envfiles
+
+
+@task
+def delete_stale_envfiles(
+    envfiles_to_delete: dict[str, set[str]],
+) -> dict[str, list[dict]]:
+    s3_hook = S3Hook(aws_conn_id=AWS_CONN_ID, api_type="client_type")
+
+    deleted_objects: dict[str, list[dict]] = {}
+    for env, envfiles in envfiles_to_delete.items():
+        bucket = f"openverse-{env}-environment-files"
+        delete_response = s3_hook.conn.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": envfile} for envfile in envfiles]},
+        )
+        deleted_objects[env] = delete_response["Deleted"]
+        deleted_str = ", ".join([obj["Key"] for obj in deleted_objects[env]])
+        logger.info(
+            "Deleted %s %s envfiles: %s", len(deleted_objects[env]), env, deleted_str
+        )
+
+    return deleted_objects
+
+
+@task
+def notify_complete(deleted_envfiles: dict[str, list[dict]]): ...
+
+
+@dag(
+    dag_id=DAG_ID,
+    schedule="@daily",
+    start_date=datetime(2024, 9, 18),
+    tags=["maintenance"],
+    max_active_tasks=MAX_ACTIVE,
+    max_active_runs=MAX_ACTIVE,
+    catchup=False,
+    # Use the docstring at the top of the file as md docs in the UI
+    doc_md=__doc__,
+    default_args=DAG_DEFAULT_ARGS,
+    render_template_as_native_obj=True,
+)
+def rotate_envfiles():
+    recent_lt_envfiles = retrieve_recent_launch_template_envfiles()
+    recent_task_def_envfiles = retrieve_recent_task_definition_envfiles()
+
+    stale_envfiles = identify_stale_envfiles(
+        recent_lt_envfiles, recent_task_def_envfiles
+    )
+
+    # (
+    #     delete_stale_envfiles(stale_envfiles)
+    #     >> notify_complete(stale_envfiles)
+    # )
+
+
+rotate_envfiles()


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse-infrastructure/issues/968 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a DAG to rotate the envfiles in the environment files buckets. The DAG finds the 3 most recent envfiles for each service, and then deletes everything else in the buckets.

Drafted because I'm still trying to understand how best to test this. @stacimc @AetherUnbound if either of y'all have any input/ideas about how to test this, please let me know. I've tried changing the AWS connection locally to test the listing logic, but Airflow expects to be able to write logs to S3 using those same connection credentials, so the tasks fail immediately when they can't write to the logs bucket. Should I give up trying to test against the real buckets and just mock responses out in unit tests? That's about as good as just trying to run it in production and seeing what happens, as it'll depend entirely on whether I get the mocks right... and there's no sure-fire way to test that with our current tools, as far as I know. I've seen [this `moto` library mentioned around before as a good way to mock AWS resources](https://github.com/getmoto/moto) but we don't use it at all, and it's missing implementation for `describe_launch_template_versions` anyway... it might still be useful for other parts.

Let me know what y'all think. I'll leave this drafted until then/until I come up with something on my own. Thanks in advance.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
TBD.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
