### PR TITLE
Fix just argument splitting on pass-through recipes with complex args

### DIFF
--- a/.vale/justfile
+++ b/.vale/justfile
@@ -14,7 +14,7 @@ IGNORE_FILES_PATTERN := ".pnpm|changelogs|projects/proposals|node_modules|.?venv
 # of the current working directory. If a custom separator is specified, newlines are
 # replaced with this separator before outputting the file list.
 _files separator="\n":
-    #! /usr/bin/env sh
+    #! /usr/bin/env bash
     files=$(
         find "$PWD/.." -type f \( -name "*.md" -o -name "*.mdx" \) \
             | grep -vE "{{ IGNORE_FILES_PATTERN }}"

--- a/api/justfile
+++ b/api/justfile
@@ -45,12 +45,14 @@ install *args:
 ######
 
 # Bring up services specific to the API profile
+[positional-arguments]
 up *flags:
-    env COMPOSE_PROFILES="api" just ../up {{ flags }}
+    env COMPOSE_PROFILES="api" just ../up "$@"
 
 # Bring up services specific to the API profile, in addition to the API server
+[positional-arguments]
 up-extra *flags:
-    env COMPOSE_PROFILES="api,api_extra" just ../up {{ flags }}
+    env COMPOSE_PROFILES="api,api_extra" just ../up "$@"
 
 # Wait for all profile services to be up
 wait-up: up
@@ -103,12 +105,14 @@ pgcli db_user_pass="deploy" db_name="openledger": up
 #########################
 
 # Run Django administrative commands locally
-dj-local +args="":
-    pdm run python manage.py {{ args }}
+[positional-arguments]
+dj-local *args:
+    pdm run python manage.py "$@"
 
 # Run Django administrative commands inside the Docker container
-dj +args="": wait-up
-    env DC_USER="{{ env_var_or_default("DC_USER", "opener") }}" just ../exec web python manage.py {{ args }}
+[positional-arguments]
+dj *args: wait-up
+    env DC_USER="{{ env_var_or_default("DC_USER", "opener") }}" just ../exec web python manage.py "$@"
 
 # Get IPython shell inside the Docker container
 ipython:
@@ -152,12 +156,14 @@ generate-docs doc="media-props" fail_on_diff="true":
 #########
 
 # Run API tests inside the Docker container
+[positional-arguments]
 test *args: wait-up
-    env DC_USER="opener" just ../exec web pytest {{ args }}
+    env DC_USER="opener" just ../exec web pytest "$@"
 
 # Run API tests locally
+[positional-arguments]
 test-local *args:
-    pdm run pytest {{ args }}
+    pdm run pytest "$@"
 
 # Run smoke test for the API docs
 doc-test: wait-up

--- a/automations/js/justfile
+++ b/automations/js/justfile
@@ -26,22 +26,14 @@ report:
 # Render #
 ##########
 
-render-release-drafter:
-    #! /usr/bin/env bash
-    render_release_drafter() {
-        slug=$1
-        name=$2
-        confjson=$(printf '{"app": "%s"}' "$name")
-        just run render-jinja.js \
-            templates/release-drafter.yml.jinja \
-            .github/release-drafter-"$slug".yml \
-            "$confjson"
-    }
-    render_release_drafter api API
-    render_release_drafter ingestion_server "Ingestion Server"
-    render_release_drafter frontend Frontend
-    render_release_drafter catalog Catalog
+_render slug name:
+    just run render-jinja.js \
+        templates/release-drafter.yml.jinja \
+        .github/release-drafter-{{ slug }}.yml \
+        '{"app": "{{ name }}"}'
 
-# Render all templates (shortcut for easy iteration)
-render-templates:
-    just render-release-drafter
+render-release-drafter:
+    just _render api API
+    just _render ingestion_server "Ingestion Server"
+    just _render frontend Frontend
+    just _render catalog Catalog

--- a/automations/js/justfile
+++ b/automations/js/justfile
@@ -12,6 +12,7 @@ NO_COLOR := "\\033[0m"
 # Run a script
 [positional-arguments]
 run script *args:
+    #! /usr/bin/env bash
     pnpm --filter automations exec node src/{{ script }} "${@:2}"
 
 #################

--- a/automations/js/justfile
+++ b/automations/js/justfile
@@ -10,8 +10,9 @@ NO_COLOR := "\\033[0m"
     just --list --unsorted
 
 # Run a script
+[positional-arguments]
 run script *args:
-    pnpm --filter automations exec node src/{{ script }} {{ args }}
+    pnpm --filter automations exec node src/{{ script }} "${@:2}"
 
 #################
 # Weekly report #
@@ -26,14 +27,15 @@ report:
 ##########
 
 render-release-drafter:
-    #! /usr/bin/env sh
+    #! /usr/bin/env bash
     render_release_drafter() {
         slug=$1
         name=$2
+        confjson=$(printf '{"app": "%s"}' "$name")
         just run render-jinja.js \
             templates/release-drafter.yml.jinja \
-            .github/release-drafter-$slug.yml \
-            "'{ \"app\": \"$name\" }'"
+            .github/release-drafter-"$slug".yml \
+            "$confjson"
     }
     render_release_drafter api API
     render_release_drafter ingestion_server "Ingestion Server"

--- a/automations/python/justfile
+++ b/automations/python/justfile
@@ -11,9 +11,11 @@ NO_COLOR := "\\033[0m"
 
 
 # Install dependencies
+[positional-arguments]
 install *args:
-    pdm install {{ args }}
+    pdm install "$@"
 
 # Run a script
+[positional-arguments]
 run script *args:
-    pdm run {{ script }} {{ args }}
+    pdm run "$@"

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -99,13 +99,14 @@ pgcli db_user_pass="deploy" db_name="openledger": up
 #########
 
 # Run a command in a test container under `SERVICE`
-_mount-test command: up-deps
+[positional-arguments]
+_mount-test *command: up-deps
     env DC_USER="airflow" just ../run \
         -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 \
         -w /opt/airflow/catalog \
-        --volume \'{{ justfile_directory() }}/../docker\':/opt/airflow/docker/ \
+        --volume {{ justfile_directory() }}/../docker:/opt/airflow/docker/ \
         {{ SERVICE }} \
-        {{ command }}
+        "$@"
 
 # Launch a Bash shell in a test container under `SERVICE`
 # Run pytest with `--pdb` to workaround xdist breaking pdb.set_trace()
@@ -115,7 +116,7 @@ test-session:
 # Run pytest in a test container under `SERVICE`
 [positional-arguments]
 test *args:
-    just _mount-test "bash -c \'pytest ""$@""\'"
+    just _mount-test bash -c "pytest $@"
 
 #############
 # Utilities #

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -56,12 +56,14 @@ install *args: check-py-version
 ######
 
 # Bring up services specific to the catalog profile
+[positional-arguments]
 up *flags:
-    env COMPOSE_PROFILES="catalog" just ../up {{ flags }}
+    env COMPOSE_PROFILES="catalog" just ../up "$@"
 
 # Bring up services specific to the catalog profile, except Airflow
+[positional-arguments]
 up-deps *flags:
-    env COMPOSE_PROFILES="catalog_dependencies" just ../up {{ flags }}
+    env COMPOSE_PROFILES="catalog_dependencies" just ../up "$@"
 
 # Load sample data into upstream DB
 init: up
@@ -111,8 +113,9 @@ test-session:
     just _mount-test bash
 
 # Run pytest in a test container under `SERVICE`
+[positional-arguments]
 test *args:
-    just _mount-test "bash -c \'pytest {{ args }}\'"
+    just _mount-test "bash -c \'pytest ""$@""\'"
 
 #############
 # Utilities #

--- a/catalog/justfile
+++ b/catalog/justfile
@@ -84,11 +84,12 @@ shell:
     env DC_USER="airflow" just ../exec {{ SERVICE }} /bin/bash
 
 # Launch an IPython shell in a new container under `SERVICE`
+[positional-arguments]
 ipython *args: up-deps
     env DC_USER="airflow" just ../run \
         --workdir /opt/airflow/catalog/dags \
         {{ SERVICE }} \
-        bash -c \'ipython {{ args }}\'
+        bash -c "ipython ${@:2}"
 
 # Launch a `pgcli` shell in the PostgreSQL container
 pgcli db_user_pass="deploy" db_name="openledger": up
@@ -124,7 +125,7 @@ test *args:
 
 # Generate the documentation (either "dag" or "media-props")
 generate-docs doc="dag" fail_on_diff="false":
-    #!/bin/bash
+    #! /usr/bin/env bash
     set -e
     if [ "{{ doc }}" == "dag" ]; then
         SCRIPT_PATH="catalog/utilities/dag_doc_gen/dag_doc_generation.py"
@@ -140,18 +141,20 @@ generate-docs doc="dag" fail_on_diff="false":
         echo "Invalid documentation type specified, use \`dag\` or \`media-props\`. Exiting."
         exit 1
     fi
+
     GENERATED_ABS_PATH="/opt/airflow/catalog/${GENERATED_REL_PATH}"
     just ../run \
       --volume {{ justfile_directory() }}/../docker:/opt/airflow/docker/ \
       -e PYTHONPATH=/opt/airflow/catalog:/opt/airflow/catalog/dags \
       {{ SERVICE }} \
-      "bash -c 'python $SCRIPT_PATH && chmod 666 $GENERATED_ABS_PATH'"
+      bash -c "python $SCRIPT_PATH && chmod 666 $GENERATED_ABS_PATH"
+
     TEMP="documentation/meta/temp"
-    mv ../catalog/$GENERATED_REL_PATH ../$TEMP.md
+    mv ../catalog/"$GENERATED_REL_PATH" ../"$TEMP".md
     echo "Moved the generated file to ../$TEMP.md"
     echo -n "Running linting..."
     # Linting step afterwards is necessary since the generated output differs greatly from what prettier expects
-    just ../lint prettier $TEMP.md &>/dev/null || true
+    just ../lint prettier "$TEMP".md &>/dev/null || true
     echo "Linting done!"
 
     echo -n "Replacing linted md <hr> '---' with '----' required by sphinx..."

--- a/docker/cache/justfile
+++ b/docker/cache/justfile
@@ -14,8 +14,9 @@ NO_COLOR := "\\033[0m"
 #######
 
 # Open the Redis CLI as an interactive REPL
+[positional-arguments]
 cli *args:
-    just ../../exec cache redis-cli {{ args }}
+    just ../../exec cache redis-cli "$@"
 
 # Delete all data cached in Redis
 flushall:

--- a/documentation/justfile
+++ b/documentation/justfile
@@ -72,8 +72,9 @@ live port="50230": clean
     pdm run sphinx-autobuild -b html . _serve/ --port {{ port }}
 
 # Compile the documentation into a static site
+[positional-arguments]
 build *args: clean
-    pdm run sphinx-build {{ args }} -b html . _build/
+    pdm run sphinx-build "$@" -b html . _build/
 
 # Serve the compiled docs using a simple HTTP server
 serve port="50231":

--- a/frontend/bin/playwright.sh
+++ b/frontend/bin/playwright.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 set -e
 
 version() {

--- a/frontend/justfile
+++ b/frontend/justfile
@@ -55,8 +55,9 @@ run-img tag="openverse-frontend:local":
 ######
 
 # Bring up services specific to the frontend profile
+[positional-arguments]
 up *flags:
-    env COMPOSE_PROFILES="frontend" just ../up {{ flags }}
+    env COMPOSE_PROFILES="frontend" just ../up "$@"
 
 # Wait for all profile services to be up
 wait-up: up
@@ -67,8 +68,9 @@ init: wait-up
     cd .. && ./setup_plausible.sh
 
 # Run a package.json script via pnpm
+[positional-arguments]
 run *args:
-    pnpm run {{ args }}
+    pnpm run "$@"
 
 # Generate the specified kind of documentation
 generate-docs doc="media-props" fail_on_diff="true":

--- a/indexer_worker/justfile
+++ b/indexer_worker/justfile
@@ -33,8 +33,9 @@ install *args="--dev":
 ######
 
 # Bring up services specific to the indexer worker profile
+[positional-arguments]
 up *flags:
-    env COMPOSE_PROFILES="catalog_indexer_worker" just ../up {{ flags }}
+    env COMPOSE_PROFILES="catalog_indexer_worker" just ../up "$@"
 
 wait-up: up
     just wait
@@ -77,9 +78,12 @@ curl-post data host="localhost:50281":
 # Tests #
 #########
 
+# Run indexer worker tests in the container
+[positional-arguments]
 test *args: wait-up
-    just ../exec catalog_indexer_worker pytest {{ args }}
+    just ../exec catalog_indexer_worker pytest "$@"
 
 # Run indexer-worker tests locally
+[positional-arguments]
 test-local *args:
-    pdm run pytest {{ args }}
+    pdm run pytest "$@"

--- a/justfile
+++ b/justfile
@@ -134,14 +134,8 @@ precommit:
     fi
 
 # Run pre-commit to lint and reformat files
-[positional-arguments]
 lint hook="" *files="": precommit
-    #! /usr/bin/env bash
-    if [[ "$files" ]]; then
-        python3 pre-commit.pyz run {{ hook }} --files "${@:2}"
-    else
-        python3 pre-commit.pyz run {{ hook }} --all-files
-    fi
+    python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files" } }}  {{ files }}
 
 # Run codeowners validator locally. Only enable experimental hooks if there are no uncommitted changes.
 lint-codeowners checks="stable":

--- a/justfile
+++ b/justfile
@@ -4,9 +4,6 @@ set dotenv-load := false
 # @ - Quiet recipes (https://github.com/casey/just#quiet-recipes)
 # _ - Private recipes (https://github.com/casey/just#private-recipes)
 
-IS_PROD := env_var_or_default("PROD", env_var_or_default("IS_PROD", ""))
-# `PROD_ENV` can be "ingestion_server" or "catalog"
-PROD_ENV := env_var_or_default("PROD_ENV", "")
 IS_CI := env_var_or_default("CI", "")
 DC_USER := env_var_or_default("DC_USER", "opener")
 
@@ -137,8 +134,9 @@ precommit:
     fi
 
 # Run pre-commit to lint and reformat files
+[positional-arguments]
 lint hook="" *files="": precommit
-    python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files" } }}  {{ files }}
+    python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files {{ files }}" } }}
 
 # Run codeowners validator locally. Only enable experimental hooks if there are no uncommitted changes.
 lint-codeowners checks="stable":
@@ -171,14 +169,7 @@ lint-codeowners checks="stable":
 # Docker #
 ##########
 
-DOCKER_FILE := "-f " + (
-    if IS_PROD == "true" {
-        if PROD_ENV == "ingestion_server" { "ingestion_server/docker-compose.yml" }
-        else if PROD_ENV == "catalog" { "catalog/docker-compose.yml" }
-        else { "docker-compose.yml" }
-    }
-    else { "docker-compose.yml" }
-)
+DOCKER_FILE := "-f docker-compose.yml"
 EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 
 export CATALOG_PY_VERSION := `just catalog/py-version`
@@ -207,13 +198,15 @@ versions:
     EOF
 
 # Run `docker compose` configured with the correct files and environment
+[positional-arguments]
 dc *args:
     @{{ if IS_CI != "" { "just env" } else { "true" } }}
-    env COMPOSE_PROFILES="{{ env_var_or_default("COMPOSE_PROFILES", "api,ingestion_server,frontend,catalog") }}" docker compose {{ DOCKER_FILE }} {{ args }}
+    env COMPOSE_PROFILES="{{ env_var_or_default("COMPOSE_PROFILES", "api,ingestion_server,frontend,catalog") }}" docker compose {{ DOCKER_FILE }} "$@"
 
 # Build all (or specified) services
+[positional-arguments]
 build *args:
-    just dc build {{ args }}
+    just dc build "$@"
 
 # List all services and their URLs and ports
 @ps:
@@ -223,11 +216,12 @@ build *args:
 
 # Also see `up` recipe in sub-justfiles
 # Bring all Docker services up, in all profiles
+[positional-arguments]
 up *flags: env && ps
     #!/usr/bin/env bash
     set -eo pipefail
     while true; do
-      if just dc up {{ if IS_CI != "" { "--quiet-pull" } else { "" } }} -d {{ flags }} ; then
+      if just dc up {{ if IS_CI != "" { "--quiet-pull" } else { "" } }} -d "$@" ; then
         break
       fi
       ((c++)) && ((c==3)) && break
@@ -249,8 +243,9 @@ init:
     just frontend/init
 
 # Take all Docker services down, in all profiles
+[positional-arguments]
 down *flags:
-    just dc down {{ flags }}
+    just dc down "$@"
 
 # Take all services down then call the specified app's up recipe. ex.: `just dup catalog` is useful for restarting the catalog with new environment variables
 dup app:
@@ -277,12 +272,14 @@ attach service:
     docker attach $(just dc ps | awk '{print $1}' | grep {{ service }})
 
 # Execute statement in service containers using Docker Compose
+[positional-arguments]
 exec +args:
-    just dc exec -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} {{ args }}
+    just dc exec -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "$@"
 
 # Execute statement in a new service container using Docker Compose
+[positional-arguments]
 run +args:
-    just dc run --rm -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "{{ args }}"
+    just dc run --rm -u {{ env_var_or_default("DC_USER", "root") }} {{ EXEC_DEFAULTS }} "$@"
 
 # Execute pgcli against one of the database instances
 _pgcli container db_user_pass db_name db_host db_port="5432":
@@ -352,20 +349,31 @@ f:
     just frontend/run dev
 
 # alias for `pnpm --filter {package} run {script}`
-p package script +args="":
-    pnpm --filter {{ package }} run {{ script }} {{ args }}
+[positional-arguments]
+p package script *args:
+    pnpm --filter {{ package }} run {{ script }} "${@:3}"
 
 # Run eslint with --fix and default file selection enabled; used to enable easy file overriding whilst retaining the defaults when running --all-files
-eslint *files="frontend automations/js packages/js .pnpmfile.cjs .eslintrc.js prettier.config.js tsconfig.base.json":
+[positional-arguments]
+eslint *args:
+    #! /usr/bin/env bash
     just p '@openverse/eslint-plugin' build
+    if [[ "$@" ]]; then
+        files=("$@")
+    else
+        # default files
+        files=(frontend automations/js packages/js .pnpmfile.cjs .eslintrc.js prettier.config.js tsconfig.base.json)
+    fi
+
     pnpm exec eslint \
         --ext .js,.ts,.vue,.json,.json5 \
         --ignore-path .gitignore \
         --ignore-path .eslintignore \
         --max-warnings=0 \
         --fix \
-        {{ files }}
+        "${files[@]}"
 
 # Alias for `just packages/js/k6/run` or `just p k6 run`
+[positional-arguments]
 @k6 *args:
-    just packages/js/k6/run {{ args }}
+    just packages/js/k6/run "$@"

--- a/justfile
+++ b/justfile
@@ -136,7 +136,12 @@ precommit:
 # Run pre-commit to lint and reformat files
 [positional-arguments]
 lint hook="" *files="": precommit
-    python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files {{ files }}" } }}
+    #! /usr/bin/env bash
+    if [[ "$files" ]]; then
+        python3 pre-commit.pyz run {{ hook }} --files "${@:2}"
+    else
+        python3 pre-commit.pyz run {{ hook }} --all-files
+    fi
 
 # Run codeowners validator locally. Only enable experimental hooks if there are no uncommitted changes.
 lint-codeowners checks="stable":
@@ -254,7 +259,7 @@ dup app:
 # Recreate all volumes and containers from scratch
 recreate:
     just down -v
-    just up "--force-recreate --build"
+    just up --force-recreate --build
     just init
 
 # Bust pnpm cache and reinstall Node.js dependencies

--- a/packages/js/k6/justfile
+++ b/packages/js/k6/justfile
@@ -1,4 +1,5 @@
 # Build and run K6 script by namespace and scenario
-run namespace scenario +extra_args="":
+[positional-arguments]
+run namespace scenario *extra_args:
     pnpm run build --input src/{{ namespace }}/{{ scenario }}.test.ts
-    k6 run {{ extra_args }} ./dist/{{ namespace }}/{{ scenario }}.test.js
+    k6 run "${@:3}" ./dist/{{ namespace }}/{{ scenario }}.test.js

--- a/packages/python/openverse-attribution/justfile
+++ b/packages/python/openverse-attribution/justfile
@@ -14,5 +14,6 @@ NO_COLOR := "\\033[0m"
 ###########
 
 # Install dependencies
+[positional-arguments]
 install *args:
-    pdm install {{ args }}
+    pdm install "$@"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes a problem we've run into several times, and never really found a suitable ("nice") solution for. 

Without these changes, when we pass just's collected arguments lists (`+args` and `*args` type things), the underlying bash call that just makes will cause arguments to be split on _any space_ and follow difficult to track rules about quotation mark escaping. Commands like this, were simply impossible, without abstract levels of quote escaping:

```shell
ov env DC_USER="airflow"  just exec scheduler airflow dags trigger staging_audio_data_refresh --conf '{"index_suffix": "init"}'

ov just api/test -k "test_image_proxy or test_check_dead_links"
```

The `--conf` argument would have its quotes stripped and turn into `{"index_suffix": "init"}`, passed to the underlying command, which `just` executes using the default shell (`bash` in the case of `ov`). Bash would interpret this as two separate positional arguments, `{index_suffix:` and `init}`, with quotation marks stripped [following bash's quotation handling logic](https://www.gnu.org/software/bash/manual/html_node/Quoting.html).

By using [`just`'s `positional-arguments` setting on these recipes](https://github.com/casey/just?tab=readme-ov-file#positional-arguments), we're able to pass arguments through using bash's argument array expansion, which preserves quoted arguments as single individual arguments, rather than splitting on all strings.

With these changes, the commands above work perfectly and exactly as expected. The quoted arguments are preserved as a single argument, rather than split when `just` compiles the recipe template which drops the argument groups.

I chose not to enable positional-arguments globally in each justfile, despite using it almost everywhere with gather args, because I didn't want to cause side effects on any recipes that weren't written with that particular setting in mind. Plus, setting it explicitly on each recipe should make it easier for folks to understand why those recipes behave the way they do compared to others (or a new one they are writing), and will give them something easy to search for in the just documentation. The global setting would be slightly harder to find and know that it was the effective difference.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out main and try to run the commands above to see what kind of error you get back. This helps make sure you know what goes wrong without these changes. Then, check out this branch, and run the commands above again, and they should work.

CI should pass, which is a decent indicator that I haven't broken anything :sweat_smile: 

Make sure to take an extra look at the recipes that use positional arguments for a final gather argument, but that also have individual named just arguments. For example, the `k6/run` recipe. The `$@` split should capture only the positional arguments that aren't handled as regular just template variables.

You can test this by echoing the final command instead of running it, to see the expanded arguments. For example, the diff below yields this output when running the `k6/run` recipe (via the root justfile alias `k6`):

```shell
$ ov j k6 frontend static-en --summary-export ./k6-summary.json -e scenario_vus=1 -e scenario_iterations=1 --console-output ./k6-summary.txt
pnpm run build --input src/frontend/static-en.test.ts
k6 run --summary-export ./k6-summary.json -e scenario_vus=1 -e scenario_iterations=1 --console-output ./k6-summary.txt ./dist/frontend/static-en.test.js
```

Here we can see that the `pnpm run build` command has the correct namespace and test-file interpolated. Likewise in the `k6 run` command. The `k6 run` command also needs to have the additional CLI args passed through between `run` and the script location. This is achieved with `"${@:3}"`, which takes a slice of the `$@` array starting at the 4th position forward. Recall that bash automatically drops from `$@` what would be assigned to `$0` (that is, the command that was run), unless you address it directly. However, the index still remains. If you echo `"${@:0}"` and `"${@:3}" in the recipe, you will see these lines respectively

```
run frontend static-en --summary-export ./k6-summary.json -e scenario_vus=1 -e scenario_iterations=1 --console-output ./k6-summary.txt

--summary-export ./k6-summary.json -e scenario_vus=1 -e scenario_iterations=1 --console-output ./k6-summary.txt
```

As you can see, while `$@` on its own does not include argv0, when slicing it as an array, you still need to consider it when deciding the index to slice from. As such, the _third_ argument passed to `just` will be in index 3 (position 4) of `$@` when sliced, so we slice from 3 onward.

<details>
<summary>Here is a diff you can use to work off and explore the concepts above to better understand <code>$@</code> if you would like</summary>

```diff
diff --git a/packages/js/k6/justfile b/packages/js/k6/justfile
index dc6c2e609..1d390b056 100644
--- a/packages/js/k6/justfile
+++ b/packages/js/k6/justfile
@@ -1,5 +1,7 @@
 # Build and run K6 script by namespace and scenario
 [positional-arguments]
-run namespace scenario *extra_args:
-    pnpm run build --input src/{{ namespace }}/{{ scenario }}.test.ts
-    k6 run "${@:3}" ./dist/{{ namespace }}/{{ scenario }}.test.js
+@run namespace scenario *extra_args:
+    echo "${@:0}"
+    echo "${@:3}"
+    echo pnpm run build --input src/{{ namespace }}/{{ scenario }}.test.ts
+    echo k6 run "${@:3}" ./dist/{{ namespace }}/{{ scenario }}.test.js
```

</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
