### PR TITLE
Update loading skeletons

### DIFF
--- a/frontend/src/components/VSkeleton/VBone.vue
+++ b/frontend/src/components/VSkeleton/VBone.vue
@@ -1,12 +1,21 @@
-<script setup lang="ts">
-withDefaults(defineProps<{ shimmer?: boolean }>(), { shimmer: true })
-</script>
+<script setup lang="ts"></script>
 
 <template>
-  <div :class="['bg-secondary', { shimmering: shimmer }]" />
+  <div class="bg-gradient shimmering motion-reduce:!animate-none" />
 </template>
 
 <style scoped>
+.bg-gradient {
+  @apply bg-secondary;
+  background: linear-gradient(
+    to right,
+    var(--color-skeleton-base) 4%,
+    var(--color-skeleton-secondary) 25%,
+    var(--color-skeleton-base) 36%
+  );
+  background-size: 1000px 100%;
+}
+
 @keyframes shimmer {
   0% {
     background-position: -1000px 0;
@@ -18,12 +27,5 @@ withDefaults(defineProps<{ shimmer?: boolean }>(), { shimmer: true })
 
 .shimmering {
   animation: shimmer 3s infinite linear;
-  background: linear-gradient(
-    to right,
-    theme("backgroundColor.secondary") 4%,
-    theme("borderColor.default") 25%,
-    theme("backgroundColor.secondary") 36%
-  );
-  background-size: 1000px 100%;
 }
 </style>

--- a/frontend/src/components/VSkeleton/VGridSkeleton.vue
+++ b/frontend/src/components/VSkeleton/VGridSkeleton.vue
@@ -3,9 +3,11 @@
  * Display placeholder elements while waiting for the actual elements to be
  * loaded in the results views.
  */
-import { computed } from "vue"
+import { computed, inject, ref } from "vue"
 
 import type { SupportedSearchType } from "~/constants/media"
+
+import { IsSidebarVisibleKey } from "~/types/provides"
 
 import VAudioTrackSkeleton from "~/components/VSkeleton/VAudioTrackSkeleton.vue"
 import VBone from "~/components/VSkeleton/VBone.vue"
@@ -14,11 +16,9 @@ const props = withDefaults(
   defineProps<{
     isForTab?: SupportedSearchType
     numElems?: number
-    isSidebarVisible?: boolean
   }>(),
   {
     isForTab: "image",
-    isSidebarVisible: false,
   }
 )
 
@@ -39,6 +39,8 @@ const elementCount = computed(() => {
   }
   return 8
 })
+
+const isSidebarVisible = inject(IsSidebarVisibleKey, ref(false))
 </script>
 
 <template>

--- a/frontend/src/components/VSkeleton/meta/VGridSkeleton.stories.ts
+++ b/frontend/src/components/VSkeleton/meta/VGridSkeleton.stories.ts
@@ -1,4 +1,4 @@
-import { h } from "vue"
+import { supportedSearchTypes } from "~/constants/media"
 
 import VGridSkeleton from "~/components/VSkeleton/VGridSkeleton.vue"
 
@@ -7,42 +7,17 @@ import type { Meta, StoryObj } from "@storybook/vue3"
 const meta = {
   title: "Components/Skeleton",
   component: VGridSkeleton,
+  argTypes: {
+    isForTab: { control: "select", options: supportedSearchTypes },
+  },
 } satisfies Meta<typeof VGridSkeleton>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const Template: Story = {
-  render: (args) => ({
-    components: { VGridSkeleton },
-    setup() {
-      return () => h(VGridSkeleton, { isForTab: args.isForTab })
-    },
-  }),
-}
-export const AllTab: Story = {
-  ...Template,
-  name: "All tab",
-
-  args: {
-    isForTab: "all",
-  },
-}
-
-export const ImageTab: Story = {
-  ...Template,
-  name: "Image tab",
-
+export const Default: Story = {
+  name: "Grid Skeleton",
   args: {
     isForTab: "image",
-  },
-}
-
-export const AudioTab = {
-  ...Template,
-  name: "Audio tab",
-
-  args: {
-    isForTab: "audio",
   },
 }

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -258,6 +258,8 @@
       --color-modal-layer: var(--color-gray-12-60);
       --color-new-highlight: var(--color-yellow-3);
       --color-gray-new-highlight: var(--color-gray-1-20);
+      --color-skeleton-base: var(--color-gray-2);
+      --color-skeleton-secondary: var(--color-gray-3);
     }
   }
 
@@ -316,6 +318,8 @@
     --color-modal-layer: var(--color-gray-12-80);
     --color-new-highlight: var(--color-pink-6);
     --color-gray-new-highlight: var(--color-gray-12-20);
+    --color-skeleton-base: var(--color-gray-2);
+    --color-skeleton-secondary: var(--color-gray-3);
   }
 
   :is(.dark-mode *),
@@ -373,6 +377,8 @@
     --color-modal-layer: var(--color-gray-12-60);
     --color-new-highlight: var(--color-yellow-3);
     --color-gray-new-highlight: var(--color-gray-1-20);
+    --color-skeleton-base: var(--color-gray-11);
+    --color-skeleton-secondary: var(--color-gray-10);
   }
 
   body {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4829 by @fcoveram

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the skeleton colors to match the updated designs.

It also fixes the number of columns when the sidebar is visible: the `isSidebarVisible` prop wasn't passed, so the number of columns was set the same when the sidebar was open, and the screen was narrower, as when it was closed.

It also moves some styles to Tailwind classes, and simplifies the Storybook story.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Open the browser devtools and set slower speed in the "Network" tab's throttling settings.
Try searching for something in Openverse. Use some new search terms to prevent loading from cache. You should see loading skeletons. The number of columns in "All content" view should match the number of columns in the results when the filters sidebar is open (In staging, you can see that there are more columns of the skeleton than of the search results when the sidebar is open)

Check the [loading skeletons in Storybook](https://docs.openverse.org/_preview/4982/storybook/?path=/story/components-skeleton--default&args=isForTab:all&globals=theme:dark), in both dark and light modes.
Emulate `prefers reduced motion` using the browser devtools, and see that the skeletons are not animated.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
