### PR TITLE
Run k6 after staging deployments

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1320,6 +1320,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           workflow_file_name: k6.yml
           wait_interval: 60
+          propagate_failure: false
           client_payload: |
             {
               "namespace": "frontend",

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -708,7 +708,7 @@ jobs:
       - name: Run k6 frontend all against local Nuxt
         run: |
           just k6 frontend all \
-            -e FRONTEND_URL=http://127.0.0.1:8443/ \
+            -e service_url=http://127.0.0.1:8443/ \
             -e text_summary=/tmp/k6-summary.txt
 
       - name: Upload artifacts

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1312,6 +1312,22 @@ jobs:
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment
 
+      - name: Trigger staging k6 load test
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: WordPress
+          repo: openverse
+          token: ${{ secrets.ACCESS_TOKEN }}
+          workflow_file_name: k6.yml
+          wait_interval: 60
+          client_payload: |
+            {
+              "namespace": "frontend",
+              "scenario": "all",
+              "service_url": "https://staging.openverse.org/",
+              "report": true
+            }
+
   deploy-api:
     name: Deploy staging API
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1320,6 +1320,8 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           workflow_file_name: k6.yml
           wait_interval: 60
+          # TODO: Set to true once we see that this test is stable, and we can fail the deployment if it fails.
+          # @see https://github.com/WordPress/openverse/pull/4991
           propagate_failure: false
           client_payload: |
             {

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -739,7 +739,7 @@ jobs:
           ## Latest k6 run output[^update]
 
           ```
-          ${summary}
+          {summary}
           ```
 
           [^update]: This comment will automatically update with new output each time k6 runs for this PR

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           just k6 ${{ 'frontend' }} ${{ 'search-en' }} \
             ${{ true && '-o cloud' || ''}} \
+            -e signing_secret="$K6_SIGNING_SECRET" \
             -e service_url=${{ 'https://staging.openverse.org' }} \
             -e text_summary=/tmp/k6-summary.txt
 

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -1,0 +1,67 @@
+name: Run k6 scenario
+
+on:
+  # temporary for testing
+  pull_request:
+
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: '"namespace" of the k6 test scenario to run.'
+        required: true
+        type: choice
+        # frontend is the only one so far, but we will add API back to the k6 tests at some point
+        options:
+          - frontend
+      scenario:
+        description: "The k6 scenario to run; availability differs per namespace. Run `ov j packages/js/k6/ls` for a list of all k6 scenarios for each namespace."
+        required: true
+        type: string
+      service_url:
+        description: "The service against which to run the k6 scenario."
+        required: true
+        type: string
+      report:
+        description: "Whether to report the run results to Grafana Cloud k6"
+        required: false
+        type: boolean
+        default: false
+
+run-name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}
+
+# Disallow running multiple load tests at once against the same service
+concurrency: ${{ github.workflow }}-${{ inputs.service_url }}
+
+jobs:
+  run-k6:
+    name: "Run k6 ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup CI env
+        uses: ./.github/actions/setup-env
+        with:
+          setup_python: false
+          install_recipe: node-install
+
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }}
+        env:
+          K6_CLOUD_TOKEN: ${{ secrets.GC_K6_TOKEN }}
+          K6_SIGNING_SECRET: ${{ secrets.K6_SIGNING_SECRET }}
+        run: |
+          just k6 ${{ inputs.namespace }} ${{ inputs.scenario }} \
+            ${{ inputs.report && '-o cloud' || ''}} \
+            -e service_url=${{ inputs.service_url }} \
+            -e text_summary=/tmp/k6-summary.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-output
+          path: /tmp/k6-summary.txt

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -1,14 +1,6 @@
 name: Run k6 scenario
 
 on:
-  # temporary for testing
-  # replace the following:
-  # - ${{ 'frontend'}} -> ${{ inputs.namespace }}
-  # - ${{ 'search-en'}} -> ${{ inputs.scenario }}
-  # - ${{ 'https://staging.openverse.org/'}} -> ${{ inputs.service_url }}
-  # - ${{ 'https://staging.openverse.org/'}} -> ${{ inputs.service_url }}
-  pull_request:
-
   workflow_dispatch:
     inputs:
       namespace:
@@ -32,14 +24,14 @@ on:
         type: boolean
         default: false
 
-run-name: k6 run ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }} report=${{ true }}
+run-name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}
 
 # Disallow running multiple load tests at once against the same service
-concurrency: ${{ github.workflow }}-${{ 'https://staging.openverse.org' }}
+concurrency: ${{ github.workflow }}-${{ inputs.service_url }}
 
 jobs:
   run-k6:
-    name: "Run k6 ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }} report=${{ true }}"
+    name: "Run k6 ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -55,18 +47,19 @@ jobs:
       - name: Setup k6
         uses: grafana/setup-k6-action@v1
 
-      - name: k6 run ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }}
+      - name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }}
         env:
           K6_CLOUD_TOKEN: ${{ secrets.GC_K6_TOKEN }}
           K6_SIGNING_SECRET: ${{ secrets.K6_SIGNING_SECRET }}
         run: |
-          just k6 ${{ 'frontend' }} ${{ 'search-en' }} \
-            ${{ true && '-o cloud' || ''}} \
+          just k6 ${{ inputs.namespace }} ${{ inputs.scenario }} \
+            ${{ inputs.report && '-o cloud' || ''}} \
             -e signing_secret="$K6_SIGNING_SECRET" \
-            -e service_url=${{ 'https://staging.openverse.org' }} \
+            -e service_url=${{ inputs.service_url }} \
             -e text_summary=/tmp/k6-summary.txt
 
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: k6-output

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -2,6 +2,11 @@ name: Run k6 scenario
 
 on:
   # temporary for testing
+  # replace the following:
+  # - ${{ 'frontend'}} -> ${{ inputs.namespace }}
+  # - ${{ 'search-en'}} -> ${{ inputs.scenario }}
+  # - ${{ 'https://staging.openverse.org/'}} -> ${{ inputs.service_url }}
+  # - ${{ 'https://staging.openverse.org/'}} -> ${{ inputs.service_url }}
   pull_request:
 
   workflow_dispatch:
@@ -27,14 +32,14 @@ on:
         type: boolean
         default: false
 
-run-name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}
+run-name: k6 run ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }} report=${{ true }}
 
 # Disallow running multiple load tests at once against the same service
-concurrency: ${{ github.workflow }}-${{ inputs.service_url }}
+concurrency: ${{ github.workflow }}-${{ 'https://staging.openverse.org' }}
 
 jobs:
   run-k6:
-    name: "Run k6 ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }} report=${{ inputs.report }}"
+    name: "Run k6 ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }} report=${{ true }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -50,14 +55,14 @@ jobs:
       - name: Setup k6
         uses: grafana/setup-k6-action@v1
 
-      - name: k6 run ${{ inputs.namespace }} ${{ inputs.scenario }} ${{ inputs.service_url }}
+      - name: k6 run ${{ 'frontend' }} ${{ 'search-en' }} ${{ 'https://staging.openverse.org' }}
         env:
           K6_CLOUD_TOKEN: ${{ secrets.GC_K6_TOKEN }}
           K6_SIGNING_SECRET: ${{ secrets.K6_SIGNING_SECRET }}
         run: |
-          just k6 ${{ inputs.namespace }} ${{ inputs.scenario }} \
-            ${{ inputs.report && '-o cloud' || ''}} \
-            -e service_url=${{ inputs.service_url }} \
+          just k6 ${{ 'frontend' }} ${{ 'search-en' }} \
+            ${{ true && '-o cloud' || ''}} \
+            -e service_url=${{ 'https://staging.openverse.org' }} \
             -e text_summary=/tmp/k6-summary.txt
 
       - name: Upload artifacts

--- a/docker/dev_env/Dockerfile
+++ b/docker/dev_env/Dockerfile
@@ -31,6 +31,7 @@ ENV PATH="${PNPM_BIN}:${N_PREFIX}/bin:${PDM_PYTHONS}:${HOME}/.local/bin:${PATH}"
 # - just: command runner
 # - jq: JSON processor
 # - which: locate a program file in `PATH`
+# - tree: list files in a tree
 # - python*: required by some Python libraries for compilation during installation
 # - libffi*: required for the Python package cffi
 # - pipx: Python CLI app installer
@@ -58,6 +59,7 @@ RUN mkdir /pipx \
     just \
     jq \
     which \
+    tree \
     xdg-utils \
     nodejs npm \
     python3.12 python3.12-devel pipx \

--- a/packages/js/k6/justfile
+++ b/packages/js/k6/justfile
@@ -4,3 +4,8 @@ run namespace scenario *extra_args:
     #! /usr/bin/env bash
     pnpm run build --input src/{{ namespace }}/{{ scenario }}.test.ts
     k6 run "${@:3}" ./dist/{{ namespace }}/{{ scenario }}.test.js
+
+# List namespaces and scenarios
+@ls:
+    echo "Openverse k6 namespaces and scenarios"
+    tree src -P '*.test.ts' --noreport | cut -c 5- | sed 's/\.test\.ts//'

--- a/packages/js/k6/src/frontend/constants.ts
+++ b/packages/js/k6/src/frontend/constants.ts
@@ -1,3 +1,3 @@
 export const PROJECT_ID = 3713375
 // Default to location of `ov j p frontend prod`
-export const FRONTEND_URL = __ENV.FRONTEND_URL || "http://127.0.0.1:8443/"
+export const FRONTEND_URL = __ENV.service_url || "http://127.0.0.1:8443/"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse-infrastructure/issues/1031 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:
- Adds an intentionally flexible new run-k6 GitHub Workflow for usage both with manual dispatch and programmatic dispatch via the GitHub CLI during other workflows (we could also leverage that to e.g., run some subset of k6 against production on a regular basis irrespective of deployments, managed using Airflow)
- Changes `FRONTEND_URL` to use a generic `service_url` variable so prepare for also having API tests in k6... this allows us not to need to change the variable name based on the other inputs.
- Adds an `ls` recipe to the k6 justfile for listing the namespaces and scenarios.
- Dispatch that workflow after the staging frontend deploys.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Review the testing runs here: https://github.com/WordPress/openverse/actions/workflows/k6.yml

Note that the three failures were due to issues with passing the signing token. That was fixed by https://github.com/WordPress/openverse-infrastructure/pull/1060 and by correctly passing the token in the workflow :slightly_smiling_face: 

If you have access to Openverse's Grafana, you can also see those runs here: https://openverse.grafana.net/a/k6-app/tests/926189

Those runs were triggered in this PR by me setting the workflow to dispatch on `pull_request` and hard-coding input parameters. I've removed those hard coded parameters and put the workflow back to dispatch.

The only remaining thing to test is the staging deployment bit that triggers this workflow, and of course we can dispatch the workflow manually from the repository to test that further as well (e.g., to test the inputs).

Otherwise, there is not much real testing possible in this PR.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
