### PR TITLE
Make the preferences test more robust

### DIFF
--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -87,12 +87,19 @@ const toggleChecked = async (
   // The knob's color is `bg-default` when off and `bg-tertiary` when on.
   await page.evaluate(
     async ([name, className]) => {
-      const knobClasses = document
-        .querySelector(`${name}`)
-        ?.parentElement?.querySelector("span")?.className
+      const getKnobClasses = () => {
+        return (
+          document
+            .getElementById(`#${name}`)
+            ?.parentElement?.querySelector("span")?.className ?? ""
+        )
+      }
 
-      if (!knobClasses?.includes(className)) {
-        setTimeout(() => {}, 200)
+      for (const waitTime of [100, 200, 500]) {
+        if (getKnobClasses().includes(className)) {
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
       }
     },
     [name, !originalChecked ? "bg-tertiary" : "bg-default"] as const

--- a/frontend/test/playwright/utils/assertions.ts
+++ b/frontend/test/playwright/utils/assertions.ts
@@ -6,5 +6,11 @@ export const expectCheckboxState = async (
   checked: boolean | undefined
 ) => {
   const checkbox = page.getByRole("checkbox", { name, checked }).first()
-  return await expect(checkbox).toBeEnabled()
+  await expect(checkbox).toBeEnabled()
+  if (checked) {
+    await expect(checkbox).toBeChecked()
+  } else {
+    console.log(`Expecting checkbox ${name} checked state to be ${checked}`)
+    await expect(checkbox).not.toBeChecked()
+  }
 }

--- a/frontend/test/playwright/utils/assertions.ts
+++ b/frontend/test/playwright/utils/assertions.ts
@@ -10,7 +10,6 @@ export const expectCheckboxState = async (
   if (checked) {
     await expect(checkbox).toBeChecked()
   } else {
-    console.log(`Expecting checkbox ${name} checked state to be ${checked}`)
     await expect(checkbox).not.toBeChecked()
   }
 }

--- a/frontend/test/playwright/utils/assertions.ts
+++ b/frontend/test/playwright/utils/assertions.ts
@@ -1,0 +1,10 @@
+import { expect, type Page } from "@playwright/test"
+
+export const expectCheckboxState = async (
+  page: Page,
+  name: string,
+  checked: boolean | undefined
+) => {
+  const checkbox = page.getByRole("checkbox", { name, checked }).first()
+  return await expect(checkbox).toBeEnabled()
+}

--- a/packages/js/eslint-plugin/src/configs/index.ts
+++ b/packages/js/eslint-plugin/src/configs/index.ts
@@ -103,6 +103,8 @@ export const project: TSESLint.Linter.ConfigType = {
               // Shared assertion for visual regression tests
               "expectSnapshot",
               "expectScreenshotAreaSnapshot",
+              // Shared assertion for checkbox state
+              "expectCheckboxState",
             ],
           },
         ],


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5001 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the preferences test to make it less flaky:
- to find the switch, we use the `getByRole` Playwright locator with the `checked` property set to `true` or `undefined`. We add an extra expect, checking that the switch is enabled. This function is extracted to `expectCheckboxState`, which is added as a valid `expect` to the Openverse ESLint plugin.
- instead of testing the saved cookie value that is not visible by the users, we reload the page and check the switch state. If the state was saved in a cookie, then the state on page load should be updated.
- an extra check with the snapshot of all of the feature flag store state is added.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The Playwright e2e test should pass in the CI. I will re-run this step several times to make sure that the test is not flaky.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
