### PR TITLE
Fix the load test comment condition

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -714,7 +714,20 @@ jobs:
           name: k6-output
           path: /tmp/k6-summary.txt
 
+      - name: Check if comment needs to be posted
+        # Do not post comments on forks, or when merging a PR
+        id: set-post-comment
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${{ github.event.pull_request.head.repo.owner.login }}" == "WordPress" && \
+                "${{ github.actor }}" != "dependabot[bot]" ]]; then
+            echo "post_comment=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "post_comment=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Make comment body
+        if: steps.set-post-comment.outputs.post_comment == 'true'
         shell: python
         run: |
           from pathlib import Path
@@ -730,6 +743,7 @@ jobs:
           """)
 
       - uses: peter-evans/find-comment@v3
+        if: steps.set-post-comment.outputs.post_comment == 'true'
         id: k6-summary-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -737,11 +751,7 @@ jobs:
 
       - name: Post comment summary
         uses: peter-evans/create-or-update-comment@v4
-        # Do not comment on forks
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.owner.login == 'WordPress' &&
-          github.actor != 'dependabot[bot]'
+        if: steps.set-post-comment.outputs.post_comment == 'true'
         with:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5020 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the `Run k6 frontend all against local Nuxt` failure when a PR is merged to main. 

Part of the action is to post the load testing results as a comment to the PR. However, when the PR is merged to main, there is no `pull_request` associated with the event, and the comment cannot be found. 

This PR adds a step that checks that the CI is running on a pull request (and not from a fork). The commenting steps (creating the comment, finding the previous comment, and updating the comment) only run if this step's output is `true`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass (both in this PR, and when this PR is merged into main)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
