### PR TITLE
Add tests for data refresh task dependencies

### DIFF
--- a/catalog/tests/dags/data_refresh/test_task_dependencies.py
+++ b/catalog/tests/dags/data_refresh/test_task_dependencies.py
@@ -1,0 +1,97 @@
+"""
+Tests vital dependencies for the data refresh: for example, ensuring that the indices have been
+created and refreshed before index promotion runs. These dependencies can be broken in
+unexpected ways so it is important to verify that the most critical ones are preserved.
+"""
+
+import logging
+
+from airflow.models import DagBag
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_staging_schedule():
+    dagbag = DagBag()
+
+    # Assert that all of the staging data refresh DAGs
+    # have a schedule of None
+    for dag in [
+        dag for dag in dagbag.dags.values() if "staging_data_refresh" in dag.tags
+    ]:
+        assert dag.schedule_interval is None, (
+            "Staging data refresh DAGs must be on a `None` schedule"
+            " or risk breaking the load_sample_data script."
+        )
+
+
+def _assert_dependencies(downstream_task_id: str, upstream_task_ids: list[str]):
+    dag = DagBag().get_dag("staging_image_data_refresh")
+
+    downstream_task = dag.get_task(downstream_task_id)
+    # Get all upstream tasks for this task, not just the direct upstream tasks
+    upstream_tasks = downstream_task.get_flat_relative_ids(upstream=True)
+
+    for upstream_task_id in upstream_task_ids:
+        assert upstream_task_id in upstream_tasks
+
+
+def test_dependencies_alter_data_task():
+    _assert_dependencies(
+        downstream_task_id="alter_table_data.alter_data_batch",
+        upstream_task_ids=["copy_upstream_tables.copy_upstream_table.copy_data"],
+    )
+
+
+def test_dependencies_reindex_task():
+    _assert_dependencies(
+        downstream_task_id="run_distributed_reindex.reindex.trigger_reindexing_task",
+        upstream_task_ids=[
+            "copy_upstream_tables.copy_upstream_table.copy_data",
+            "alter_table_data.alter_data_batch",
+            "create_index",
+        ],
+    )
+
+
+def test_dependencies_create_and_populate_filtered_index_task():
+    _assert_dependencies(
+        downstream_task_id="create_and_populate_filtered_index.trigger_and_wait_for_reindex.trigger_reindex",
+        upstream_task_ids=[
+            "run_distributed_reindex.reindex.assert_reindexing_success",
+            "run_distributed_reindex.refresh_index",
+        ],
+    )
+
+
+def test_dependencies_promote_table_task():
+    _assert_dependencies(
+        downstream_task_id="promote_tables.promote_table.promote",
+        upstream_task_ids=[
+            "run_distributed_reindex.reindex.assert_reindexing_success",
+            "create_and_populate_filtered_index.refresh_index",
+            "promote_tables.promote_table.remap_table_indices_to_table.create_table_indices",
+            "promote_tables.promote_table.remap_table_constraints_to_table.apply_constraints_to_table",
+        ],
+    )
+
+
+def test_dependenceis_promote_index_task():
+    _assert_dependencies(
+        downstream_task_id="promote_index.point_new_alias",
+        upstream_task_ids=[
+            "run_distributed_reindex.refresh_index",
+            "promote_tables.promote_table.promote",
+        ],
+    )
+
+
+def test_dependenceis_promote_filtered_index_task():
+    _assert_dependencies(
+        downstream_task_id="promote_filtered_index.point_new_alias",
+        upstream_task_ids=[
+            "create_and_populate_filtered_index.refresh_index",
+            "promote_tables.promote_table.promote",
+        ],
+    )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #4340 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The new data refresh has already been added to the `load_sample_data` scripts, such that it is run each time a contributor runs `ov j api/init` and also in CI. This adds a lot of coverage for the "happy path" of the data refresh.

In addition to this, however, it's important to test that certain vital task dependencies are maintained. While developing the data refresh I found that it's surprisingly easy to accidentally break the dependency graph in a manner such that, while a normal data refresh works as expected, an upstream task failure may not cascade properly. TL;DR: it's easy to introduce a change that seems fine, but causes elasticsearch reindexing/promotion to occur _even if the `copy_data` step fails_. This is a huge concern because it could result in bad or incomplete data going live.

This PR adds tests to ensure that those vital dependencies are maintained.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Tests should pass; take a look and see if there are any other dependencies you feel should be asserted.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
