### PR TITLE
Correctly set locale `language` property

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -102,6 +102,7 @@ export default defineNuxtConfig({
         dir: "ltr",
         file: "en.json",
         language: "en", // used for SEO purposes (html lang attribute)
+        isCatchallLocale: true, // the catchall locale for `en` locales
 
         /* Custom fields */
 

--- a/frontend/src/locales/scripts/get-validated-locales.js
+++ b/frontend/src/locales/scripts/get-validated-locales.js
@@ -29,14 +29,8 @@ const getValidatedLocales = async () => {
     code: locale.slug,
     dir: locale.textDirection || "ltr",
     file: `${locale.slug}.json`,
-    // Check for a language in all three versions of the ISO 639 spec,
-    // defaulting to the v1 two-character codes before checking for the
-    // three-character codes in the v2 and v3 specs.
-    language:
-      locale.langCodeIso_639_1 ??
-      locale.langCodeIso_639_2 ??
-      locale.langCodeIso_639_3 ??
-      undefined,
+    // Used for the html lang attribute.
+    language: locale.slug,
 
     /* Custom fields */
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5024 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The Nuxt i18n module sets the `lang` value of the `html` element using the `language` property of the locale. Previously, we were using one of the ISO properties of the locale, but this is incorrect. The value we need is in `slug` property.

Previously, we set `language` as `langCodeIso_639_1 || langCodeIso_639_2 || langCodeIso_639_3`.

This means that all variants of Spanish would overwrite each other because they all had the same ISO values (`{ "langCodeIso_639_1": "es", "langCodeIso_639_2": "spa", "langCodeIso_639_3": "spa" }`), even though their slugs were different (`es`, `es-mx`, etc). If you look in the header language links on https://staging.openverse.org, you will see that we only have a single language for all regions.

[Fix frontend to include languages that do not have iso-639-1 codes](https://github.com/WordPress/openverse/pull/4363) was the latest PR that touched this code. Before that, we would discard any language that did not have the `iso` set, and `iso` was one of the `iso` codes. Now that we use `slug`, we do not discard any languages (including Saraiki mentioned in that issue) solely based on the `iso`(`language`) code. We only discard locales that have low translated percentage.

Because of the way the English is set up separately, its values (url) were being overwritten by other region's English (South African `en-za`).
In this PR, you can see that we have different translations for different regions.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the app with `NUXT_PUBLIC_I18N_BASE_URL` env variable set to `https://openverse.org` (so that `href` in the links is set correctly):   `ov env NUXT_PUBLIC_I18N_BASE_URL=https://openverse.org just frontend/run dev`. Check that the alternate language links are set correctly

<img width="640" alt="Screenshot 2024-10-11 at 9 20 20 PM" src="https://github.com/user-attachments/assets/cdf6fbaa-4e64-4a9c-b0aa-e7dc9a5f3940">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
