### PR TITLE
Fix WP Photo Directory DAG

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -70,7 +70,6 @@ class WordPressDataIngester(ProviderDataIngester):
             self.current_page = prev_query_params["page"] + 1
 
         return {
-            "format": "json",
             "page": self.current_page,
             "per_page": self.batch_limit,
             "_embed": "true",

--- a/catalog/tests/dags/providers/provider_api_scripts/test_wordpress.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_wordpress.py
@@ -29,13 +29,13 @@ def test_get_query_params_returns_defaults_and_sets_total_pages():
     with patch.object(wp.delayed_requester, "head", return_value=mock_head_request):
         actual_result = wp.get_next_query_params({})
 
-    expected_result = {"format": "json", "page": 1, "per_page": 100, "_embed": "true"}
+    expected_result = {"page": 1, "per_page": 100, "_embed": "true"}
     assert actual_result == expected_result
     assert wp.total_pages == 5
 
 
 def test_get_query_params_increments_current_page(ingester):
-    expected_result = {"format": "json", "page": 3, "per_page": 100, "_embed": "true"}
+    expected_result = {"page": 3, "per_page": 100, "_embed": "true"}
     actual_result = ingester.get_next_query_params({**expected_result, "page": 2})
     assert actual_result == expected_result
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I was trying this DAG locally and getting zero results every time. It turns out the `format` query parameter breaks the response entirely:

This is empty: https://wordpress.org/photos/wp-json/wp/v2/photos?format=json

Whereas this works fine and returns JSON every time: https://wordpress.org/photos/wp-json/wp/v2/photos

Removing the format query parameter from the DAG fixes the issue.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the DAG on `main` and confirm you get zero results in `pull_image_data`.

Run the DAG on this branch, and confirm you now get the full result set.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
