### PR TITLE
Add Slack Alert for non-dated provider DAGs with no data

### DIFF
--- a/catalog/dags/providers/provider_dag_factory.py
+++ b/catalog/dags/providers/provider_dag_factory.py
@@ -365,6 +365,7 @@ def create_report_load_completion(
         task_id="report_load_completion",
         python_callable=reporting.report_completion,
         op_kwargs=op_kwargs,
+        retries=0,
         trigger_rule=TriggerRule.ALL_DONE,
     )
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Improves reporting associated with #5038

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

#5038 identified and fixed an issue where the WordPress Photo Directory provider DAG was ingesting 0 records, but without raising any errors that would have alerted us in Slack. This PR adds logic to `report_completion` to raise an alert in Slack if a _non-dated_ DAG ingests 0 records, to help catch these critical issues.

This is limited to non-dated DAGs because, since they ingest all data for a provider without a date-range, we can be confident something is wrong if 0 records are ingested. For some of our dated DAGs (specifically, Europeana and Finnish Museums), it's actually expected to have some 0-record ingestion days. In the future, we may consider more complex logic for non-dated DAGs, for example by specifying a number of days at which we should alert if we continue to not see any data. This is more complex because it requires looking up the results of previous DagRuns and is therefore excluded here.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

The unit tests should cover everything, but for manual testing:

* Run the europeana DAG. Verify that it returns 0 records but `report_load_completion` passes. (If you happened to test this on a day that Europeana is returning data, you may need to hard-code the europeana ingester to return 0 records)
* Re-introduce the bug from #5038 by updating `get_next_query_params` on [this line](https://github.com/WordPress/openverse/blob/c0baed6489126250c2921c8630acbe8afe77c27a/catalog/dags/providers/provider_api_scripts/wordpress.py#L73):
```diff
        return {
+           "format": "json",
            "page": self.current_page,
            "per_page": self.batch_limit,
            "_embed": "true",
        }
```
Then run the `wordpress_workflow` DAG and see that the `report_load_completion` task now raises an error.
* Remove the bug you just re-introduced and run the `wordpress_workflow` DAG again, manually marking the `pull_data` task as a success once it has ingested a few 100 rows. See that no errors are raised any more.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
