### PR TITLE
Fix flaky e2e preferences test

### DIFF
--- a/frontend/src/pages/preferences.vue
+++ b/frontend/src/pages/preferences.vue
@@ -124,7 +124,7 @@ const doneHydrating = computed(() => useHydrating())
             @change="handleChange"
           >
             <div>
-              <strong>{{ flag.name }}</strong>
+              <strong>{{ flag.name }}{{ `: ${flag.state}` }}</strong>
               <br />
               {{ flag.description }}
             </div>

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -1,4 +1,4 @@
-import { type Page, test } from "@playwright/test"
+import { type Page, expect, test } from "@playwright/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 
@@ -81,29 +81,12 @@ const toggleChecked = async (
   originalChecked: boolean | undefined
 ) => {
   const featureFlag = await getSwitchableInput(page, name, originalChecked)
-  await featureFlag.setChecked(!originalChecked)
+  const expectedChecked = !originalChecked
+  await featureFlag.setChecked(expectedChecked)
 
-  // If the switch knob wasn't rendered yet, wait for it to be rendered.
-  // The knob's color is `bg-default` when off and `bg-tertiary` when on.
-  await page.evaluate(
-    async ([name, className]) => {
-      const getKnobClasses = () => {
-        return (
-          document
-            .getElementById(`#${name}`)
-            ?.parentElement?.querySelector("span")?.className ?? ""
-        )
-      }
+  const expectedText = `${name}: ${expectedChecked ? "on" : "off"}`
 
-      for (const waitTime of [100, 200, 500]) {
-        if (getKnobClasses().includes(className)) {
-          return
-        }
-        await new Promise((resolve) => setTimeout(resolve, waitTime))
-      }
-    },
-    [name, !originalChecked ? "bg-tertiary" : "bg-default"] as const
-  )
+  await expect(page.getByText(expectedText).first()).toBeVisible()
 }
 
 test.describe("switchable features", () => {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5001 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The flakiness was caused by the fact that we cannot test if the preference was fixed in a robust way. Even if we detect that the switch state changed, it does not yet mean that the feature flag state was updated.

I updated the preference page to add the easily queriable state of the feature flag to the page. 
<img width="410" alt="Screenshot 2024-10-18 at 9 36 49 AM" src="https://github.com/user-attachments/assets/a309e3a8-8b3b-4f7d-aff7-63f9a7d5c7bc">

Now, if we assert that the state text is correct, we can be certain that the feature flag was updated (and it wasn't only the switch update). 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
