### PR TITLE
Add missing warning arg in `rotate_envfiles` DAG

### DIFF
--- a/catalog/dags/maintenance/rotate_envfiles.py
+++ b/catalog/dags/maintenance/rotate_envfiles.py
@@ -91,8 +91,14 @@ def retrieve_recent_launch_template_envfiles(
         for lt_version in lt_versions["LaunchTemplateVersions"]:
             lt_data = lt_version["LaunchTemplateData"]
             if "TagSpecifications" not in lt_data:
+                lt_id_version = (
+                    f"{lt_version['LaunchTemplateId']}:{lt_version['VersionNumber']}"
+                )
                 logger.warning(
-                    "Skipping %s due to lack of tag specifications. This is probably because the launch template was created before tag specifications were properly configured."
+                    "Skipping %s due to lack of tag specifications. This is probably "
+                    "because the launch template was created before tag "
+                    "specifications were properly configured.",
+                    lt_id_version,
                 )
                 continue
 
@@ -105,8 +111,9 @@ def retrieve_recent_launch_template_envfiles(
                 None,
             )
             if instance_tag_spec is None:
-                # We've already checked if tag specs existed above. If the instance tags don't exist but other tag specs do
-                # then there's a larger problem that requires investigation.
+                # We've already checked if tag specs existed above. If the instance
+                # tags don't exist but other tag specs do then there's a larger
+                # problem that requires investigation.
                 raise ValueError(
                     f"Unable to find instance tags for launch template {lt_name}"
                 )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #4954 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
When enabling the DAG, I noticed this warning message looked incomplete:

https://github.com/WordPress/openverse/blob/670d4e73a0bd53a90e738547d5330b273b9a455a/catalog/dags/maintenance/rotate_envfiles.py#L93-L96

> [2024-10-24, 13:45:51 UTC] {rotate_envfiles.py:94} WARNING - Skipping %s due to lack of tag specifications. This is probably because the launch template was created before tag specifications were properly configured.

For lack of something more expressive, I included the launch template ID and version there, so the message now should look like this:

> [2024-10-24, 13:03:11 -04] {rotate_envfiles.py:94} WARNING - Skipping lt-0677c0d672a537f8c:3 due to lack of tag specifications. This is probably because the launch template was created before tag specifications were properly configured.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Found them in the linked PR. If you don't set the AWS connection via the airflow UI, you might want to add these environment variables to your `.env` file for simplicity.

```
AIRFLOW_CONN_AWS_S3_ENVFILE_ROTATION=aws://<user_id>:<secret>@/?region_name=us-east-1
AIRFLOW_VAR_S3_ENVFILE_ROTATION_AWS_CONN_ID=aws_s3_envfile_rotation
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`ov just catalog/generate-docs media-props` for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
