### PR TITLE
Add baseline functionality for running Playwright tests against live environments

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1312,6 +1312,22 @@ jobs:
           wait_time: 60 # check every minute
           max_time: 1800 # allow up to 30 minutes for a deployment
 
+      - name: Trigger staging Playwright smoketests
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: WordPress
+          repo: openverse
+          github_token: ${{ secrets.ACCESS_TOKEN }}
+          workflow_file_name: playwright_deployment_smoketest.yml
+          wait_interval: 60
+          # TODO: Set to true once we see that this test is stable, and we can fail the deployment if it fails.
+          # @see https://github.com/WordPress/openverse/pull/4991
+          propagate_failure: false
+          client_payload: |
+            {
+              "service_url": "https://staging.openverse.org/"
+            }
+
       - name: Trigger staging k6 load test
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:

--- a/.github/workflows/playwright_deployment_smoketest.yml
+++ b/.github/workflows/playwright_deployment_smoketest.yml
@@ -1,8 +1,6 @@
 name: Run Playwright smoketests
 
 on:
-  pull_request:
-
   workflow_dispatch:
     inputs:
       service_url:
@@ -10,14 +8,14 @@ on:
         required: true
         type: string
 
-run-name: Playwright smoketests ${{ inputs.service_url || 'https://staging.openverse.org' }}
+run-name: Playwright smoketests ${{ inputs.service_url }}
 
 # Disallow running multiple smoketests at once against the same service
-concurrency: ${{ github.workflow }}-${{ inputs.service_url || 'https://staging.openverse.org' }}
+concurrency: ${{ github.workflow }}-${{ inputs.service_url }}
 
 jobs:
   smoketests:
-    name: "Playwright smoketests ${{ inputs.service_url || 'https://staging.openverse.org' }}"
+    name: "Playwright smoketests ${{ inputs.service_url }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +32,7 @@ jobs:
         env:
           # The secret name is k6 but it's usable for anything sending HMAC signed requests
           HMAC_SIGNING_SECRET: ${{ secrets.K6_SIGNING_SECRET }}
-          PLAYWRIGHT_BASE_URL: ${{ inputs.service_url || 'https://staging.openverse.org' }}
+          PLAYWRIGHT_BASE_URL: ${{ inputs.service_url }}
         run: |
           just p frontend test:playwright --grep '@deployment-smoketest'
 

--- a/.github/workflows/playwright_deployment_smoketest.yml
+++ b/.github/workflows/playwright_deployment_smoketest.yml
@@ -1,0 +1,46 @@
+name: Run Playwright smoketests
+
+on:
+  pull_request:
+
+  workflow_dispatch:
+    inputs:
+      service_url:
+        description: "The service against which to run the Playwright smoketests."
+        required: true
+        type: string
+
+run-name: Playwright smoketests ${{ inputs.service_url || 'https://staging.openverse.org' }}
+
+# Disallow running multiple smoketests at once against the same service
+concurrency: ${{ github.workflow }}-${{ inputs.service_url || 'https://staging.openverse.org' }}
+
+jobs:
+  smoketests:
+    name: "Playwright smoketests ${{ inputs.service_url || 'https://staging.openverse.org' }}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup CI env
+        uses: ./.github/actions/setup-env
+        with:
+          setup_python: false
+          install_recipe: node-install
+
+      - name: Run playwright
+        env:
+          # The secret name is k6 but it's usable for anything sending HMAC signed requests
+          HMAC_SIGNING_SECRET: ${{ secrets.K6_SIGNING_SECRET }}
+          PLAYWRIGHT_BASE_URL: ${{ inputs.service_url || 'https://staging.openverse.org' }}
+        run: |
+          just p frontend test:playwright --grep '@deployment-smoketest'
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        id: test-results
+        with:
+          name: test_results
+          path: frontend/test-results

--- a/frontend/.remake/component-storybook-test/remake-fileName.spec.ts
+++ b/frontend/.remake/component-storybook-test/remake-fileName.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/docker-compose.playwright.yml
+++ b/frontend/docker-compose.playwright.yml
@@ -20,3 +20,5 @@ services:
       - DEBUG=pw:webserver
       - UPDATE_TAPES=${UPDATE_TAPES:-false}
       - FASTSTART=${FASTSTART:-false}
+      - PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL:-}
+      - HMAC_SIGNING_SECRET=${HMAC_SIGNING_SECRET:-}

--- a/frontend/test/playwright/e2e/all-results-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-analytics.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   getFirstResult,

--- a/frontend/test/playwright/e2e/all-results-keyboard.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-keyboard.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import audio from "~~/test/playwright/utils/audio"
 import {
@@ -30,116 +32,122 @@ const singleResultRegex = (
   )
 }
 
-test.describe("all results grid keyboard accessibility test", () => {
-  const searchTerm = "birds"
-  test.beforeEach(async ({ page }) => {
-    await preparePageForTests(page, "xl")
-    await goToSearchTerm(page, searchTerm)
-  })
+test.describe(
+  "all results grid keyboard accessibility test",
+  { tag: "@deployment-smoketest" },
+  () => {
+    const searchTerm = "birds"
+    test.beforeEach(async ({ page }) => {
+      await preparePageForTests(page, "xl")
+      await goToSearchTerm(page, searchTerm)
+    })
 
-  test("should open image results as links", async ({ page }) => {
-    const mediaType = "image"
-    await walkToType(mediaType, page)
-    await page.keyboard.press("Enter")
-    const urlRegex = singleResultRegex(mediaType, searchTerm)
+    test("should open image results as links", async ({ page }) => {
+      const mediaType = "image"
+      await walkToType(mediaType, page)
+      await page.keyboard.press("Enter")
+      const urlRegex = singleResultRegex(mediaType, searchTerm)
 
-    await page.waitForURL(urlRegex)
-    expect(page.url()).toMatch(urlRegex)
-  })
+      await page.waitForURL(urlRegex)
+      expect(page.url()).toMatch(urlRegex)
+    })
 
-  test("should open audio results as links", async ({ page }) => {
-    const mediaType = "audio"
-    await walkToType(mediaType, page)
-    await page.keyboard.press("Enter")
-    const urlRegex = singleResultRegex(mediaType, searchTerm)
-    await page.waitForURL(urlRegex)
-    expect(page.url()).toMatch(urlRegex)
-  })
+    test("should open audio results as links", async ({ page }) => {
+      const mediaType = "audio"
+      await walkToType(mediaType, page)
+      await page.keyboard.press("Enter")
+      const urlRegex = singleResultRegex(mediaType, searchTerm)
+      await page.waitForURL(urlRegex)
+      expect(page.url()).toMatch(urlRegex)
+    })
 
-  test("should show instructions snackbar when focusing first audio", async ({
-    page,
-  }) => {
-    await walkToType("audio", page)
+    test("should show instructions snackbar when focusing first audio", async ({
+      page,
+    }) => {
+      await walkToType("audio", page)
 
-    await expect(page.getByRole("alert")).toBeVisible()
-  })
+      await expect(page.getByRole("alert")).toBeVisible()
+    })
 
-  test("should hide the instructions snackbar when interacted with audio", async ({
-    page,
-  }) => {
-    await walkToType("audio", page)
+    test("should hide the instructions snackbar when interacted with audio", async ({
+      page,
+    }) => {
+      await walkToType("audio", page)
 
-    await expect(page.getByRole("alert")).toBeVisible()
+      await expect(page.getByRole("alert")).toBeVisible()
 
-    const focusedResult = await locateFocusedResult(page)
-    const playButton = await audio.getInactive(focusedResult)
-    await playButton.click()
+      const focusedResult = await locateFocusedResult(page)
+      const playButton = await audio.getInactive(focusedResult)
+      await playButton.click()
 
-    await expect(page.getByRole("alert")).toBeHidden()
-  })
+      await expect(page.getByRole("alert")).toBeHidden()
+    })
 
-  test("should allow toggling audio playback via play/pause click", async ({
-    page,
-  }) => {
-    await walkToType("audio", page)
-    const focusedResult = await locateFocusedResult(page)
-    const playButton = await audio.getInactive(focusedResult)
-    await playButton.click()
+    test("should allow toggling audio playback via play/pause click", async ({
+      page,
+    }) => {
+      await walkToType("audio", page)
+      const focusedResult = await locateFocusedResult(page)
+      const playButton = await audio.getInactive(focusedResult)
+      await playButton.click()
 
-    // Get the path for comparison purposes
-    const url = new URL(page.url())
-    const path = url.pathname + url.search
+      // Get the path for comparison purposes
+      const url = new URL(page.url())
+      const path = url.pathname + url.search
 
-    // should not navigate
-    expect(path).toMatch(/\/search\/?\?q=birds$/)
+      // should not navigate
+      expect(path).toMatch(/\/search\/?\?q=birds$/)
 
-    const pauseButton = await audio.getActive(focusedResult)
-    await pauseButton.click()
-    await expect(playButton).toBeVisible()
-  })
+      const pauseButton = await audio.getActive(focusedResult)
+      await pauseButton.click()
+      await expect(playButton).toBeVisible()
+    })
 
-  test("should allow toggling audio playback via spacebar", async ({
-    page,
-  }) => {
-    await walkToType("audio", page)
-    await page.keyboard.press(keycodes.Spacebar)
-    const focusedResult = await locateFocusedResult(page)
-    await expect(await audio.getActive(focusedResult)).toBeVisible()
-    await page.keyboard.press(keycodes.Spacebar)
-    await expect(await audio.getInactive(focusedResult)).toBeVisible()
-  })
+    test("should allow toggling audio playback via spacebar", async ({
+      page,
+    }) => {
+      await walkToType("audio", page)
+      await page.keyboard.press(keycodes.Spacebar)
+      const focusedResult = await locateFocusedResult(page)
+      await expect(await audio.getActive(focusedResult)).toBeVisible()
+      await page.keyboard.press(keycodes.Spacebar)
+      await expect(await audio.getInactive(focusedResult)).toBeVisible()
+    })
 
-  test("should pause audio after playing another", async ({ page }) => {
-    await walkToType("audio", page)
-    const focusedResult = await locateFocusedResult(page)
-    const playButton = await audio.getInactive(focusedResult)
-    await playButton.click()
-    const pauseButton = await audio.getActive(focusedResult)
+    test("should pause audio after playing another", async ({ page }) => {
+      await walkToType("audio", page)
+      const focusedResult = await locateFocusedResult(page)
+      const playButton = await audio.getInactive(focusedResult)
+      await playButton.click()
+      const pauseButton = await audio.getActive(focusedResult)
 
-    await page.keyboard.press(keycodes.Tab)
-    await walkToNextOfType("audio", page)
+      await page.keyboard.press(keycodes.Tab)
+      await walkToNextOfType("audio", page)
 
-    const nextFocusedResult = await locateFocusedResult(page)
-    const nextPlayButton = await audio.getInactive(nextFocusedResult)
-    await nextPlayButton.click()
-    await audio.getActive(nextFocusedResult)
+      const nextFocusedResult = await locateFocusedResult(page)
+      const nextPlayButton = await audio.getInactive(nextFocusedResult)
+      await nextPlayButton.click()
+      await audio.getActive(nextFocusedResult)
 
-    await expect(playButton).toBeVisible()
-    await expect(pauseButton).toBeHidden()
-  })
+      await expect(playButton).toBeVisible()
+      await expect(pauseButton).toBeHidden()
+    })
 
-  // Test for https://github.com/WordPress/openverse/issues/3940
-  test("clicking on skip-to-content should not navigate", async ({ page }) => {
-    const getResultsLabel = async (type: SupportedMediaType) => {
-      const link = await getContentLink(page, type)
-      return link.textContent()
-    }
-    const imageResultsLabel = await getResultsLabel("image")
-    const audioResultsLabel = await getResultsLabel("audio")
+    // Test for https://github.com/WordPress/openverse/issues/3940
+    test("clicking on skip-to-content should not navigate", async ({
+      page,
+    }) => {
+      const getResultsLabel = async (type: SupportedMediaType) => {
+        const link = await getContentLink(page, type)
+        return link.textContent()
+      }
+      const imageResultsLabel = await getResultsLabel("image")
+      const audioResultsLabel = await getResultsLabel("audio")
 
-    await skipToContent(page)
+      await skipToContent(page)
 
-    expect(await getResultsLabel("image")).toEqual(imageResultsLabel)
-    expect(await getResultsLabel("audio")).toEqual(audioResultsLabel)
-  })
-})
+      expect(await getResultsLabel("image")).toEqual(imageResultsLabel)
+      expect(await getResultsLabel("audio")).toEqual(audioResultsLabel)
+    })
+  }
+)

--- a/frontend/test/playwright/e2e/attribution.spec.ts
+++ b/frontend/test/playwright/e2e/attribution.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 import {

--- a/frontend/test/playwright/e2e/audio-detail.spec.ts
+++ b/frontend/test/playwright/e2e/audio-detail.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   collectAnalyticsEvents,

--- a/frontend/test/playwright/e2e/audio-results.spec.ts
+++ b/frontend/test/playwright/e2e/audio-results.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/collections.spec.ts
+++ b/frontend/test/playwright/e2e/collections.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 import {

--- a/frontend/test/playwright/e2e/external-sources.spec.ts
+++ b/frontend/test/playwright/e2e/external-sources.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/filters-sidebar-keyboard.spec.ts
+++ b/frontend/test/playwright/e2e/filters-sidebar-keyboard.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/filters.spec.ts
+++ b/frontend/test/playwright/e2e/filters.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   changeSearchType,

--- a/frontend/test/playwright/e2e/global-audio.spec.ts
+++ b/frontend/test/playwright/e2e/global-audio.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/header-internal.spec.ts
+++ b/frontend/test/playwright/e2e/header-internal.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   isDialogOpen,

--- a/frontend/test/playwright/e2e/healthcheck.spec.ts
+++ b/frontend/test/playwright/e2e/healthcheck.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 test("returns OK on healthcheck", async ({ page }) => {
   await page.goto("/healthcheck")

--- a/frontend/test/playwright/e2e/homepage.spec.ts
+++ b/frontend/test/playwright/e2e/homepage.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { mockProviderApis } from "~~/test/playwright/utils/route"
 import {

--- a/frontend/test/playwright/e2e/image-detail.spec.ts
+++ b/frontend/test/playwright/e2e/image-detail.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { mockProviderApis } from "~~/test/playwright/utils/route"
 import {

--- a/frontend/test/playwright/e2e/load-more.spec.ts
+++ b/frontend/test/playwright/e2e/load-more.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/mobile-menu.spec.ts
+++ b/frontend/test/playwright/e2e/mobile-menu.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, type Page } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/preferences.spec.ts
+++ b/frontend/test/playwright/e2e/preferences.spec.ts
@@ -1,4 +1,6 @@
-import { type Page, expect, test } from "@playwright/test"
+import { type Page, expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 

--- a/frontend/test/playwright/e2e/recent-searches.spec.ts
+++ b/frontend/test/playwright/e2e/recent-searches.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test, type Page } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/redirect-queryless-searches.spec.ts
+++ b/frontend/test/playwright/e2e/redirect-queryless-searches.spec.ts
@@ -3,7 +3,9 @@
  * redirect to the homepage.
  */
 
-import { test, expect } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { searchTypes, searchPath } from "~/constants/media"
 

--- a/frontend/test/playwright/e2e/report-media.spec.ts
+++ b/frontend/test/playwright/e2e/report-media.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page, BrowserContext } from "@playwright/test"
+import { expect, Page, BrowserContext } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { mockProviderApis } from "~~/test/playwright/utils/route"
 import {

--- a/frontend/test/playwright/e2e/search-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/search-analytics.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/search-navigation.spec.ts
+++ b/frontend/test/playwright/e2e/search-navigation.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   filters,

--- a/frontend/test/playwright/e2e/search-query-client.spec.ts
+++ b/frontend/test/playwright/e2e/search-query-client.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   changeSearchType,

--- a/frontend/test/playwright/e2e/search-query-server.spec.ts
+++ b/frontend/test/playwright/e2e/search-query-server.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   currentContentType,

--- a/frontend/test/playwright/e2e/search-types.spec.ts
+++ b/frontend/test/playwright/e2e/search-types.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   changeSearchType,

--- a/frontend/test/playwright/e2e/search.spec.ts
+++ b/frontend/test/playwright/e2e/search.spec.ts
@@ -6,7 +6,9 @@
  * When pending: does not show 'No images', Safer Browsing, search rating or error message
  * On error: shows error message
  */
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   collectAnalyticsEvents,

--- a/frontend/test/playwright/e2e/sensitive-results.spec.ts
+++ b/frontend/test/playwright/e2e/sensitive-results.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   filters,

--- a/frontend/test/playwright/e2e/seo.spec.ts
+++ b/frontend/test/playwright/e2e/seo.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 

--- a/frontend/test/playwright/e2e/single-result-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/single-result-analytics.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/e2e/skip-to-content.spec.ts
+++ b/frontend/test/playwright/e2e/skip-to-content.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/playwright/e2e/sources.spec.ts
+++ b/frontend/test/playwright/e2e/sources.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { getH1 } from "~~/test/playwright/utils/components"
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"

--- a/frontend/test/playwright/e2e/translation-banner.spec.ts
+++ b/frontend/test/playwright/e2e/translation-banner.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 

--- a/frontend/test/playwright/utils/breakpoints.ts
+++ b/frontend/test/playwright/utils/breakpoints.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import type { LanguageDirection } from "~~/test/playwright/utils/i18n"
 

--- a/frontend/test/playwright/utils/test.ts
+++ b/frontend/test/playwright/utils/test.ts
@@ -1,0 +1,61 @@
+// eslint-disable-next-line no-restricted-imports
+import { test as base } from "@playwright/test"
+
+const encoder = new TextEncoder()
+
+const signingSecret = process.env.HMAC_SIGNING_SECRET
+
+const { subtle } = globalThis.crypto
+
+let signingKey: null | CryptoKey = null
+
+async function getSigningKey() {
+  if (!signingSecret) {
+    return null
+  }
+
+  if (!signingKey) {
+    const encodedSecret = encoder.encode(signingSecret)
+    signingKey = await crypto.subtle.importKey(
+      "raw",
+      encodedSecret,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    )
+  }
+
+  return signingKey
+}
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Only match staging; it'll just be ignored for local testing
+    await page.route(
+      (url) => url.host === "staging.openverse.org",
+      async (route) => {
+        const key = await getSigningKey()
+        if (!key) {
+          return route.continue()
+        }
+
+        const request = route.request()
+        const url = new URL(request.url())
+        const timestamp = Math.floor(Date.now() / 1000)
+        const resource = `${url.pathname}${url.search}${timestamp}`
+        const mac = await subtle.sign("HMAC", key, encoder.encode(resource))
+
+        const headers = request.headers()
+        await route.continue({
+          headers: {
+            ...headers,
+            "x-ov-cf-mac": Buffer.from(mac).toString("base64url"),
+            "x-ov-cf-timestamp": timestamp.toString(),
+          },
+        })
+      }
+    )
+
+    await use(page)
+  },
+})

--- a/frontend/test/playwright/visual-regression/components/content-report-form.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/content-report-form.spec.ts
@@ -1,4 +1,6 @@
-import { Page, test } from "@playwright/test"
+import { type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { preparePageForTests } from "~~/test/playwright/utils/navigation"
 import breakpoints from "~~/test/playwright/utils/breakpoints"

--- a/frontend/test/playwright/visual-regression/components/external-sources-section.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/external-sources-section.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   goToSearchTerm,

--- a/frontend/test/playwright/visual-regression/components/filters.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/filters.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test, type Page } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   filters,

--- a/frontend/test/playwright/visual-regression/components/global-audio-player.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/global-audio-player.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import {
   pathWithDir,

--- a/frontend/test/playwright/visual-regression/components/header.spec.ts
+++ b/frontend/test/playwright/visual-regression/components/header.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints, {
   isMobileBreakpoint,

--- a/frontend/test/playwright/visual-regression/pages/errors.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/errors.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import {

--- a/frontend/test/playwright/visual-regression/pages/homepage.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/homepage.spec.ts
@@ -1,4 +1,6 @@
-import { test, Page } from "@playwright/test"
+import { Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import { hideInputCursors } from "~~/test/playwright/utils/page"

--- a/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import {

--- a/frontend/test/playwright/visual-regression/pages/pages.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/pages.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import {

--- a/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/search-with-banners.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import {

--- a/frontend/test/storybook/functional/smoke-test.spec.ts
+++ b/frontend/test/storybook/functional/smoke-test.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, type Page, type Locator } from "@playwright/test"
+import { expect, type Page, type Locator } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 const checkPageLoaded = async (page: Page) => {
   await expect(

--- a/frontend/test/storybook/functional/v-checkbox.spec.ts
+++ b/frontend/test/storybook/functional/v-checkbox.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"
 

--- a/frontend/test/storybook/functional/v-popover.spec.ts
+++ b/frontend/test/storybook/functional/v-popover.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 const popoverStory =
   "/iframe.html?id=components-vpopover--control&viewMode=story"

--- a/frontend/test/storybook/visual-regression/custom-button-components.spec.ts
+++ b/frontend/test/storybook/visual-regression/custom-button-components.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"
 import breakpoints from "~~/test/playwright/utils/breakpoints"

--- a/frontend/test/storybook/visual-regression/focus.spec.ts
+++ b/frontend/test/storybook/visual-regression/focus.spec.ts
@@ -1,4 +1,6 @@
-import { test, Page } from "@playwright/test"
+import { Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { expectScreenshotAreaSnapshot } from "~~/test/playwright/utils/expect-snapshot"
 

--- a/frontend/test/storybook/visual-regression/v-button.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-button.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"
 

--- a/frontend/test/storybook/visual-regression/v-checkbox.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-checkbox.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import { expectScreenshotAreaSnapshot } from "~~/test/playwright/utils/expect-snapshot"
 

--- a/frontend/test/storybook/visual-regression/v-collection-header.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-collection-header.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import { dirParam } from "~~/test/storybook/utils/args"

--- a/frontend/test/storybook/visual-regression/v-filter-button.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-filter-button.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"

--- a/frontend/test/storybook/visual-regression/v-filter-tab.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-filter-tab.spec.ts
@@ -1,4 +1,6 @@
-import { expect, type Page, test } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeUrlWithArgs } from "~~/test/storybook/utils/args"
 import { waitForResponse } from "~~/test/storybook/utils/response"

--- a/frontend/test/storybook/visual-regression/v-footer.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-footer.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-header-internal.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-header-internal.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import {

--- a/frontend/test/storybook/visual-regression/v-icon-button.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-icon-button.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { expectSnapshot } from "~~/test/playwright/utils/expect-snapshot"
 

--- a/frontend/test/storybook/visual-regression/v-image-cell.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-image-cell.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-language-select.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-language-select.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"
 import { expectSnapshot } from "~~/test/playwright/utils/expect-snapshot"

--- a/frontend/test/storybook/visual-regression/v-media-license.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-media-license.spec.ts
@@ -1,4 +1,6 @@
-import { test, Page } from "@playwright/test"
+import { Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-media-reuse.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-media-reuse.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 import { sleep } from "~~/test/playwright/utils/navigation"

--- a/frontend/test/storybook/visual-regression/v-notitication-banner.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-notitication-banner.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-safety-wall.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-safety-wall.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-search-bar-button.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-search-bar-button.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { test } from "~~/test/playwright/utils/test"
 
 import { expectSnapshot } from "~~/test/playwright/utils/expect-snapshot"
 

--- a/frontend/test/storybook/visual-regression/v-search-type-button.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-search-type-button.spec.ts
@@ -1,4 +1,6 @@
-import { expect, type Page, test } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeUrlWithArgs } from "~~/test/storybook/utils/args"
 import { t } from "~~/test/playwright/utils/i18n"

--- a/frontend/test/storybook/visual-regression/v-search-types.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-search-types.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import breakpoints from "~~/test/playwright/utils/breakpoints"
 

--- a/frontend/test/storybook/visual-regression/v-select-field.spec.ts
+++ b/frontend/test/storybook/visual-regression/v-select-field.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from "@playwright/test"
+import { expect } from "@playwright/test"
+
+import { test } from "~~/test/playwright/utils/test"
 
 import { makeGotoWithArgs } from "~~/test/storybook/utils/args"
 import { expectSnapshot } from "~~/test/playwright/utils/expect-snapshot"

--- a/packages/js/eslint-plugin/src/configs/index.ts
+++ b/packages/js/eslint-plugin/src/configs/index.ts
@@ -108,6 +108,16 @@ export const project: TSESLint.Linter.ConfigType = {
             ],
           },
         ],
+
+        "no-restricted-imports": [
+          "error",
+          {
+            name: "@playwright/test",
+            importNames: ["test"],
+            message:
+              "Import test from `~~/test/playwright/utils/test` to ensure global fixtures are used.",
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse/issues/4706 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR introduces the same HMAC request signing strategy used for #4908 tests against live environments to use with Playwright. This allows Playwright tests to run against the live environment and bypass Cloudflare's WAF, otherwise it gets blocked as automated traffic.

To enable the signing transparently, I've created an override of the `page` fixture that automatically adds the HMAC headers to requests. This requires using `test` imported from `~~/test/playwright/utils/test` so the fixture is always available. I've updated all imports of `test` to use the new location and added an ESLint rule to encourage importing from the fixture-enabled location.

Additionally, I've added a new workflow file similar to the k6 workflow for running the Playwright smoke tests. The smoke tests are identified via the [test annotation](https://playwright.dev/docs/test-annotations#tag-tests) `@deployment-smoketest`. The workflow is dispatched after staging deployments, before the load test runs.

For this initial integration, I've just tagged some keyboard navigation tests with `@deployment-smoketest`, but to fully close the issue, more tests should be included.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should pass, regular Playwright test runs should be unaffected.

You should be able to run the deployment smoke tests locally using the following command:

```bash
env HMAC_SIGNING_SECRET=<signing secret> PLAYWRIGHT_BASE_URL=https://staging.openverse.org just p frontend test:playwright:local --grep '@deployment-smoketest'
```

Maintainers can pull the signing secret as needed.

I also added temporary triggers for the new workflow file to run on pull_requests, and you can check out the successful run of that [at this link](https://github.com/WordPress/openverse/actions/runs/11510009898/job/32041101434?pr=5075). I've removed the pull_request trigger now, so it will only run when dispatched, just like the k6 workflow.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [N/A] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
