### PR TITLE
Use the correct environment DB for getting the record count of media

### DIFF
--- a/catalog/dags/data_refresh/distributed_reindex.py
+++ b/catalog/dags/data_refresh/distributed_reindex.py
@@ -24,7 +24,7 @@ from requests import Response
 from common import elasticsearch as es
 from common.constants import (
     AWS_CONN_ID,
-    OPENLEDGER_API_CONN_ID,
+    POSTGRES_API_CONN_IDS,
     PRODUCTION,
     Environment,
 )
@@ -394,7 +394,7 @@ def perform_distributed_reindex(
     """Perform the distributed reindex on a fleet of remote indexer workers."""
     id_range = PGExecuteQueryOperator(
         task_id="get_record_id_range",
-        conn_id=OPENLEDGER_API_CONN_ID,
+        conn_id=POSTGRES_API_CONN_IDS.get(target_environment),
         sql=dedent(
             f"""
             SELECT min(id), max(id) FROM {data_refresh_config.table_mapping.temp_table_name};


### PR DESCRIPTION

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

The `get_record_id_range` task of the data refresh, which gets a range of record ids to pass to the indexer workers for copying, was incorrectly always querying against the production API. This means on a staging data refresh it will fail at this step (due to the temp table not existing in prod).

This PR just updates the DAG to select the correct DB.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run the `staging_audio_data_refresh` locally and check the logs for the `get_record_id_range` task. See that it now correctly reports `Retrieving connection 'postgres_openledger_api_staging'`.

You can also run the `production_audio_data_refresh` locally and see that it is connecting to: `Retrieving connection 'postgres_openledger_api'`.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
