### PR TITLE
Create env files from templates in a change-preserving way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs/
 
 # Environment
 .env
+.env.bkp-*
 .ov_profile.json
 
 # Python environments

--- a/justfile
+++ b/justfile
@@ -152,17 +152,65 @@ lint-codeowners checks="stable":
 # Init #
 ########
 
+# Smart copy .env files from templates
+_env src dest:
+    #!/usr/bin/env python3
+    from pathlib import Path
+    import shutil
+
+    src = Path("{{ src }}")
+    dest = Path("{{ dest }}")
+    print(f"Creating {dest} from {src}.")
+
+    # If there is no existing env file, only copy the template.
+    if not dest.exists():
+        shutil.copy(src, dest)
+        exit(0)
+
+    # Read existing env file and store contents.
+    existing_env = {
+        key: value
+        for line in dest.read_text().splitlines()
+        if line and not line.startswith("#")
+        for key, _, value in [line.partition("=")]
+        if key and value
+    }
+
+    with dest.open("w") as dest_file:
+        for line in src.read_text().splitlines():
+            # Write comments and empty lines unchanged.
+            if not line or line.startswith("#"):
+                dest_file.write(f"{line}\n")
+                continue
+
+            key, _, value = line.partition("=")
+
+            # If existing value is changed, keep the existing value.
+            existing_value = existing_env.pop(key, None)
+            if existing_value and existing_value != value:
+                print(f"{key}={existing_value} (existing)")
+                value = existing_value
+
+            dest_file.write(f"{key}={value}\n")
+
+        # Keep extra variables that are not in the env template.
+        if len(existing_env):
+            dest_file.write("\n# Preserved variables\n")
+            for key, value in existing_env.items():
+                print(f"{key}={value} (preserved)")
+                dest_file.write(f"{key}={value}\n")
+
 # Create .env files from templates
 @env:
     # Root
-    ([ ! -f .env ] && cp env.template .env) || true
+    just _env env.template .env
     # Docker
-    ([ ! -f docker/minio/.env ] && cp docker/minio/env.template docker/minio/.env) || true
+    just _env docker/minio/env.template docker/minio/.env
     # First-party services
-    ([ ! -f catalog/.env ] && cp catalog/env.template catalog/.env) || true
-    ([ ! -f ingestion_server/.env ] && cp ingestion_server/env.template ingestion_server/.env) || true
-    ([ ! -f indexer_worker/.env ] && cp indexer_worker/env.template indexer_worker/.env)   || true
-    ([ ! -f api/.env ] && cp api/env.template api/.env) || true
+    just _env catalog/env.template catalog/.env
+    just _env ingestion_server/env.template ingestion_server/.env
+    just _env indexer_worker/env.template indexer_worker/.env
+    just _env api/env.template api/.env
 
 ##########
 # Docker #

--- a/justfile
+++ b/justfile
@@ -155,6 +155,8 @@ lint-codeowners checks="stable":
 # Smart copy .env files from templates
 _env src dest:
     #!/usr/bin/env python3
+    import datetime
+    import filecmp
     from pathlib import Path
     import shutil
 
@@ -162,8 +164,14 @@ _env src dest:
     dest = Path("{{ dest }}")
     print(f"Creating {dest} from {src}.")
 
-    # If there is no existing env file, only copy the template.
-    if not dest.exists():
+    if dest.exists() and not filecmp.cmp(src, dest):
+        # If there is an existing env file, back it up.
+        ts = datetime.datetime.now().strftime("%Y-%m-%d")
+        bkp = dest.with_suffix(f"{dest.suffix}.bkp-{ts}")
+        print(f"Backing up existing {dest} to {bkp}.")
+        shutil.copy(dest, bkp)
+    else:
+        # If there is no existing env file, only copy the template.
         shutil.copy(src, dest)
         exit(0)
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2938 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR updates the `env` recipe to make it "smarter". Instead of copying over the file and overwriting changes, the Python script now keeps changed env values and even extra env key-value pairs in the file.

Assume the following `env.template` file:
```
key_one=value_one
key_two=value_two
```

Assume the following `.env` file:
```
key_one=new_value_one
key_three=value_three
```

After `just env` the `.env` file would be as follows.
```
key_one=new_value_one
key_two=value_two

# Preserved variables
key_three=value_three
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Make some changes to the `catalog/.env` file. You could change some values, delete some keys or add some new keys.
1. Run `just env`.
2. See that the changes are preserved, deleted keys are restored and custom extra keys are kept at the bottom of the file.
3. Confirm this against the printed logs.

## Shortcomings

This approach does not preserve any extra comments in the `.env` file. Those will be deleted.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
