### PR TITLE
Update the analytics events for relevancy

### DIFF
--- a/frontend/shared/types/analytics.ts
+++ b/frontend/shared/types/analytics.ts
@@ -43,6 +43,10 @@ export type SearchParamsForEvent = {
 export type SearchResultParams = {
   /** The unique ID of the media */
   id: string
+  /** The search term */
+  query: string
+  /** The position of the result in the search results */
+  position: number
 }
 
 /**
@@ -78,11 +82,9 @@ export type Events = {
    *   - How often are searches returning fewer than one page of results?
    *   - How many results do most searches yield?
    */
-  GET_SEARCH_RESULTS: {
+  GET_SEARCH_RESULTS: SearchParamsForEvent & {
     /** the media type of the results. Is different from `searchType` when searchType is "all media" */
     mediaType: SupportedMediaType
-    /** The search term */
-    query: string
     /** The number of results found for this search */
     resultsCount: number
   }
@@ -293,6 +295,7 @@ export type Events = {
    *   - Which results are most popular for given searches?
    *   - How often do searches lead to clicking a result?
    *   - Are there popular searches that do not result in result selection?
+   *   - How often do users select results from the "All content" search?
    */
   SELECT_SEARCH_RESULT: SearchResultParams &
     Pick<SearchParamsForEvent, "collectionType"> & {

--- a/frontend/shared/types/analytics.ts
+++ b/frontend/shared/types/analytics.ts
@@ -45,7 +45,7 @@ export type SearchResultParams = {
   id: string
   /** The search term */
   query: string
-  /** The position of the result in the search results */
+  /** The position, not index, of the result in the search results */
   position: number
 }
 

--- a/frontend/shared/types/collection-component-props.ts
+++ b/frontend/shared/types/collection-component-props.ts
@@ -6,6 +6,7 @@ export type SingleResultProps = {
   kind: ResultKind
   searchTerm: string
   relatedTo?: string
+  position?: number
 }
 export type CommonCollectionProps = SingleResultProps & {
   collectionLabel: string

--- a/frontend/shared/utils/query-utils.ts
+++ b/frontend/shared/utils/query-utils.ts
@@ -11,6 +11,19 @@ export const firstParam = (
   return params ?? null
 }
 
+export function getNumber(
+  params: LocationQueryValue | LocationQueryValue[] | undefined
+): number {
+  const value = firstParam(params)
+  return value ? parseInt(value, 10) : -1
+}
+
+export function getString(
+  params: LocationQueryValue | LocationQueryValue[] | undefined
+): string {
+  return firstParam(params) ?? ""
+}
+
 export const validateUUID = (id: string | undefined | null) => {
   if (!id) {
     return false

--- a/frontend/src/components/VImageResult/VImageResult.vue
+++ b/frontend/src/components/VImageResult/VImageResult.vue
@@ -25,12 +25,14 @@ const props = withDefaults(
        * uses the image's intrinsic size.
        */
       aspectRatio?: AspectRatio
+      position?: number
     }
   >(),
   {
     aspectRatio: "square",
     kind: "search",
     relatedTo: "null",
+    position: -1,
   }
 )
 
@@ -61,7 +63,7 @@ const imageUrl = computed(() => {
 })
 
 const imageLink = computed(() => {
-  return `/image/${props.image.id}/${singleResultQuery(props.searchTerm)}`
+  return `/image/${props.image.id}/${singleResultQuery(props.searchTerm, props.position)}`
 })
 
 /**
@@ -116,6 +118,7 @@ const sendSelectSearchResultEvent = (event: MouseEvent) => {
     kind: props.kind,
     mediaType: IMAGE,
     provider: props.image.provider,
+    position: props.position,
     relatedTo: props.relatedTo ?? "null",
     sensitivities: props.image.sensitivity?.join(",") ?? "",
     isBlurred: shouldBlur.value ?? "null",

--- a/frontend/src/components/VImageResult/VImageResult.vue
+++ b/frontend/src/components/VImageResult/VImageResult.vue
@@ -110,10 +110,8 @@ const sendSelectSearchResultEvent = (event: MouseEvent) => {
     return
   }
 
-  const { searchType, collectionType } = searchStore.searchParamsForEvent
   $sendCustomEvent("SELECT_SEARCH_RESULT", {
-    searchType,
-    collectionType,
+    ...searchStore.searchParamsForEvent,
     id: props.image.id,
     kind: props.kind,
     mediaType: IMAGE,

--- a/frontend/src/components/VMediaInfo/VGetMediaButton.vue
+++ b/frontend/src/components/VMediaInfo/VGetMediaButton.vue
@@ -3,6 +3,7 @@ import { useNuxtApp } from "#imports"
 
 import type { SupportedMediaType } from "#shared/constants/media"
 import type { Media } from "#shared/types/media"
+import { useRouteResultParams } from "~/composables/use-route-result-params"
 
 import VButton from "~/components/VButton.vue"
 
@@ -10,12 +11,12 @@ const props = defineProps<{
   media: Media
   mediaType: SupportedMediaType
 }>()
-
+const { resultParams } = useRouteResultParams()
 const { $sendCustomEvent } = useNuxtApp()
 
 const sendGetMediaEvent = () => {
   $sendCustomEvent("GET_MEDIA", {
-    id: props.media.id,
+    ...resultParams.value,
     provider: props.media.provider,
     mediaType: props.mediaType,
   })

--- a/frontend/src/components/VMediaInfo/VLicenseTabPanel.vue
+++ b/frontend/src/components/VMediaInfo/VLicenseTabPanel.vue
@@ -2,6 +2,7 @@
 import { useNuxtApp } from "#imports"
 
 import type { SupportedMediaType } from "#shared/constants/media"
+import { useRouteResultParams } from "~/composables/use-route-result-params"
 
 import VCopyButton from "~/components/VCopyButton.vue"
 import VTabPanel from "~/components/VTabs/VTabPanel.vue"
@@ -23,10 +24,12 @@ const props = defineProps<{
   mediaType: SupportedMediaType
 }>()
 
+const { resultParams } = useRouteResultParams()
+
 const { $sendCustomEvent } = useNuxtApp()
 const handleCopy = () => {
   $sendCustomEvent("COPY_ATTRIBUTION", {
-    id: props.mediaId,
+    ...resultParams.value,
     format: props.tab,
     mediaType: props.mediaType,
   })

--- a/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAllResultsGrid.vue
@@ -38,11 +38,12 @@ const isSm = computed(() => uiStore.isBreakpoint("sm"))
       "
       :aria-label="collectionLabel"
     >
-      <template v-for="item in results">
+      <template v-for="(item, idx) in results">
         <VImageResult
           v-if="isDetail.image(item)"
           :key="item.id"
           :image="item"
+          :position="idx + 1"
           :search-term="searchTerm"
           kind="search"
           aspect-ratio="square"
@@ -51,6 +52,7 @@ const isSm = computed(() => uiStore.isBreakpoint("sm"))
           v-if="isDetail.audio(item)"
           :key="item.id"
           :audio="item"
+          :position="idx + 1"
           :search-term="searchTerm"
           layout="box"
           :size="isSm ? 'l' : 's'"

--- a/frontend/src/components/VSearchResultsGrid/VAudioCollection.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAudioCollection.vue
@@ -44,7 +44,7 @@ const audioTrackSize = computed(() => {
       :class="kind === 'related' ? 'gap-4' : 'gap-2 md:gap-1'"
     >
       <VAudioResult
-        v-for="audio in results"
+        v-for="(audio, idx) in results"
         :key="audio.id"
         :search-term="searchTerm"
         :related-to="relatedTo"
@@ -52,6 +52,7 @@ const audioTrackSize = computed(() => {
         layout="row"
         :size="audioTrackSize"
         :kind="kind"
+        :position="idx + 1"
       />
     </ol>
   </div>

--- a/frontend/src/components/VSearchResultsGrid/VAudioResult.vue
+++ b/frontend/src/components/VSearchResultsGrid/VAudioResult.vue
@@ -23,9 +23,10 @@ const props = withDefaults(
       layout: Extract<AudioLayout, "box" | "row">
       size?: AudioSize
       audio: AudioDetail
+      position?: number
     }
   >(),
-  { relatedTo: "null" }
+  { relatedTo: "null", position: -1 }
 )
 
 const { $sendCustomEvent } = useNuxtApp()
@@ -34,7 +35,7 @@ const searchStore = useSearchStore()
 const { isHidden: shouldBlur } = useSensitiveMedia(ref(props.audio))
 
 const href = computed(() => {
-  return `/audio/${props.audio.id}/${singleResultQuery(props.searchTerm)}`
+  return `/audio/${props.audio.id}/${singleResultQuery(props.searchTerm, props.position)}`
 })
 
 const sendSelectSearchResultEvent = (
@@ -47,13 +48,12 @@ const sendSelectSearchResultEvent = (
     return
   }
   useAudioSnackbar().hide()
-  const { searchType, collectionType } = searchStore.searchParamsForEvent
   $sendCustomEvent("SELECT_SEARCH_RESULT", {
-    searchType,
-    collectionType,
+    ...searchStore.searchParamsForEvent,
     id: audio.id,
     kind: props.kind,
     mediaType: AUDIO,
+    position: props.position,
     provider: audio.provider,
     relatedTo: props.relatedTo ?? "null",
     sensitivities: audio.sensitivity?.join(",") ?? "",

--- a/frontend/src/components/VSearchResultsGrid/VImageCollection.vue
+++ b/frontend/src/components/VSearchResultsGrid/VImageCollection.vue
@@ -19,9 +19,10 @@ withDefaults(defineProps<CollectionComponentProps<"image">>(), {
     :aria-label="collectionLabel"
   >
     <VImageResult
-      v-for="image in results"
+      v-for="(image, idx) in results"
       :key="image.id"
       :image="image"
+      :position="idx + 1"
       :search-term="searchTerm"
       aspect-ratio="intrinsic"
       :kind="kind"

--- a/frontend/src/composables/use-route-result-params.ts
+++ b/frontend/src/composables/use-route-result-params.ts
@@ -1,0 +1,22 @@
+import { useRoute } from "#imports"
+import { computed } from "vue"
+
+import { getNumber, getString } from "#shared/utils/query-utils"
+
+/**
+ * Extracts the media ID, search term, and result position from the single result page route.
+ */
+export const useRouteResultParams = () => {
+  const route = useRoute()
+
+  const resultParams = computed(() => {
+    const id = getString(route.params.id)
+    const query = getString(route.query.q)
+    const position = getNumber(route.query.p)
+    return { id, query, position }
+  })
+
+  return {
+    resultParams,
+  }
+}

--- a/frontend/src/pages/image/[id]/index.vue
+++ b/frontend/src/pages/image/[id]/index.vue
@@ -22,6 +22,7 @@ import { useAnalytics } from "~/composables/use-analytics"
 import { useSensitiveMedia } from "~/composables/use-sensitive-media"
 import { useSingleResultPageMeta } from "~/composables/use-single-result-page-meta"
 import { usePageRobotsRule } from "~/composables/use-page-robots-rule"
+import { useRouteResultParams } from "~/composables/use-route-result-params"
 
 import VBone from "~/components/VSkeleton/VBone.vue"
 import VMediaReuse from "~/components/VMediaInfo/VMediaReuse.vue"
@@ -99,10 +100,10 @@ const showLoadingState = computed(() => {
 
 const { sendCustomEvent } = useAnalytics()
 
-const handleRightClick = (id: string) => {
-  sendCustomEvent("RIGHT_CLICK_IMAGE", {
-    id,
-  })
+const { resultParams } = useRouteResultParams()
+
+const handleRightClick = () => {
+  sendCustomEvent("RIGHT_CLICK_IMAGE", resultParams.value)
 }
 
 const { reveal, isHidden } = useSensitiveMedia(image.value)
@@ -262,7 +263,7 @@ watch(error, (err) => {
             :height="image.height ?? 0"
             @load="onImageLoaded"
             @error="onImageError"
-            @contextmenu="handleRightClick(image.id)"
+            @contextmenu="handleRightClick"
           />
           <div
             v-if="sketchFabUid"

--- a/frontend/src/stores/media/index.ts
+++ b/frontend/src/stores/media/index.ts
@@ -485,8 +485,8 @@ export const useMediaStore = defineStore("media", {
 
         if (page == 1) {
           $sendCustomEvent("GET_SEARCH_RESULTS", {
-            mediaType: mediaType,
-            query: queryParams.q,
+            ...searchStore.searchParamsForEvent,
+            mediaType,
             resultsCount: mediaCount,
           })
         }

--- a/frontend/test/playwright/e2e/all-results-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-analytics.spec.ts
@@ -56,6 +56,7 @@ test.describe("all results grid analytics test", () => {
     const expectedPayload: Events["SELECT_SEARCH_RESULT"] = {
       ...defaultPayload,
       ...audioResult,
+      position: 2,
     }
     expectEventPayloadToMatch(selectSearchResultEvent, expectedPayload)
   })
@@ -75,6 +76,7 @@ test.describe("all results grid analytics test", () => {
       id: "da5cb478-c093-4d62-b721-cda18797e3fb",
       mediaType: IMAGE,
       provider: "flickr",
+      position: 1,
     }
 
     expectEventPayloadToMatch(selectSearchResultEvent, expectedPayload)

--- a/frontend/test/playwright/e2e/all-results-analytics.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-analytics.spec.ts
@@ -18,6 +18,7 @@ import type { Events } from "#shared/types/analytics"
 test.describe.configure({ mode: "parallel" })
 
 const searchResultPayload = {
+  query: "birds",
   kind: "search",
   collectionType: "null",
   searchType: ALL_MEDIA,

--- a/frontend/test/playwright/e2e/all-results-keyboard.spec.ts
+++ b/frontend/test/playwright/e2e/all-results-keyboard.spec.ts
@@ -20,11 +20,19 @@ test.describe.configure({ mode: "parallel" })
 
 const singleResultRegex = (
   mediaType: SupportedMediaType,
-  searchTerm?: string
+  searchTerm?: string,
+  position?: number
 ) => {
-  const query = searchTerm ? `\\?q=${searchTerm}` : ""
+  const query = new URLSearchParams()
+  if (searchTerm) {
+    query.set("q", searchTerm)
+  }
+  if (position) {
+    query.set("p", position.toString())
+  }
+  const queryStr = query.toString() ? `\\?${query}` : ""
   return new RegExp(
-    `/${mediaType}/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}${query}$`,
+    `/${mediaType}/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}${queryStr}$`,
     "i"
   )
 }
@@ -43,7 +51,7 @@ test.describe(
       const mediaType = "image"
       await walkToType(mediaType, page)
       await page.keyboard.press("Enter")
-      const urlRegex = singleResultRegex(mediaType, searchTerm)
+      const urlRegex = singleResultRegex(mediaType, searchTerm, 1)
 
       await page.waitForURL(urlRegex)
       expect(page.url()).toMatch(urlRegex)
@@ -53,7 +61,7 @@ test.describe(
       const mediaType = "audio"
       await walkToType(mediaType, page)
       await page.keyboard.press("Enter")
-      const urlRegex = singleResultRegex(mediaType, searchTerm)
+      const urlRegex = singleResultRegex(mediaType, searchTerm, 2)
       await page.waitForURL(urlRegex)
       expect(page.url()).toMatch(urlRegex)
     })

--- a/frontend/test/playwright/e2e/attribution.spec.ts
+++ b/frontend/test/playwright/e2e/attribution.spec.ts
@@ -85,6 +85,8 @@ test.describe("attribution", () => {
       id: imageId,
       format,
       mediaType: "image",
+      query: "",
+      position: -1,
     })
   })
 })

--- a/frontend/test/playwright/e2e/audio-detail.spec.ts
+++ b/frontend/test/playwright/e2e/audio-detail.spec.ts
@@ -56,6 +56,8 @@ test("sends GET_MEDIA event on CTA button click", async ({ context, page }) => {
   const expectedPayload: Events["GET_MEDIA"] = {
     ...audioObject,
     mediaType: "audio",
+    query: "",
+    position: -1,
   }
   expectEventPayloadToMatch(getMediaEvent, expectedPayload)
 })
@@ -138,6 +140,8 @@ test("sends SELECT_SEARCH_RESULT event on related audio click", async ({
     mediaType: "audio",
     provider: "wikimedia_audio",
     searchType: "all",
+    query: "",
+    position: 1,
     sensitivities: "",
     isBlurred: false,
     collectionType: "null",

--- a/frontend/test/playwright/e2e/image-detail.spec.ts
+++ b/frontend/test/playwright/e2e/image-detail.spec.ts
@@ -86,6 +86,8 @@ test("sends GET_MEDIA event on CTA button click", async ({ context, page }) => {
     id: imageObject.id,
     provider: imageObject.provider,
     mediaType: "image",
+    query: "",
+    position: -1,
   }
   expectEventPayloadToMatch(getMediaEvent, expectedPayload)
 })
@@ -107,6 +109,8 @@ test("sends RIGHT_CLICK_IMAGE event on right-click", async ({
 
   const expectedPayload: Events["RIGHT_CLICK_IMAGE"] = {
     id: imageObject.id,
+    query: "",
+    position: -1,
   }
   expectEventPayloadToMatch(rightClickImageEvent, expectedPayload)
 })
@@ -137,9 +141,11 @@ test("sends SELECT_SEARCH_RESULT event on related image click", async ({
     mediaType: "image",
     provider: "flickr",
     searchType: "all",
+    query: "",
     sensitivities: "",
     isBlurred: false,
     collectionType: "null",
+    position: 1,
   }
   expectEventPayloadToMatch(selectSearchResultEvent, expectedPayload)
 })

--- a/frontend/test/playwright/e2e/search-navigation.spec.ts
+++ b/frontend/test/playwright/e2e/search-navigation.spec.ts
@@ -143,19 +143,17 @@ test.describe("search query param is set on a single page results", () => {
     page,
   }) => {
     await openFirstResult(page, "image")
-    const url = page.url()
-    const query = url.substring(url.indexOf("=") + 1)
+    const url = new URLSearchParams(page.url().split("?")[1])
 
-    expect(query).toEqual("cat")
+    expect(url.get("q")).toEqual("cat")
   })
 
   test("the search query param should be set to the search term inside the header on a single page result of type audio", async ({
     page,
   }) => {
     await openFirstResult(page, "audio")
-    const url = page.url()
-    const query = url.substring(url.indexOf("=") + 1)
+    const url = new URLSearchParams(page.url().split("?")[1])
 
-    expect(query).toEqual("cat")
+    expect(url.get("q")).toEqual("cat")
   })
 })

--- a/frontend/test/playwright/utils/search-results.ts
+++ b/frontend/test/playwright/utils/search-results.ts
@@ -34,7 +34,7 @@ export const locateFocusedResult = async (page: Page) => {
   expect(href).toBeDefined()
   const url = new URL(href ?? "")
 
-  return page.locator(`[href="${url.pathname}?q=birds"]`)
+  return page.locator(`[href*="${url.pathname}?q=birds"]`)
 }
 
 /**


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5005 by @zackkrida
Fixes #5107 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the analytics events so that we can analyze results for relevancy for their search queries.

When the user interacts with a search results, we can assume that the result is relevant to their search [^1]. There are several events that are sent when the users interact with a single result: `SELECT_SEARCH_RESULT` on the search result page, and `COPY_ATTRIBUTION`, `GET_MEDIA` and `RIGHT_CLICK` on the single result page. 

This PR adds the data on which search term was the media returned for, and what position it had in the result list. Now, we will be able to analyze not only which items the users click on on the search results for the specific query, but also which items they are downloading, or copying the attribution for. I think `COPY_ATTRIBUTION` is the strongest signal for the result being relevant for the specific search query.

### Changes to the audio result
The `href` computation for audio was moved from the `VAudioTrack` to `VAudioResult`, to match the image result behavior. Audio track only has a URL if it is an audio result, not if it's the main audio track on the single result page.

### Simplifying the event properties

Before this PR, we had two very similar properties: `searchTerm` for the search results, and `collectionValue` for the collection views. Since we can filter the Plausible events by more than one property, I combined the two into single `searchTerm` (or `query`).

### Type-safe e2e event testing
This PR also updates the e2e tests to check for full equality of the analytics event payloads (excluding the default width, height and breakpoint properties), so that we never miss anything. The payloads are also extracted to separate variables to make them type-checked.

[^1]: unless the result was selected to report it from the single result page.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app using `ov just frontend/run dev`
Run a search and select a search result. You should see `SELECT_SEARCH_RESULT` event with query and position logged in the console.
If you click on "Copy button", or right-click on the image, you should see the new properties (position and query) for the analytics events in the console.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
