### PR TITLE
Remove logic to change port to 8002 for prod data refresh

### DIFF
--- a/catalog/dags/data_refresh/distributed_reindex.py
+++ b/catalog/dags/data_refresh/distributed_reindex.py
@@ -261,15 +261,9 @@ def create_connection(
     """
     worker_conn_id = f"indexer_worker_{instance_id or media_type}"
 
-    # TODO: Locally we use 8003 to avoid collision with the legacy indexer worker that's
-    # part of the ingestion server. When the ingestion server and legacy data refresh are
-    # removed, we should modify the local environment to use 8002 here as well and
-    # avoid having to do this check.
-    port = "8003" if environment != PRODUCTION else "8002"
-
     # Create the Connection
     logger.info(f"Creating connection with id {worker_conn_id}")
-    worker_conn = Connection(conn_id=worker_conn_id, uri=f"http://{server}:{port}/")
+    worker_conn = Connection(conn_id=worker_conn_id, uri=f"http://{server}:8003/")
     session = settings.Session()
     session.add(worker_conn)
     session.commit()


### PR DESCRIPTION

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #5083 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

We think that the indexer worker port being misconfigured in production to 8002, when it is 8003 locally, may be causing/part of the issue with #5083. Rather than changing the port we try to access from the data refresh, we're going to update the indexer worker in production and this code will no longer be required.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
CI should not fail.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
