### PR TITLE
Prevent layout shift by removing `<ClientOnly>` on the theme selector

### DIFF
--- a/frontend/src/components/VFooter/VFooter.vue
+++ b/frontend/src/components/VFooter/VFooter.vue
@@ -104,9 +104,7 @@ const linkColumnHeight = computed(() => ({
             v-bind="languageProps"
             class="language max-w-full border-secondary"
           />
-          <ClientOnly>
-            <VThemeSelect class="border-secondary" />
-          </ClientOnly>
+          <VThemeSelect class="border-secondary" />
         </div>
       </template>
       <template v-else>

--- a/frontend/src/components/VThemeSelect/VThemeSelect.vue
+++ b/frontend/src/components/VThemeSelect/VThemeSelect.vue
@@ -6,9 +6,9 @@ light, dark and system.
 <script setup lang="ts">
 import { useI18n, useDarkMode } from "#imports"
 
-import { computed, type ComputedRef } from "vue"
+import { computed, ref, onMounted, watch, type Ref } from "vue"
 
-import { useUiStore } from "~/stores/ui"
+import { useUiStore, type ColorMode } from "~/stores/ui"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
 import VSelectField, {
@@ -26,14 +26,13 @@ const THEME_ICON_NAME = Object.freeze({
 const THEME_TEXT = {
   light: i18n.t(`theme.choices.light`),
   dark: i18n.t(`theme.choices.dark`),
+  system: i18n.t(`theme.choices.system`),
 }
 
-const colorMode = computed({
-  get: () => uiStore.colorMode,
-  set: (value) => {
-    uiStore.setColorMode(value)
-  },
-})
+const colorMode: Ref<ColorMode | undefined> = ref(undefined)
+const handleUpdateModelValue = (value: string) => {
+  uiStore.setColorMode(value as ColorMode)
+}
 
 const isDarkModeSeen = computed(() => uiStore.isDarkModeSeen)
 const setIsDarkModeSeen = () => {
@@ -46,28 +45,35 @@ const darkMode = useDarkMode()
  * The icon always reflects the actual theme applied to the site.
  * Therefore, it must be based on the value of `effectiveColorMode`.
  */
-const currentThemeIcon = computed(
-  () => THEME_ICON_NAME[darkMode.effectiveColorMode.value]
-)
+const currentThemeIcon: Ref<"sun" | "moon" | undefined> = ref(undefined)
 
 /**
  * The choices are computed because the text for the color mode choice
  * "system" is dynamic and reflects the user's preferred color scheme at
  * the OS-level.
  */
-const choices: ComputedRef<Choice[]> = computed(() => {
-  const systemText = `${i18n.t(`theme.choices.system`)} (${THEME_TEXT[darkMode.osColorMode.value]})`
-  return [
-    { key: "light", text: THEME_TEXT.light },
-    { key: "dark", text: THEME_TEXT.dark },
-    { key: "system", text: systemText },
-  ]
-})
+const choices: Ref<Choice[]> = ref([
+  { key: "light", text: THEME_TEXT.light },
+  { key: "dark", text: THEME_TEXT.dark },
+  { key: "system", text: THEME_TEXT.system },
+])
+
+const updateRefs = () => {
+  colorMode.value = uiStore.colorMode
+  currentThemeIcon.value = THEME_ICON_NAME[darkMode.effectiveColorMode.value]
+  choices.value[2].text = `${THEME_TEXT.system} (${THEME_TEXT[darkMode.osColorMode.value]})`
+}
+
+onMounted(updateRefs)
+watch(
+  () => [darkMode.effectiveColorMode.value, darkMode.osColorMode.value],
+  updateRefs
+)
 </script>
 
 <template>
   <VSelectField
-    v-model="colorMode"
+    :model-value="colorMode"
     field-id="theme"
     :choices="choices"
     :blank-text="$t('theme.theme')"
@@ -75,9 +81,10 @@ const choices: ComputedRef<Choice[]> = computed(() => {
     :show-selected="false"
     :show-new-highlight="!isDarkModeSeen"
     @click="setIsDarkModeSeen"
+    @update:model-value="handleUpdateModelValue"
   >
     <template #start>
-      <VIcon :name="currentThemeIcon" />
+      <VIcon v-if="currentThemeIcon" :name="currentThemeIcon" />
     </template>
   </VSelectField>
 </template>

--- a/frontend/src/components/VThemeSelect/VThemeSelect.vue
+++ b/frontend/src/components/VThemeSelect/VThemeSelect.vue
@@ -29,7 +29,7 @@ const THEME_TEXT = {
   system: i18n.t(`theme.choices.system`),
 }
 
-const colorMode: Ref<ColorMode | undefined> = ref(undefined)
+const colorMode: Ref<ColorMode> = ref(uiStore.colorMode)
 const handleUpdateModelValue = (value: string) => {
   uiStore.setColorMode(value as ColorMode)
 }


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5085 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR
- removes `<ClientOnly>` around `VThemeSelect` in the footer
- updates the `VThemeSelect` component to use `Ref`s instead of `ComputedRefs`s
- uses `onMounted` and `watch` to keep the refs updated

These in combination lead to the layout shift being eliminated and avoid server-client hydration mismatches.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
