### PR TITLE
Append concurrency tag to prevent issues between DAGs in staging

### DIFF
--- a/catalog/dags/common/sensors/utils.py
+++ b/catalog/dags/common/sensors/utils.py
@@ -64,7 +64,7 @@ def get_dags_with_concurrency_tag(
     return [id for id in dag_ids if id not in {*excluded_dag_ids, running_dag_id}]
 
 
-@task
+@task(map_index_template="{{ task.op_kwargs['external_dag_id'] }}")
 def wait_for_external_dag(
     external_dag_id: str,
     task_id: str | None = None,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5128 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the missing `STAGING_DB_CONCURRENCY_TAG` to the staging data refresh DAG to prevent it from running with conflicting DAGs like the staging database restore.

It also gives the index of the `wait_for_external_dag` mapped tasks a friendlier name than the default numbers. Now it shows the DAG id being checked.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Spin up the catalog and API stack `ov just c && ov just a`
2. Run the `staging_<media>_data_refresh` DAGs and observe the checks for the conflicting DAGs are in place.

![Screenshot 2024-11-08 at 16-38-45 staging_image_data_refresh - Grid - Airflow](https://github.com/user-attachments/assets/e75a7922-4c2c-4dfb-84c8-53bf33e14c4b)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`ov just catalog/generate-docs media-props` for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
