### PR TITLE
Modify k6 load tests

### DIFF
--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -55,6 +55,7 @@ jobs:
           just k6 ${{ inputs.namespace }} ${{ inputs.scenario }} \
             ${{ inputs.report && '-o cloud' || ''}} \
             -e signing_secret="$K6_SIGNING_SECRET" \
+            -e scenario_duration="6m" \
             -e service_url=${{ inputs.service_url }} \
             -e text_summary=/tmp/k6-summary.txt
 

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -71,20 +71,22 @@ export interface UiState {
 
 export const breakpoints = Object.keys(ALL_SCREEN_SIZES)
 
+export const defaultUiState: UiState = {
+  instructionsSnackbarState: "not_shown",
+  innerFilterVisible: false,
+  isFilterDismissed: false,
+  isDesktopLayout: false,
+  breakpoint: "sm",
+  dismissedBanners: [],
+  shouldBlurSensitive: true,
+  revealedSensitiveResults: [],
+  headerHeight: 80,
+  colorMode: "system",
+  isDarkModeSeen: false,
+}
+
 export const useUiStore = defineStore("ui", {
-  state: (): UiState => ({
-    instructionsSnackbarState: "not_shown",
-    innerFilterVisible: false,
-    isFilterDismissed: false,
-    isDesktopLayout: false,
-    breakpoint: "sm",
-    dismissedBanners: [],
-    shouldBlurSensitive: true,
-    revealedSensitiveResults: [],
-    headerHeight: 80,
-    colorMode: "system",
-    isDarkModeSeen: false,
-  }),
+  state: (): UiState => ({ ...defaultUiState }),
 
   getters: {
     cookieState(state): OpenverseCookieState["ui"] {

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -71,22 +71,20 @@ export interface UiState {
 
 export const breakpoints = Object.keys(ALL_SCREEN_SIZES)
 
-export const defaultUiState: UiState = {
-  instructionsSnackbarState: "not_shown",
-  innerFilterVisible: false,
-  isFilterDismissed: false,
-  isDesktopLayout: false,
-  breakpoint: "sm",
-  dismissedBanners: [],
-  shouldBlurSensitive: true,
-  revealedSensitiveResults: [],
-  headerHeight: 80,
-  colorMode: "system",
-  isDarkModeSeen: false,
-}
-
 export const useUiStore = defineStore("ui", {
-  state: (): UiState => ({ ...defaultUiState }),
+  state: (): UiState => ({
+    instructionsSnackbarState: "not_shown",
+    innerFilterVisible: false,
+    isFilterDismissed: false,
+    isDesktopLayout: false,
+    breakpoint: "sm",
+    dismissedBanners: [],
+    shouldBlurSensitive: true,
+    revealedSensitiveResults: [],
+    headerHeight: 80,
+    colorMode: "system",
+    isDarkModeSeen: false,
+  }),
 
   getters: {
     cookieState(state): OpenverseCookieState["ui"] {

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -106,17 +106,17 @@ const createScenario = (
   funcName: Action
 ): Scenario => {
   return {
+    executor: "constant-arrival-rate",
+    env,
+    exec: funcName,
     // k6 CLI flags do not allow override scenario options, so we need to add our own
     // Ideally we would use default
     // https://community.grafana.com/t/overriding-vus-individual-scenario/98923
     timeUnit: __ENV.scenario_time_utin || "1m",
     rate: parseInt(__ENV.scenario_rate) || 10,
-    duration: __ENV.scenario_duration || "5m",
+    duration: __ENV.scenario_duration || "4m",
     preAllocatedVUs: 100,
     maxVUs: 200,
-    executor: "constant-arrival-rate",
-    env,
-    exec: funcName,
   }
 }
 

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -107,7 +107,7 @@ const createScenario = (
 ): Scenario => {
   return {
     timeUnit: __ENV.scenario_time_utin || "1m",
-    rate: parseInt(__ENV.scenario_rate) || 40,
+    rate: parseInt(__ENV.scenario_rate) || 30,
     duration: __ENV.scenario_duration || "5m",
     preAllocatedVUs: 100,
     maxVUs: 200,

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -115,8 +115,8 @@ const createScenario = (
     timeUnit: __ENV.scenario_time_utin || "1m",
     rate: parseInt(__ENV.scenario_rate) || 3,
     duration: __ENV.scenario_duration || "4m",
-    preAllocatedVUs: 100,
-    maxVUs: 200,
+    preAllocatedVUs: 10,
+    maxVUs: 20,
   }
 }
 

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -108,7 +108,7 @@ const createScenario = (
   return {
     timeUnit: __ENV.scenario_time_utin || "1m",
     rate: parseInt(__ENV.scenario_rate) || 20,
-    duration: __ENV.scenario_duration || "3m",
+    duration: __ENV.scenario_duration || "5m",
     preAllocatedVUs: 100,
     maxVUs: 200,
     executor: "constant-arrival-rate",

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -107,7 +107,7 @@ const createScenario = (
 ): Scenario => {
   return {
     timeUnit: __ENV.scenario_time_utin || "1m",
-    rate: parseInt(__ENV.scenario_rate) || 20,
+    rate: parseInt(__ENV.scenario_rate) || 30,
     duration: __ENV.scenario_duration || "5m",
     preAllocatedVUs: 100,
     maxVUs: 200,

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -107,7 +107,7 @@ const createScenario = (
 ): Scenario => {
   return {
     timeUnit: __ENV.scenario_time_utin || "1m",
-    rate: parseInt(__ENV.scenario_rate) || 30,
+    rate: parseInt(__ENV.scenario_rate) || 40,
     duration: __ENV.scenario_duration || "5m",
     preAllocatedVUs: 100,
     maxVUs: 200,

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -106,19 +106,17 @@ const createScenario = (
   funcName: Action
 ): Scenario => {
   return {
+    // k6 CLI flags do not allow override scenario options, so we need to add our own
+    // Ideally we would use default
+    // https://community.grafana.com/t/overriding-vus-individual-scenario/98923
     timeUnit: __ENV.scenario_time_utin || "1m",
-    rate: parseInt(__ENV.scenario_rate) || 30,
+    rate: parseInt(__ENV.scenario_rate) || 10,
     duration: __ENV.scenario_duration || "5m",
     preAllocatedVUs: 100,
     maxVUs: 200,
     executor: "constant-arrival-rate",
     env,
     exec: funcName,
-    // k6 CLI flags do not allow override scenario options, so we need to add our own
-    // Ideally we would use default
-    // https://community.grafana.com/t/overriding-vus-individual-scenario/98923
-    // vus: parseFloat(__ENV.scenario_vus) || 5,
-    // iterations: parseFloat(__ENV.scenario_iterations) || 40
   }
 }
 

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -106,14 +106,19 @@ const createScenario = (
   funcName: Action
 ): Scenario => {
   return {
-    executor: "per-vu-iterations",
+    timeUnit: __ENV.scenario_time_utin || "1m",
+    rate: parseInt(__ENV.scenario_rate) || 20,
+    duration: __ENV.scenario_duration || "1m",
+    preAllocatedVUs: 100,
+    maxVUs: 200,
+    executor: "constant-arrival-rate",
     env,
     exec: funcName,
     // k6 CLI flags do not allow override scenario options, so we need to add our own
     // Ideally we would use default
     // https://community.grafana.com/t/overriding-vus-individual-scenario/98923
-    vus: parseFloat(__ENV.scenario_vus) || 5,
-    iterations: parseFloat(__ENV.scenario_iterations) || 40,
+    // vus: parseFloat(__ENV.scenario_vus) || 5,
+    // iterations: parseFloat(__ENV.scenario_iterations) || 40
   }
 }
 

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -108,7 +108,7 @@ const createScenario = (
   return {
     timeUnit: __ENV.scenario_time_utin || "1m",
     rate: parseInt(__ENV.scenario_rate) || 20,
-    duration: __ENV.scenario_duration || "1m",
+    duration: __ENV.scenario_duration || "3m",
     preAllocatedVUs: 100,
     maxVUs: 200,
     executor: "constant-arrival-rate",

--- a/packages/js/k6/src/frontend/scenarios.ts
+++ b/packages/js/k6/src/frontend/scenarios.ts
@@ -113,7 +113,7 @@ const createScenario = (
     // Ideally we would use default
     // https://community.grafana.com/t/overriding-vus-individual-scenario/98923
     timeUnit: __ENV.scenario_time_utin || "1m",
-    rate: parseInt(__ENV.scenario_rate) || 10,
+    rate: parseInt(__ENV.scenario_rate) || 3,
     duration: __ENV.scenario_duration || "4m",
     preAllocatedVUs: 100,
     maxVUs: 200,


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5179 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The frontend k6 load test runs against the local Nuxt app on every CI run. Initially, when the test was added to run against the staging environment, it failed due to CPU limitations. To address this, we temporarily increased the staging CPU from 0.25 vCPU to 2 vCPU. However, our goal is to restore the staging environment to its previous resource levels while still reliably detecting potential memory leaks.

The k6 load tests run agains the locally-ran Nuxt app in the GitHub-hosted CI runners on every CI run, and then again after the PR is merged, against the Nuxt app deployed on staging. The GitHub-hosted CI runners use 4 CPU processor and 16 GB of RAM [^1]. 

This PR adjusts the k6 test settings to maintain a constant request rate while preventing the tests from overwhelming the staging environment. It uses the `constant-arrival-rate` executor, which means that the rate of requests per seconds is constant, and does not depend on whether response was received or not.

After experimenting with different configurations, I think the following values will be a good start:

- **duration**: 4-minute test is ensures that the load test completes within the CI pipeline timeframe, aligning with Playwright tests. 
- **requests-per-second**: I tried to lower this value 4 times, to match the required CPU usage in staging: from 7.28 rps to 1.72 rps. This was achieved by setting the rate for each scenario to 3 per minute. With six scenarios, this configuration results in an overall request rate of approximately 1.72 requests per second. 

Here are some statistics from the k6 tests in staging, as well as the last 3 CI runs in this PR:

| **Metric**                | **Staging Environment**              | **GH CI Run 1 - Rate 30, Duration 5m** | **GH CI Run 2 - Rate 10, Duration 5m** | **GH CI Run 3 - Rate 3, Duration 4m**  |
|---------------------------|---------------------------------------|----------------------------------------|----------------------------------------|----------------------------------------|
| **Requests Per Second (req/s)** | 7.28 req/s                            | 16.05 req/s                            | 5.39 req/s                             | 1.72 req/s                             |
| **Total Requests**        | 4420                                  | 4832                                   | 1622                                   | 416                                    |
| **Total Test Duration**   | ~10 minutes (607 seconds)            | ~5 minutes (301 seconds)               | ~5 minutes (301 seconds)               | ~4 minutes (240 seconds)               |
| **Average Request Time**  | 3.47 seconds                         | 153.4 milliseconds                     | 140.08 milliseconds                    | 197.71 milliseconds                    |
| **Maximum Request Time**  | 10.26 seconds                        | 801.91 milliseconds                    | 976.82 milliseconds                    | 801.33 milliseconds                    |
| **Dropped Iterations**    | 235                                   | 0                                      | 0                                      | 0                                      |
| **Iterations**            | 965                                   | 906                                    | 304                                    | 78                                     |
| **Iteration Rate**        | 1.59 iterations/s                    | 3.01 iterations/s                      | 1.01 iterations/s                      | 0.32 iterations/s                      |

[^1]: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### Deployment
For better testing how the k6 tests catch memory leaks and whether the new values are appropriate, I think the following process should be followed:
1. Merge in the changes reverted in #4864, and see how the tests go in staging. We should see memory problems, manifested in either in a higher memory consumption in the AWS dashboard, or in the higher request timings/dropped iterations values.
2. Merge in this PR to try to cap the CPU usage at 25% (since 25% of 2 vCPU should be equivalent to 100% of 0.25 vCPU). The values for the k6 tests should improve, but the memory leak should still be detectable.
3. Revert the first change with the memory leak, confirm that the memory and CPU consumptions are within the lower limits of the staging values we want.
4. Reduce the staging task resources.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Confirm that the deployment plan makes sense or suggest improvements.
Check the CI report for the load test and see that the requests per minutes are lower, and the test finishes within 4 minutes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
