### PR TITLE
Add option to skip dotenv files recreation when `just up` runs

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,4 +1,3 @@
-# Catalog
-AIRFLOW_PORT=9090
-AWS_ACCESS_KEY=test_key
-AWS_SECRET_KEY=test_secret
+# DC_USER=opener
+
+# SKIP_DOTENV_FILES_RECREATION=true

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set dotenv-load := false
+set dotenv-load := true
 
 # Meaning of Just prefixes:
 # @ - Quiet recipes (https://github.com/casey/just#quiet-recipes)

--- a/justfile
+++ b/justfile
@@ -209,16 +209,21 @@ _env src dest:
                 dest_file.write(f"{key}={value}\n")
 
 # Create .env files from templates
-@env:
-    # Root
-    just _env env.template .env
-    # Docker
-    just _env docker/minio/env.template docker/minio/.env
-    # First-party services
-    just _env catalog/env.template catalog/.env
-    just _env ingestion_server/env.template ingestion_server/.env
-    just _env indexer_worker/env.template indexer_worker/.env
-    just _env api/env.template api/.env
+env:
+    #!/usr/bin/env sh
+    if ! {{ env_var_or_default("SKIP_DOTENV_FILES_RECREATION", "false") }} ; then
+        # Root
+        just _env env.template .env
+        # Docker
+        just _env docker/minio/env.template docker/minio/.env
+        # First-party services
+        just _env catalog/env.template catalog/.env
+        just _env ingestion_server/env.template ingestion_server/.env
+        just _env indexer_worker/env.template indexer_worker/.env
+        just _env api/env.template api/.env
+    else
+        echo "Skipping .env files (re)creation."
+    fi
 
 ##########
 # Docker #

--- a/justfile
+++ b/justfile
@@ -211,19 +211,19 @@ _env src dest:
 # Create .env files from templates
 env:
     #!/usr/bin/env sh
-    if ! {{ env_var_or_default("SKIP_DOTENV_FILES_RECREATION", "false") }} ; then
-        # Root
-        just _env env.template .env
-        # Docker
-        just _env docker/minio/env.template docker/minio/.env
-        # First-party services
-        just _env catalog/env.template catalog/.env
-        just _env ingestion_server/env.template ingestion_server/.env
-        just _env indexer_worker/env.template indexer_worker/.env
-        just _env api/env.template api/.env
-    else
+    if {{ env_var_or_default("SKIP_DOTENV_FILES_RECREATION", "false") }} ; then
         echo "Skipping .env files (re)creation."
+        exit 0
     fi
+    # Root
+    just _env env.template .env
+    # Docker
+    just _env docker/minio/env.template docker/minio/.env
+    # First-party services
+    just _env catalog/env.template catalog/.env
+    just _env ingestion_server/env.template ingestion_server/.env
+    just _env indexer_worker/env.template indexer_worker/.env
+    just _env api/env.template api/.env
 
 ##########
 # Docker #


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
A situation that somewhat exasperates me is that every time the `just up` command runs, it prints several lines to the terminal, and running it every day creates a long list of `.env.bkp-<date>` files. These files aren't modified often, so I prefer to skip this process.

An alternative could be to create a variable to make the execution of `just _env` quiet.

Follow up on #5099.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run the command and observe the files recreation is skipped.

```sh
SKIP_DOTENV_FILES_RECREATION=true just env
```

2. Confirm the `just up` recipe works as it used to do it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`ov just catalog/generate-docs media-props`  for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
