### PR TITLE
Update the icon color in `onMounted`

### DIFF
--- a/frontend/src/components/VLicense/VLicense.vue
+++ b/frontend/src/components/VLicense/VLicense.vue
@@ -7,10 +7,10 @@ import { useI18n } from "#imports"
 
 import { computed } from "vue"
 
-import { useDarkMode } from "~/composables/use-dark-mode"
+import { useIconNames } from "~/composables/use-icon-names"
 
 import type { License } from "~/constants/license"
-import { getFullLicenseName, getElements } from "~/utils/license"
+import { getFullLicenseName } from "~/utils/license"
 import { camelCase } from "~/utils/case"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
@@ -37,11 +37,13 @@ const props = withDefaults(
   }
 )
 
-const { effectiveColorMode } = useDarkMode()
-
 const { t } = useI18n({ useScope: "global" })
 
-const iconNames = computed(() => getElements(props.license))
+const { iconNames } = useIconNames({
+  license: props.license,
+  filterOutCc: false,
+})
+
 const licenseName = computed(() => {
   const licenseKey =
     props.license === "sampling+" ? props.license : camelCase(props.license)
@@ -60,7 +62,7 @@ const licenseName = computed(() => {
         :key="name"
         :class="{ 'license-bg text-black': bgFilled }"
         view-box="0 0 30 30"
-        :name="`licenses/${name}-${effectiveColorMode}`"
+        :name="name"
         :size="4"
       />
     </div>

--- a/frontend/src/components/VLicense/VLicenseElements.vue
+++ b/frontend/src/components/VLicense/VLicenseElements.vue
@@ -4,7 +4,7 @@ import { useI18n } from "#imports"
 import { computed } from "vue"
 
 import type { License } from "~/constants/license"
-import { useDarkMode } from "~/composables/use-dark-mode"
+import { useIconNames } from "~/composables/use-icon-names"
 import { useUiStore } from "~/stores/ui"
 import { camelCase } from "~/utils/case"
 import { getElements } from "~/utils/license"
@@ -28,12 +28,15 @@ const props = withDefaults(
   }
 )
 
-const { effectiveColorMode } = useDarkMode()
-
 const i18n = useI18n({ useScope: "global" })
 const elementNames = computed(() =>
   getElements(props.license).filter((icon) => icon !== "cc")
 )
+
+const { iconNames } = useIconNames({
+  license: props.license,
+  filterOutCc: true,
+})
 
 const isSmall = computed(() => props.size === "small")
 const uiStore = useUiStore()
@@ -47,14 +50,14 @@ const getLicenseDescription = (element: string) => {
 <template>
   <ul class="flex flex-col gap-y-2 md:gap-y-4">
     <li
-      v-for="element in elementNames"
+      v-for="(element, idx) in elementNames"
       :key="element"
       class="flex items-center gap-x-3 text-sm md:text-base"
     >
       <VIcon
         view-box="0 0 30 30"
         :size="isSmall || isMobile ? 5 : 6"
-        :name="`licenses/${element}-${effectiveColorMode}`"
+        :name="iconNames[idx]"
       />
       <span v-if="elementNames.length > 1" class="sr-only">{{
         element.toUpperCase()

--- a/frontend/src/composables/use-dark-mode.ts
+++ b/frontend/src/composables/use-dark-mode.ts
@@ -65,6 +65,15 @@ export function useDarkMode() {
     return colorMode.value
   })
 
+  /**
+   * The server does not have access to media queries, so the `system` color mode defaults to "light".
+   */
+  const serverColorMode = computed(() => {
+    return !darkModeToggleable.value || colorMode.value === "system"
+      ? "light"
+      : colorMode.value
+  })
+
   const cssClass = computed(() => {
     return {
       light: LIGHT_MODE_CLASS,
@@ -77,6 +86,7 @@ export function useDarkMode() {
     colorMode,
     osColorMode,
     effectiveColorMode,
+    serverColorMode,
     cssClass,
   }
 }

--- a/frontend/src/composables/use-icon-names.ts
+++ b/frontend/src/composables/use-icon-names.ts
@@ -1,0 +1,49 @@
+import { getElements } from "#imports"
+
+import { computed, onMounted, ref, watch } from "vue"
+
+import type { License } from "~/constants/license"
+import { useDarkMode } from "~/composables/use-dark-mode"
+
+/**
+ * Generate the names for `VIcon` components based on the license and color mode.
+ * The value is updated on mounted and when the color mode changes.
+ *
+ * This is necessary to prevent client-server mismatch: the server does not have access
+ * to media queries, so the `system` color mode always defaults to "light".
+ * @param license - the license to generate icons for
+ * @param filterOutCc - whether to filter out the `cc` from the list of icons
+ */
+export const useIconNames = ({
+  license,
+  filterOutCc,
+}: {
+  license: License
+  filterOutCc: boolean
+}) => {
+  const getIconNames = (elements: string[], colorMode: "dark" | "light") => {
+    return elements.map((element) => `licenses/${element}-${colorMode}`)
+  }
+  const { effectiveColorMode, serverColorMode } = useDarkMode()
+
+  const icons = computed(() => {
+    const elements = getElements(license)
+    return filterOutCc
+      ? elements.filter((element) => element !== "cc")
+      : elements
+  })
+
+  const iconNames = ref(getIconNames(icons.value, serverColorMode.value))
+
+  onMounted(() => {
+    watch(
+      effectiveColorMode,
+      () => {
+        iconNames.value = getIconNames(icons.value, effectiveColorMode.value)
+      },
+      { immediate: true }
+    )
+  })
+
+  return { iconNames }
+}


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5227 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR replaces the `computed` values for icon names with `ref` that are updated in `onMounted` (which runs after the hydration is done). The license icons and the theme icons are affected, but I can revert the change for the theme switcher if #5236 is the preferred approach, @dhruvkb .

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Select the "system" mode and refresh a single result page. Make sure your system is set to dark mode by default (or use the browser devtools). Refresh the page and see that there are no client-server mismatch warnings: neither for the theme switcher (sun/moon icons) nor for the license icons on every image result:

<img width="318" alt="Light mode license icon" src="https://github.com/user-attachments/assets/7fac83dd-2e81-4fdb-9b1d-acb4d8adfb23">
<img width="314" alt="Dark mode license icon" src="https://github.com/user-attachments/assets/7665040d-0d74-4ef7-ae90-44fd422e3029">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
