### PR TITLE
Launch the dark mode

### DIFF
--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -34,7 +34,7 @@
     "dark_mode_ui_toggle": {
       "status": {
         "staging": "switchable",
-        "production": "switchable"
+        "production": "enabled"
       },
       "defaultState": "on",
       "description": "Display the UI toggle to change the site color theme and respect system preferences.",

--- a/frontend/feat/feature-flags.json
+++ b/frontend/feat/feature-flags.json
@@ -34,7 +34,7 @@
     "dark_mode_ui_toggle": {
       "status": {
         "staging": "switchable",
-        "production": "disabled"
+        "production": "switchable"
       },
       "defaultState": "on",
       "description": "Display the UI toggle to change the site color theme and respect system preferences.",

--- a/frontend/src/components/VFeatureNotice/VDarkModeFeatureNotice.vue
+++ b/frontend/src/components/VFeatureNotice/VDarkModeFeatureNotice.vue
@@ -11,9 +11,8 @@ const handleClick = () => {
 </script>
 
 <template>
-  <!-- TODO: Populate the post permalink. -->
   <VFeatureNotice
-    see-more-href="https://make.wordpress.org/openverse/"
+    see-more-href="https://make.wordpress.org/openverse/?p=2216"
     @click="handleClick"
   >
     {{ $t("notification.darkMode.text") }}

--- a/frontend/test/unit/specs/composables/use-dark-mode.spec.ts
+++ b/frontend/test/unit/specs/composables/use-dark-mode.spec.ts
@@ -1,4 +1,4 @@
-import { computed } from "#imports"
+import { computed } from "vue"
 
 import { describe, expect, test, vi } from "vitest"
 import { usePreferredColorScheme } from "@vueuse/core"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets the feature flag to `switchable`, and `on` by default both in production and in staging. It also adds the link to the draft announcement Make post.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and see that the link leads to the draft post (maintainers only, you need to be logged int to see the draft). The theme switcher should be on by default.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
