### PR TITLE
Fix broken schemathesis tests

### DIFF
--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -46,6 +46,7 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
     view_is_async = True
 
     lookup_field = "identifier"
+    lookup_value_converter = "uuid"
 
     pagination_class = StandardPagination
 

--- a/api/conf/settings/sentry.py
+++ b/api/conf/settings/sentry.py
@@ -4,6 +4,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
 from conf.settings.base import ENVIRONMENT
+from conf.settings.security import DEBUG
 
 
 SENTRY_DSN = config("SENTRY_DSN", default="")
@@ -12,9 +13,6 @@ SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0, cast=
 SENTRY_PROFILES_SAMPLE_RATE = config(
     "SENTRY_PROFILES_SAMPLE_RATE", default=0, cast=float
 )
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("DJANGO_DEBUG_ENABLED", default=False, cast=bool)
 
 INTEGRATIONS = [
     DjangoIntegration(),

--- a/api/conf/urls/__init__.py
+++ b/api/conf/urls/__init__.py
@@ -24,7 +24,7 @@ versioned_paths = [
     path("", include(deprecations_urlpatterns)),  # Deprecated, redirects to new URL
 ]
 
-router = SimpleRouter()
+router = SimpleRouter(use_regex_path=False)
 router.register("audio", AudioViewSet, basename="audio")
 router.register("images", ImageViewSet, basename="image")
 versioned_paths += router.urls

--- a/api/test/test_schema.py
+++ b/api/test/test_schema.py
@@ -3,9 +3,30 @@ import re
 from django.conf import settings
 
 import schemathesis
+from schemathesis.checks import content_type_conformance
 
 
 schema = schemathesis.from_uri(f"{settings.CANONICAL_ORIGIN}/v1/schema/")
+
+
+def status_code_aware_content_type_conformance(ctx, res, case):
+    """
+    Skip Content-Type conformance check when status code is 404.
+
+    A status code of 404 can come from two sources:
+    - Django sees the incoming URL and cannot map it to any endpoint.
+      This returns an HTML response.
+    - DRF gets the request but cannot map any object to the identifier.
+      This returns a content-negotiated HTML/JSON response.
+
+    Since the end user will likely not be using the data in the 404
+    response anyway, we don't need the Content-Type to be validated.
+    """
+
+    if res.status_code == 404:
+        return
+
+    return content_type_conformance(ctx, res, case)
 
 
 # The null-bytes Bearer tokens are skipped.
@@ -30,4 +51,7 @@ def test_schema(case: schemathesis.Case):
         # from schemathesis's implementation of `parameterize`.
         return
 
-    case.call_and_validate()
+    case.call_and_validate(
+        excluded_checks=[content_type_conformance],
+        additional_checks=[status_code_aware_content_type_conformance],
+    )


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes issues with schemathesis arising in #5273.
- Extends schemathesis' content-type conformation tests to handle 404 responses from Django and DRF.
- Switches to DRF's path-based `SimpleRouter`.
- Fixes a double definition of the `DEBUG` setting field.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
