### PR TITLE
Add required variables for Nuxt Sentry setup

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -180,8 +180,9 @@ jobs:
       - name: Build image `${{ matrix.image }}`
         uses: docker/build-push-action@v6
         with:
+          # The Sentry auth token is only set for the production release of the frontend (on push to main or manual release).
           secrets: |
-            "sentry_auth_token=${{ matrix.image == 'frontend' && !((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
+            "sentry_auth_token=${{ matrix.image == 'frontend' && ((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -165,7 +165,6 @@ jobs:
           setup_python: false
           setup_nodejs: ${{ matrix.image == 'frontend' && 'true' || 'false' }}
           install_recipe: ${{ matrix.image == 'frontend' && 'node-install' || '' }}
-          locales: ${{ matrix.image == 'frontend' && 'production' || '' }}
 
       # Sets build args specifying versions needed to build Docker image.
       - name: Prepare build args
@@ -182,7 +181,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           secrets: |
-            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
+            "sentry_auth_token=${{ matrix.image == 'frontend' && ((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false
@@ -203,7 +202,6 @@ jobs:
             FRONTEND_NODE_VERSION=${{ steps.prepare-build-args.outputs.frontend_node_version }}
             FRONTEND_PNPM_VERSION=${{ steps.prepare-build-args.outputs.frontend_pnpm_version }}
             PGCLI_VERSION=${{ steps.prepare-build-args.outputs.pgcli_version }}
-            ADD_SENTRY_RELEASE=${{ ((github.event_name == 'push' && github.repository == 'WordPress/openverse') || (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) }}
             ${{ matrix.build-args || '' }}
 
       - name: Upload image `${{ matrix.image }}`

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -193,7 +193,6 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
           build-contexts: ${{ matrix.build-contexts }}
           build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SEMANTIC_VERSION=${{ needs.get-image-tag.outputs.image_tag }}
             OV_PDM_VERSION=${{ steps.prepare-build-args.outputs.ov_pdm_version }}
             CATALOG_PY_VERSION=${{ steps.prepare-build-args.outputs.catalog_py_version }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -690,6 +690,7 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
+          locales: "test"
 
       - name: Build and run Nuxt and Talkback
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -153,9 +153,6 @@ jobs:
       - determine-images
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       # Sets up `just` and Node.js.
       # Node.js is needed for the frontend to download translations.
       # `just` is needed to run the recipes and set build args.
@@ -180,9 +177,9 @@ jobs:
 
       - name: Build image `${{ matrix.image }}`
         uses: docker/build-push-action@v6
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
+          secrets: |
+            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false
@@ -204,8 +201,6 @@ jobs:
             FRONTEND_PNPM_VERSION=${{ steps.prepare-build-args.outputs.frontend_pnpm_version }}
             PGCLI_VERSION=${{ steps.prepare-build-args.outputs.pgcli_version }}
             ${{ matrix.build-args || '' }}
-          secrets: |
-            id=sentry_auth_token,env=SENTRY_AUTH_TOKEN
 
       - name: Upload image `${{ matrix.image }}`
         id: upload-img

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -183,7 +183,7 @@ jobs:
         with:
           # The Sentry auth token is only set for the production release of the frontend (on push to main or manual release).
           secrets: |
-            "sentry_auth_token=${{ matrix.image == 'frontend' && ((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
+            ${{ matrix.image == 'frontend' && ((github.event_name == 'push' && github.repository == 'WordPress/openverse') || (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -153,6 +153,9 @@ jobs:
       - determine-images
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       # Sets up `just` and Node.js.
       # Node.js is needed for the frontend to download translations.
       # `just` is needed to run the recipes and set build args.

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -182,7 +182,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           secrets: |
-            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
+            "sentry_auth_token=${{ matrix.image == 'frontend' && secrets.SENTRY_AUTH_TOKEN }}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false
@@ -203,6 +203,7 @@ jobs:
             FRONTEND_NODE_VERSION=${{ steps.prepare-build-args.outputs.frontend_node_version }}
             FRONTEND_PNPM_VERSION=${{ steps.prepare-build-args.outputs.frontend_pnpm_version }}
             PGCLI_VERSION=${{ steps.prepare-build-args.outputs.pgcli_version }}
+            ADD_SENTRY_RELEASE=${{ ((github.event_name == 'push' && github.repository == 'WordPress/openverse') || (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) }}
             ${{ matrix.build-args || '' }}
 
       - name: Upload image `${{ matrix.image }}`

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -670,7 +670,6 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
-          locales: "production"
 
       - name: Run build
         run: just frontend/run build
@@ -692,7 +691,6 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
-          locales: "test"
 
       - name: Build and run Nuxt and Talkback
         run: |
@@ -800,7 +798,6 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
-          locales: "test"
 
       - name: Run check recipe
         run: just ${{ matrix.recipe }}
@@ -913,7 +910,6 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
-          locales: "test"
 
       - name: Run Playwright tests
         run: just frontend/run ${{ matrix.script }} --workers=2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -181,7 +181,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           secrets: |
-            "sentry_auth_token=${{ matrix.image == 'frontend' && ((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
+            "sentry_auth_token=${{ matrix.image == 'frontend' && !((github.event_name == 'push' && github.repository == 'WordPress/openverse') ||(github.event_name == 'workflow_dispatch' && inputs.perform_deploy)) && secrets.SENTRY_AUTH_TOKEN || ''}}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -180,6 +180,8 @@ jobs:
 
       - name: Build image `${{ matrix.image }}`
         uses: docker/build-push-action@v6
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
@@ -203,6 +205,8 @@ jobs:
             FRONTEND_PNPM_VERSION=${{ steps.prepare-build-args.outputs.frontend_pnpm_version }}
             PGCLI_VERSION=${{ steps.prepare-build-args.outputs.pgcli_version }}
             ${{ matrix.build-args || '' }}
+          secrets: |
+            id=sentry_auth_token,env=SENTRY_AUTH_TOKEN
 
       - name: Upload image `${{ matrix.image }}`
         id: upload-img

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -182,7 +182,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           secrets: |
-            "sentry_auth_token=${{ matrix.image == 'frontend' && secrets.SENTRY_AUTH_TOKEN }}"
+            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
           context: ${{ matrix.context }}
           target: ${{ matrix.target }}
           push: false

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -165,6 +165,7 @@ jobs:
           setup_python: false
           setup_nodejs: ${{ matrix.image == 'frontend' && 'true' || 'false' }}
           install_recipe: ${{ matrix.image == 'frontend' && 'node-install' || '' }}
+          locales: ${{ matrix.image == 'frontend' && 'production' || '' }}
 
       # Sets build args specifying versions needed to build Docker image.
       - name: Prepare build args
@@ -669,6 +670,7 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
+          locales: "production"
 
       - name: Run build
         run: just frontend/run build
@@ -910,6 +912,7 @@ jobs:
         with:
           setup_python: false
           install_recipe: node-install
+          locales: "test"
 
       - name: Run Playwright tests
         run: just frontend/run ${{ matrix.script }} --workers=2

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,7 +37,7 @@ ENV SKIP_PRE_COMMIT=true
 # Get rid of the lockfile as it won't be accurate for the build without workspace.
 # Then install dependencies, and in the process:
 #   - fix the missing lockfile by writing a new one
-RUN pnpm install && pnpm i18n
+RUN pnpm install
 
 # disable telemetry when building the app
 ENV NUXT_TELEMETRY_DISABLED=1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,7 @@ ARG FRONTEND_NODE_VERSION
 FROM docker.io/node:${FRONTEND_NODE_VERSION}-alpine AS builder
 
 ARG SEMANTIC_VERSION
+ARG ADD_SENTRY_RELEASE
 
 # Install system packages needed to build on macOS
 RUN apk add --no-cache --virtual .gyp python3 make g++ \
@@ -46,11 +47,16 @@ ENV NODE_ENV=production
 # Increase memory limit for the build process (necessary for i18n routes)
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
+ENV ADD_SENTRY_RELEASE=${ADD_SENTRY_RELEASE}
+
 
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
-    sh -c 'SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
-    echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" >> .env.sentry-build-plugin'
+    sh -c 'if [ "$ADD_SENTRY_RELEASE" = "true" ]; then \
+      SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
+      echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" >> .env.sentry-build-plugin; \
+    fi' \
 
+RUN printenv
 
 RUN pnpm build
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,6 @@ ARG FRONTEND_NODE_VERSION
 FROM docker.io/node:${FRONTEND_NODE_VERSION}-alpine AS builder
 
 ARG SEMANTIC_VERSION
-ARG SENTRY_AUTH_TOKEN
 
 # Install system packages needed to build on macOS
 RUN apk add --no-cache --virtual .gyp python3 make g++ \
@@ -48,9 +47,9 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
-# Use BuildKit secret for SENTRY_AUTH_TOKEN
 RUN --mount=type=secret,id=sentry_auth_token \
   sh -c "export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) && pnpm build"
+
 ############
 # Nuxt app #
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,14 +3,15 @@
 
 # Automatically build image using Node.js version specified in `package.json`.
 ARG FRONTEND_NODE_VERSION
-ARG SENTRY_AUTH_TOKEN
-ARG SEMANTIC_VERSION
 
 ###################
 # Node.js builder #
 ###################
 
 FROM docker.io/node:${FRONTEND_NODE_VERSION}-alpine AS builder
+
+ARG SEMANTIC_VERSION
+ARG SENTRY_AUTH_TOKEN
 
 # Install system packages needed to build on macOS
 RUN apk add --no-cache --virtual .gyp python3 make g++ \
@@ -46,10 +47,10 @@ ENV NODE_ENV=production
 # Increase memory limit for the build process (necessary for i18n routes)
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
-ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 
-RUN pnpm build
-
+# Use BuildKit secret for SENTRY_AUTH_TOKEN
+RUN --mount=type=secret,id=sentry_auth_token \
+  sh -c "export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) && pnpm build"
 ############
 # Nuxt app #
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -50,14 +50,15 @@ ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 ENV ADD_SENTRY_RELEASE=${ADD_SENTRY_RELEASE}
 
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
-    sh -c 'if [ "$ADD_SENTRY_RELEASE" = "true" ]; then \
-      SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
-      echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" >> .env.sentry-build-plugin; \
-    fi' && printenv
+    sh -c 'SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
+      echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" && \
+      export SENTRY_AUTH_TOKEN; \
+    ' && printenv
 
 RUN echo add sentry release: "$ADD_SENTRY_RELEASE" && echo semantic version: "$SEMANTIC_VERSION" && echo sentry auth token: "$SENTRY_AUTH_TOKEN"
 
 RUN pnpm build
+
 ############
 # Nuxt app #
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,9 +47,15 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
-# Use the Sentry auth token secret to send the sourcemaps to Sentry
+# Use the Sentry auth token secret to send the sourcemaps to Sentry only if the secret is provided
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
-    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" pnpm build
+    sh -c 'if [ -f /run/secrets/sentry_auth_token ]; then \
+      SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"; \
+      echo "Using Sentry Auth Token: $SENTRY_AUTH_TOKEN"; \
+    else \
+      echo "No Sentry Auth Token provided"; \
+    fi' && pnpm build
+
 
 ############
 # Nuxt app #

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,6 +47,8 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
+RUN printenv
+
 RUN --mount=type=secret,id=sentry_auth_token \
   sh -c "export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) && pnpm build"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,6 +47,7 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
+# Use the Sentry auth token secret to send the sourcemaps to Sentry
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
     SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" pnpm build
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -53,9 +53,9 @@ RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
     sh -c 'if [ "$ADD_SENTRY_RELEASE" = "true" ]; then \
       SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
       echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" >> .env.sentry-build-plugin; \
-    fi' \
+    fi' && printenv
 
-RUN printenv
+RUN echo add sentry release: "$ADD_SENTRY_RELEASE" && echo semantic version: "$SEMANTIC_VERSION" && echo sentry auth token: "$SENTRY_AUTH_TOKEN"
 
 RUN pnpm build
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,6 @@ ARG FRONTEND_NODE_VERSION
 FROM docker.io/node:${FRONTEND_NODE_VERSION}-alpine AS builder
 
 ARG SEMANTIC_VERSION
-ARG ADD_SENTRY_RELEASE
 
 # Install system packages needed to build on macOS
 RUN apk add --no-cache --virtual .gyp python3 make g++ \
@@ -47,13 +46,6 @@ ENV NODE_ENV=production
 # Increase memory limit for the build process (necessary for i18n routes)
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
-ENV ADD_SENTRY_RELEASE=${ADD_SENTRY_RELEASE}
-
-RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
-    sh -c 'SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
-      echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" && \
-      export SENTRY_AUTH_TOKEN; \
-    ' && printenv
 
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
     SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" pnpm build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,8 @@
 
 # Automatically build image using Node.js version specified in `package.json`.
 ARG FRONTEND_NODE_VERSION
+ARG SENTRY_AUTH_TOKEN
+ARG SEMANTIC_VERSION
 
 ###################
 # Node.js builder #
@@ -43,6 +45,8 @@ ENV NODE_ENV=production
 
 # Increase memory limit for the build process (necessary for i18n routes)
 ENV NODE_OPTIONS="--max_old_space_size=4096"
+ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
+ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 
 RUN pnpm build
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,12 +47,11 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
-RUN printenv
+RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
+    sh -c 'SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \
+    echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" >> .env.sentry-build-plugin'
 
-RUN --mount=type=secret,id=sentry_auth_token \
-    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"
 
-RUN printenv
 RUN pnpm build
 ############
 # Nuxt app #

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -49,9 +49,11 @@ ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
 RUN printenv
 
+RUN --mount=type=secret,id=sentry_auth_token \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"
 
-RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN && pnpm build"
-
+RUN printenv
+RUN pnpm build
 ############
 # Nuxt app #
 ############

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -49,8 +49,8 @@ ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 
 RUN printenv
 
-RUN --mount=type=secret,id=sentry_auth_token \
-  sh -c "export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) && pnpm build"
+
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN && pnpm build"
 
 ############
 # Nuxt app #

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -55,9 +55,8 @@ RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
       export SENTRY_AUTH_TOKEN; \
     ' && printenv
 
-RUN echo add sentry release: "$ADD_SENTRY_RELEASE" && echo semantic version: "$SEMANTIC_VERSION" && echo sentry auth token: "$SENTRY_AUTH_TOKEN"
-
-RUN pnpm build
+RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" pnpm build
 
 ############
 # Nuxt app #

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -49,7 +49,6 @@ ENV NODE_OPTIONS="--max_old_space_size=4096"
 ENV SEMANTIC_VERSION=${SEMANTIC_VERSION}
 ENV ADD_SENTRY_RELEASE=${ADD_SENTRY_RELEASE}
 
-
 RUN --mount=type=secret,id=sentry_auth_token,mode=0444 \
     sh -c 'if [ "$ADD_SENTRY_RELEASE" = "true" ]; then \
       SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" && \

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -132,6 +132,11 @@ export default defineNuxtConfig({
       org: "openverse",
       project: "openverse-frontend",
     },
+    unstable_sentryBundlerPluginOptions: {
+      release: {
+        name: import.meta.env.SEMANTIC_VERSION,
+      },
+    },
   },
   sourcemap: {
     client: "hidden",

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -131,6 +131,10 @@ export default defineNuxtConfig({
     sourceMapsUploadOptions: {
       org: "openverse",
       project: "openverse-frontend",
+      /**
+       * This token is only used in the CI to upload source maps to Sentry when building the production
+       * image of the frontend.
+       */
       authToken: process.env.SENTRY_AUTH_TOKEN,
     },
     unstable_sentryBundlerPluginOptions: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -131,6 +131,7 @@ export default defineNuxtConfig({
     sourceMapsUploadOptions: {
       org: "openverse",
       project: "openverse-frontend",
+      authToken: process.env.SENTRY_AUTH_TOKEN,
     },
     unstable_sentryBundlerPluginOptions: {
       release: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -134,7 +134,7 @@ export default defineNuxtConfig({
     },
     unstable_sentryBundlerPluginOptions: {
       release: {
-        name: import.meta.env.SEMANTIC_VERSION,
+        name: process.env.SEMANTIC_VERSION,
       },
     },
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "predev": "pnpm install && pnpm i18n:en",
     "dev": "run-p dev:only 'i18n:en --watch'",
-    "dev:only": "nuxt dev --host 0.0.0.0",
+    "dev:only": "npx nuxi dev --host 0.0.0.0",
     "dev:secure": "LOCAL_SSL=enabled pnpm dev",
-    "build": "NODE_ENV=production nuxt build",
+    "build": "npx nuxi build",
     "build:clean": "rm -rf .nuxt",
     "docker:build": "docker build . -t openverse-frontend:latest",
     "docker:run": "docker run --rm -it -p 127.0.0.1:8443:8443/tcp openverse-frontend:latest",

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -5,13 +5,6 @@ import dotenv from "dotenv"
 // @see the section on server setup: https://nuxt.com/modules/sentry
 dotenv.config()
 
-console.log(
-  "Will initialize Sentry with dsn",
-  process.env.NUXT_PUBLIC_SENTRY_DSN
-)
-console.log("environment", process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT)
-console.log("release", process.env.SEMANTIC_VERSION)
-
 Sentry.init({
   dsn: process.env.NUXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -5,6 +5,13 @@ import dotenv from "dotenv"
 // @see the section on server setup: https://nuxt.com/modules/sentry
 dotenv.config()
 
+console.log(
+  "Will initialize Sentry with dsn",
+  process.env.NUXT_PUBLIC_SENTRY_DSN
+)
+console.log("environment", process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT)
+console.log("release", process.env.SEMANTIC_VERSION)
+
 Sentry.init({
   dsn: process.env.NUXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT,

--- a/justfile
+++ b/justfile
@@ -48,7 +48,6 @@ node-install:
     pnpm i
     pnpm --filter './packages/js/*' run build
     pnpm prepare:nuxt
-    just frontend/run i18n:en
 
 
 # Set up locales for the frontend


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Follow up on #5279

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This pull request updates the Docker build process to address an issue with environment variables not being properly read by Sentry during image builds. This prevented the source maps from being created and sent to Sentry. The `release` also wasn't set, so the source maps did not work.

In our CI pipeline, when a pull request is merged into the main branch, the process builds a Docker image that will then be deployed to production. We need to generate the source maps and release for this image, and not other builds.

To generate and upload the source maps and release, Sentry needs the auth token. This is set in CI only on the push to main (when a PR is merged) or when release is triggered manually through the Actions GUI. This way, the source maps are generated and sent to Sentry only once per PR.

Setting the release name also did not work with the env variable, only using the `sentry.unstable_sentryBundlerPluginOptions` properties in `nuxt.config.ts` did [^1].

~~With these changes, I also removed some locales setup from the `setup-env`, because they are set up second time during the build of the app - so duplicated unnecessarily.~~ Instead of removing the locale setup from `setup-env`, I removed it from the Dockerfile.

[^1]: [[Nuxt] Cannot set release name used by sentry-vite-plugin](https://github.com/getsentry/sentry-javascript/issues/13380)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
You can see the run that did set an auth token (because I inverted the condition for variable), and built the sourcemaps and uploaded them to Sentry: https://github.com/WordPress/openverse/actions/runs/12387322051/job/34576691827?pr=5284

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
