### PR TITLE
Fix scrollbars for Windows browsers

### DIFF
--- a/frontend/src/components/VModal/VModalContent.vue
+++ b/frontend/src/components/VModal/VModalContent.vue
@@ -227,6 +227,6 @@ by the address bar.
 }
 .modal-content {
   max-height: calc(100vh - var(--modal-header-height, 0) - 6rem);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 </style>

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -14,7 +14,7 @@ defineOptions({
     class="app h-dyn-screen grid grid-cols-1 grid-rows-[auto,1fr] flex-col bg-complementary dark:bg-default"
   >
     <VHeader class="header-el" kind="internal" color="complementary" />
-    <div class="main-content flex flex-grow flex-col overflow-y-scroll">
+    <div class="main-content flex flex-grow flex-col overflow-y-auto">
       <slot class="flex-grow" />
       <VFooter mode="internal" class="bg-complementary dark:bg-default" />
     </div>


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5282  by @obulat 

## Description
This pull request fixes the issue where scrollbars were displayed unnecessarily in Windows browsers due to the use of `overflow-y-scroll` in `default.vue` and `VModalContent.vue`. 

<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
**Before**
![image](https://github.com/user-attachments/assets/3b8c5c83-7032-434d-a4e4-c40aa34b7ef8)
**After**
![image](https://github.com/user-attachments/assets/d8a4ed6d-8c5a-4b5d-94d7-d3e11bcc4f58)


## Changes made:
- In `default.vue`, replaced `overflow-y-scroll` with `overflow-y-auto` to ensure scrollbars are shown only when content overflows.
- In `VModalContent.vue`, replaced `overflow-y: scroll;` with `overflow-y: auto;` to prevent always-visible scrollbars and allow them to appear only when needed.

## Testing Instructions
1. Run the application locally on a Windows machine.
2. Navigate to the homepage.
3. Ensure that scrollbars appear only when the content overflows, and they remain hidden when the content fits within the viewport.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
