### PR TITLE
Add sources cache to Nuxt app

### DIFF
--- a/frontend/server/api/sources.ts
+++ b/frontend/server/api/sources.ts
@@ -1,76 +1,51 @@
-import { ofetch } from "ofetch"
 import { consola } from "consola"
-import { defineEventHandler } from "h3"
-import { useRuntimeConfig } from "nitropack/runtime"
-import { useStorage } from "nitropack/runtime/storage"
+import { useRuntimeConfig, defineCachedFunction } from "nitropack/runtime"
+import { defineEventHandler, getProxyRequestHeaders, type H3Event } from "h3"
 
-import { supportedMediaTypes } from "#shared/constants/media"
-import type { SupportedMediaType } from "#shared/constants/media"
+import {
+  supportedMediaTypes,
+  type SupportedMediaType,
+} from "#shared/constants/media"
+import { userAgentHeader } from "#shared/constants/user-agent.mjs"
 import { mediaSlug } from "#shared/utils/query-utils"
 
-const UPDATE_FREQUENCY = 1000 * 60 * 60 // 1 hour
-
-const needsUpdate = (lastUpdated: Date | null | undefined) => {
-  if (!lastUpdated) {
-    return true
-  }
-  const timePassed = new Date().getTime() - new Date(lastUpdated).getTime()
-  return timePassed > UPDATE_FREQUENCY
-}
-
-type MediaTypeCache = { data: MediaProvider[]; updatedAt: Date | null }
+const UPDATE_FREQUENCY_SECONDS = 60 * 60 // 1 hour
 
 type Sources = {
   [K in SupportedMediaType]: MediaProvider[]
 }
 
-const SOURCES = "sources"
+const getSources = defineCachedFunction(
+  async (mediaType: SupportedMediaType, event: H3Event) => {
+    const apiUrl = useRuntimeConfig(event).public.apiUrl
+
+    consola.info(`Fetching sources for ${mediaType} media`)
+
+    return await $fetch<MediaProvider[]>(
+      `${apiUrl}v1/${mediaSlug(mediaType)}/stats/`,
+      {
+        headers: {
+          ...getProxyRequestHeaders(event),
+          ...userAgentHeader,
+        },
+      }
+    )
+  },
+  {
+    maxAge: UPDATE_FREQUENCY_SECONDS,
+    name: "sources",
+    getKey: (mediaType) => mediaType,
+  }
+)
 
 /**
- * This endpoint that returns cached sources data for all supported media types,
- * if the data is no older than `UPDATE_FREQUENCY`.
- * Otherwise, it fetches the data from the API, caches it and returns the updated data.
+ * The cached function uses stale-while-revalidate (SWR) to fetch sources for each media type only once per hour.
  */
 export default defineEventHandler(async (event) => {
-  const cache = useStorage<MediaTypeCache>(SOURCES)
-
-  const sources = { image: [], audio: [] } as Sources
+  const sources: Sources = { audio: [], image: [] }
 
   for (const mediaType of supportedMediaTypes) {
-    const cacheKey = `${SOURCES}:${mediaType}`
-
-    const cachedSources = await cache.getItem(cacheKey)
-    const expired = needsUpdate(cachedSources?.updatedAt)
-
-    if (cachedSources && cachedSources.data?.length && !expired) {
-      sources[mediaType] = cachedSources.data
-      consola.debug(`Using cached ${mediaType} sources data.`)
-    } else {
-      const reason = !cachedSources
-        ? "cache is not set"
-        : !cachedSources.data?.length
-          ? "the cached array is empty"
-          : "cache is outdated"
-
-      consola.debug(`Fetching ${mediaType} sources data because ${reason}.`)
-      const apiUrl = useRuntimeConfig(event).public.apiUrl
-      try {
-        const res = await ofetch<MediaProvider[]>(
-          `${apiUrl}v1/${mediaSlug(mediaType)}/stats`,
-          { headers: event.headers }
-        )
-        const updatedAt = new Date()
-        await cache.setItem(cacheKey, { data: res, updatedAt })
-        consola.info(
-          `Fetched ${res.length} ${mediaType} sources data on ${updatedAt.toISOString()}.`
-        )
-        sources[mediaType] = res
-      } catch (error) {
-        consola.error("Error fetching sources data", error)
-        event.context.$sentry.captureException(error)
-        sources[mediaType] = cachedSources?.data ?? []
-      }
-    }
+    sources[mediaType] = await getSources(mediaType, event)
   }
 
   return sources

--- a/frontend/server/api/sources.ts
+++ b/frontend/server/api/sources.ts
@@ -1,0 +1,77 @@
+import { ofetch } from "ofetch"
+import { consola } from "consola"
+import { defineEventHandler } from "h3"
+import { useRuntimeConfig } from "nitropack/runtime"
+import { useStorage } from "nitropack/runtime/storage"
+
+import { supportedMediaTypes } from "#shared/constants/media"
+import type { SupportedMediaType } from "#shared/constants/media"
+import { mediaSlug } from "#shared/utils/query-utils"
+
+const UPDATE_FREQUENCY = 1000 * 60 * 60 // 1 hour
+
+const needsUpdate = (lastUpdated: Date | null | undefined) => {
+  if (!lastUpdated) {
+    return true
+  }
+  const timePassed = new Date().getTime() - new Date(lastUpdated).getTime()
+  return timePassed > UPDATE_FREQUENCY
+}
+
+type MediaTypeCache = { data: MediaProvider[]; updatedAt: Date | null }
+
+type Sources = {
+  [K in SupportedMediaType]: MediaProvider[]
+}
+
+const SOURCES = "sources"
+
+/**
+ * This endpoint that returns cached sources data for all supported media types,
+ * if the data is no older than `UPDATE_FREQUENCY`.
+ * Otherwise, it fetches the data from the API, caches it and returns the updated data.
+ */
+export default defineEventHandler(async (event) => {
+  const cache = useStorage<MediaTypeCache>(SOURCES)
+
+  const sources = { image: [], audio: [] } as Sources
+
+  for (const mediaType of supportedMediaTypes) {
+    const cacheKey = `${SOURCES}:${mediaType}`
+
+    const cachedSources = await cache.getItem(cacheKey)
+    const expired = needsUpdate(cachedSources?.updatedAt)
+
+    if (cachedSources && cachedSources.data?.length && !expired) {
+      sources[mediaType] = cachedSources.data
+      consola.debug(`Using cached ${mediaType} sources data.`)
+    } else {
+      const reason = !cachedSources
+        ? "cache is not set"
+        : !cachedSources.data?.length
+          ? "the cached array is empty"
+          : "cache is outdated"
+
+      consola.debug(`Fetching ${mediaType} sources data because ${reason}.`)
+      const apiUrl = useRuntimeConfig(event).public.apiUrl
+      try {
+        const res = await ofetch<MediaProvider[]>(
+          `${apiUrl}v1/${mediaSlug(mediaType)}/stats`,
+          { headers: event.headers }
+        )
+        const updatedAt = new Date()
+        await cache.setItem(cacheKey, { data: res, updatedAt })
+        consola.info(
+          `Fetched ${res.length} ${mediaType} sources data on ${updatedAt.toISOString()}.`
+        )
+        sources[mediaType] = res
+      } catch (error) {
+        consola.error("Error fetching sources data", error)
+        event.context.$sentry.captureException(error)
+        sources[mediaType] = cachedSources?.data ?? []
+      }
+    }
+  }
+
+  return sources
+})

--- a/frontend/test/unit/specs/stores/provider.spec.ts
+++ b/frontend/test/unit/specs/stores/provider.spec.ts
@@ -3,7 +3,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { setActivePinia, createPinia } from "~~/test/unit/test-utils/pinia"
 
-import { AUDIO, IMAGE } from "#shared/constants/media"
+import { IMAGE } from "#shared/constants/media"
 import type { MediaProvider } from "#shared/types/media-provider"
 import { useProviderStore } from "~/stores/provider"
 
@@ -42,8 +42,8 @@ describe("provider store", () => {
     expect(providerStore.providers.audio.length).toEqual(0)
     expect(providerStore.providers.image.length).toEqual(0)
     expect(providerStore.fetchState).toEqual({
-      [AUDIO]: { hasStarted: false, isFetching: false, fetchingError: null },
-      [IMAGE]: { hasStarted: false, isFetching: false, fetchingError: null },
+      isFetching: false,
+      fetchingError: null,
     })
   })
 
@@ -55,7 +55,8 @@ describe("provider store", () => {
   `(
     "getProviderName returns provider name or capitalizes providerCode",
     async ({ providerCode, displayName }) => {
-      await providerStore.$patch({ providers: { [IMAGE]: testProviders } })
+      providerStore.$patch({ providers: { [IMAGE]: testProviders } })
+
       expect(providerStore.getProviderName(providerCode, IMAGE)).toEqual(
         displayName
       )


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5287 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR uses the server route with `defineCachedFunction` to cache the `/stats` response for an hour. This is following SWR (stale-while-revalidate) principle, so if a request to update the stats fails, the cached (even outdated) version is still returned.

This PR also simplifies the provider store to combine the fetch state for images and audio into a single object since we don't really need the distinction between the media types.

The requests don't add the auth token to the API request, but it should be okay because the request is only sent once an hour.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app locally, and open the `localhost:8443/sources` page. You should see the log about `/stats` requests (for audio and images) in the terminal (not the browser console). Now, reload the page several times. There should be no other requests logged, since the data is cached in the nitro server.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
