### PR TITLE
Pull all addons in one DB request

### DIFF
--- a/api/api/models/audio.py
+++ b/api/api/models/audio.py
@@ -224,19 +224,6 @@ class Audio(AudioFileMixin, AbstractMedia):
     def audio_set(self):
         return getattr(self, "audioset")
 
-    def get_waveform(self) -> list[float]:
-        """
-        Get the waveform if it exists. Return a blank list otherwise.
-
-        :return: the waveform, if it exists; empty list otherwise
-        """
-
-        try:
-            add_on = AudioAddOn.objects.get(audio_identifier=self.identifier)
-            return add_on.waveform_peaks or []
-        except AudioAddOn.DoesNotExist:
-            return []
-
     def get_or_create_waveform(self):
         add_on, _ = AudioAddOn.objects.get_or_create(audio_identifier=self.identifier)
 

--- a/api/api/serializers/audio_serializers.py
+++ b/api/api/serializers/audio_serializers.py
@@ -179,7 +179,7 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
         super().__init__(*args, **kwargs)
 
     def get_peaks(self, obj) -> list[int]:
-        audio_addon = self.context["addons"].get(obj.identifier)
+        audio_addon = self.context.get("addons", {}).get(obj.identifier)
         if audio_addon:
             return audio_addon.waveform_peaks
 

--- a/api/api/serializers/audio_serializers.py
+++ b/api/api/serializers/audio_serializers.py
@@ -179,9 +179,9 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
         super().__init__(*args, **kwargs)
 
     def get_peaks(self, obj) -> list[int]:
-        if isinstance(obj, Hit):
-            obj = Audio.objects.get(identifier=obj.identifier)
-        return obj.get_waveform()
+        audio_addon = self.context["addons"].get(obj.identifier)
+        if audio_addon:
+            return audio_addon.waveform_peaks
 
     def to_representation(self, instance):
         # Get the original representation

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -49,6 +49,9 @@ class AudioViewSet(MediaViewSet):
     def get_queryset(self):
         return super().get_queryset().select_related("sensitive_audio", "audioset")
 
+    def include_addons(self, serializer):
+        return serializer.validated_data.get("peaks")
+
     # Extra actions
 
     async def get_image_proxy_media_info(self) -> image_proxy.MediaInfo:

--- a/api/api/views/audio_views.py
+++ b/api/api/views/audio_views.py
@@ -16,6 +16,7 @@ from api.docs.audio_docs import (
 )
 from api.docs.audio_docs import thumbnail as thumbnail_docs
 from api.models import Audio
+from api.models.audio import AudioAddOn
 from api.serializers.audio_serializers import (
     AudioReportRequestSerializer,
     AudioSearchRequestSerializer,
@@ -38,6 +39,7 @@ class AudioViewSet(MediaViewSet):
     """Viewset for all endpoints pertaining to audio."""
 
     model_class = Audio
+    addon_model_class = AudioAddOn
     media_type = AUDIO_TYPE
     query_serializer_class = AudioSearchRequestSerializer
     default_index = settings.MEDIA_INDEX_MAPPING[AUDIO_TYPE]

--- a/api/api/views/media_views.py
+++ b/api/api/views/media_views.py
@@ -159,6 +159,20 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
                 detail=f"Invalid source '{source}'. Valid sources are: {valid_string}.",
             )
 
+    def include_addons(self, serializer):
+        """
+        Whether to include objects of the addon model when mapping hits to
+        objects of the media model.
+
+        If the media type has an addon model, this method should be overridden
+        in the subclass to return ``True`` based on serializer input.
+
+        :param serializer: the validated serializer instance
+        :return: whether to include addon model objects
+        """
+
+        return False
+
     def get_media_results(
         self,
         request,
@@ -200,8 +214,8 @@ class MediaViewSet(AsyncViewSetMixin, AsyncAPIView, ReadOnlyModelViewSet):
         except ValueError as e:
             raise APIException(getattr(e, "message", str(e)))
 
-        peaks = params.validated_data.get("peaks")
-        results, addons = self.get_db_results(results, include_addons=peaks)
+        include_addons = self.include_addons(params)
+        results, addons = self.get_db_results(results, include_addons)
         serializer_context = (
             search_context
             | self.get_serializer_context()

--- a/api/test/integration/test_dead_link_filter.py
+++ b/api/test/integration/test_dead_link_filter.py
@@ -31,6 +31,10 @@ def empty_validation_cache(monkeypatch):
 _MAKE_HEAD_REQUESTS_MODULE_PATH = "api.utils.check_dead_links._make_head_requests"
 
 
+def _mock_get_db_results(results, include_addons=False):
+    return (results, [])
+
+
 def _patch_make_head_requests():
     def _make_head_requests(urls, *args, **kwargs):
         responses = []
@@ -67,7 +71,7 @@ def test_dead_link_filtering(mocked_map, api_client):
     with patch(
         "api.views.image_views.ImageViewSet.get_db_results"
     ) as mock_get_db_result:
-        mock_get_db_result.side_effect = lambda value: value
+        mock_get_db_result.side_effect = _mock_get_db_results
         res_with_dead_links = api_client.get(
             path,
             query_params | {"filter_dead": False},
@@ -121,7 +125,7 @@ def test_dead_link_filtering_all_dead_links(
     with patch(
         "api.views.image_views.ImageViewSet.get_db_results"
     ) as mock_get_db_result:
-        mock_get_db_result.side_effect = lambda value: value
+        mock_get_db_result.side_effect = _mock_get_db_results
         with patch_link_validation_dead_for_count(page_size / DEAD_LINK_RATIO):
             response = api_client.get(
                 path,

--- a/api/test/unit/models/test_audio.py
+++ b/api/test/unit/models/test_audio.py
@@ -41,28 +41,3 @@ def test_audio_waveform_caches(generate_peaks_mock, audio_fixture):
     audio_fixture.delete()
 
     assert AudioAddOn.objects.count() == 1
-
-
-@pytest.mark.django_db
-@mock.patch("api.models.audio.AudioAddOn.objects.get")
-def test_audio_waveform_sent_when_present(get_mock, audio_fixture):
-    # When ``AudioAddOn.waveform_peaks`` exists, waveform is filled
-    peaks = [0, 0.25, 0.5, 0.25, 0.1]
-    get_mock.return_value = mock.Mock(waveform_peaks=peaks)
-    assert audio_fixture.get_waveform() == peaks
-
-
-@pytest.mark.django_db
-@mock.patch("api.models.audio.AudioAddOn.objects.get")
-def test_audio_waveform_blank_when_absent(get_mock, audio_fixture):
-    # When ``AudioAddOn`` does not exist, waveform is blank
-    get_mock.side_effect = AudioAddOn.DoesNotExist()
-    assert audio_fixture.get_waveform() == []
-
-
-@pytest.mark.django_db
-@mock.patch("api.models.audio.AudioAddOn.objects.get")
-def test_audio_waveform_blank_when_none(get_mock, audio_fixture):
-    # When ``AudioAddOn.waveform_peaks`` is None, waveform is blank
-    get_mock.return_value = mock.Mock(waveform_peaks=None)
-    assert audio_fixture.get_waveform() == []

--- a/api/test/unit/views/test_audio_views.py
+++ b/api/test/unit/views/test_audio_views.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_django.asserts
+
+from test.factory.models import AudioFactory
+
+
+@pytest.mark.parametrize("peaks, query_count", [(True, 2), (False, 1)])
+@pytest.mark.django_db
+def test_peaks_param_determines_addons(api_client, peaks, query_count):
+    num_results = 20
+
+    # Since controller returns a list of ``Hit``s, not model instances, we must
+    # set the ``meta`` param on each of them to match the shape of ``Hit``.
+    results = AudioFactory.create_batch(size=num_results)
+    for result in results:
+        result.meta = None
+
+    controller_ret = (
+        results,
+        1,  # num_pages
+        num_results,
+        {},  # search_context
+    )
+    with (
+        patch(
+            "api.views.media_views.search_controller",
+            query_media=MagicMock(return_value=controller_ret),
+        ),
+        patch(
+            "api.serializers.media_serializers.search_controller",
+            get_sources=MagicMock(return_value={}),
+        ),
+        pytest_django.asserts.assertNumQueries(query_count),
+    ):
+        res = api_client.get(f"/v1/audio/?peaks={peaks}")
+
+    assert res.status_code == 200


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5274

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR prevents audio list requests with `?peaks=true` from making N+1 queries by fetching all `AudioAddon` models from the DB in a single call.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

With DEBUG logging enabled, make API calls to the `/v1/audio/` endpoint with `?peaks=true`. You should see only 2 total calls to the DB, where the second call is for audio addons:

```sql
SELECT
  "api_audioaddon"."created_on",
  "api_audioaddon"."updated_on",
  "api_audioaddon"."audio_identifier",
  "api_audioaddon"."waveform_peaks"
FROM "api_audioaddon"
WHERE "api_audioaddon"."audio_identifier" IN (
  '134d47ed3cd448f1b34e2671a428b463'::uuid,
  -- more UUIDs
  '2708c8f651254cbd992373e55359f1a8'::uuid
);
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
