### PR TITLE
Fix Sentry client setup

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -38,8 +38,10 @@ export default defineNuxtConfig({
       sentry: {
         dsn: "",
         environment: "local",
-        // Release is a build time variable, and as such, is defined in app.config.ts
       },
+      // Release is a build time variable. However, due to the way Sentry is set up, setting it in app.config.ts
+      // does not work, so we set it here using `process.env` to bake in the value at build time.
+      sentryRelease: process.env.SEMANTIC_VERSION,
       plausible: {
         ignoredHostnames: ["localhost", "staging.openverse.org"],
         logIgnoredEvents: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,7 +108,7 @@
     "npm-run-all2": "^7.0.0",
     "nuxt": "^3.14.1592",
     "rimraf": "^6.0.1",
-    "storybook": "^8.3.6",
+    "storybook": "8.3.6",
     "talkback": "^4.2.0",
     "typescript": "5.6.3",
     "vitest": "^2.1.4",

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -1,11 +1,11 @@
-import { useAppConfig, useRuntimeConfig } from "#imports"
+import { useRuntimeConfig } from "#imports"
 
 import * as Sentry from "@sentry/nuxt"
 
 Sentry.init({
   dsn: useRuntimeConfig().public.sentry.dsn,
   environment: useRuntimeConfig().public.sentry.environment,
-  release: useAppConfig().semanticVersion,
+  release: useRuntimeConfig().public.sentryRelease,
   ignoreErrors: [
     // Can be safely ignored, @see https://github.com/WICG/resize-observer/issues/38
     /ResizeObserver loop limit exceeded/i,
@@ -14,3 +14,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
 })
 Sentry.setContext("render context", { platform: "client" })
+Sentry.setTag("platform", "client")

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -13,3 +13,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
 })
 Sentry.setContext("render context", { platform: "server" })
+Sentry.setTag("platform", "server")

--- a/frontend/server/api/sources.ts
+++ b/frontend/server/api/sources.ts
@@ -19,7 +19,7 @@ const getSources = defineCachedFunction(
   async (mediaType: SupportedMediaType, event: H3Event) => {
     const apiUrl = useRuntimeConfig(event).public.apiUrl
 
-    consola.info(`Fetching sources for ${mediaType} media`)
+    consola.info(`Fetching ${mediaType} sources.`)
 
     return await $fetch<MediaProvider[]>(
       `${apiUrl}v1/${mediaSlug(mediaType)}/stats/`,
@@ -27,6 +27,8 @@ const getSources = defineCachedFunction(
         headers: {
           ...getProxyRequestHeaders(event),
           ...userAgentHeader,
+          "Content-Type": "application/json",
+          Accept: "application/json",
         },
       }
     )

--- a/frontend/src/app.config.ts
+++ b/frontend/src/app.config.ts
@@ -1,5 +1,0 @@
-import { defineAppConfig } from "#imports"
-
-export default defineAppConfig({
-  semanticVersion: import.meta.env.SEMANTIC_VERSION as string,
-})

--- a/frontend/src/pages/preferences.vue
+++ b/frontend/src/pages/preferences.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { definePageMeta } from "#imports"
+import { definePageMeta, useNuxtApp } from "#imports"
 import { computed } from "vue"
 
 import { SWITCHABLE, ON, OFF } from "#shared/constants/feature-flag"
@@ -51,7 +51,11 @@ const featureGroups = computed(() => {
   return featureFlagStore.getFeatureGroups()
 })
 
-const doneHydrating = computed(() => useHydrating())
+const { doneHydrating } = useHydrating()
+
+const captureException = () => {
+  useNuxtApp().$captureException(new Error("Test Sentry Exception"))
+}
 </script>
 
 <template>
@@ -133,5 +137,14 @@ const doneHydrating = computed(() => useHydrating())
 
     <h2>{{ $t("prefPage.storeState") }}</h2>
     <pre><code>{{ flags }}</code></pre>
+
+    <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
+    <VButton
+      v-if="$config.public.sentry.environment === 'local'"
+      variant="bordered-gray"
+      size="medium"
+      @click="captureException"
+      >Capture Sentry Exception</VButton
+    ><!-- eslint-enable -->
   </VContentPage>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       storybook:
-        specifier: ^8.3.6
+        specifier: 8.3.6
         version: 8.3.6
       talkback:
         specifier: ^4.2.0


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5296 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the way the `release` value is set for the Sentry module on the client. It uses a `sentryRelease` value in the `nuxtConfig` set to the `process.env.SEMANTIC_VERSION`. Using a different name for the variable (i.e., not the corresponding `NUXT_PUBLIC_SENTRY_RELEASE` one) makes sure that the value is not changed during the runtime.

This PR also adds a `platform` tag to easily filter server/client events in Sentry UI.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To test that the release is baked in during the build time, you can use different values for `SEMANTIC_VERSION` env variable during build/runtime. To do that:
1. Build the app using `ov env SEMANTIC_VERSION=build just frontend/run build`
2. Start the app with a different value: `ov env SEMANTIC_VERSION=start just frontend/run build`
3. Go to `http://localhost:8443/preferences`, scroll down to see the "Capture Sentry Exception" button and click it. In the devtools, check the payload of the Sentry POST request. It should have `release: "build"` in it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
