### PR TITLE
Start the catalog service as part of `ov just init`

### DIFF
--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -63,6 +63,9 @@ function verify_loaded_data {
   fi
 }
 
+# Start the catalog (needed for data refresh process)
+just catalog/up
+
 load_sample_data "image"
 verify_loaded_data "image"
 load_sample_data "audio"


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

This fixes an issue I identified while trying to run `ov just init` - see [the Make WordPress Slack](https://wordpress.slack.com/archives/C02012JB00N/p1734561799110209)

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the `ov just init` script to start the catalog stack at the very beginning, so that it's ready and initialized for the `just catalog/cli` commands that come later in the `load_sample_data.sh` script.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

### On `main`

Run `ov just init` and observe that it fails:

```
just dc exec -u airflow  "$@"
env COMPOSE_PROFILES="api,ingestion_server,frontend,catalog" docker compose -f docker-compose.yml "$@"
service "scheduler" is not running
error: Recipe `dc` failed on line 266 with exit code 1
error: Recipe `exec` failed on line 339 with exit code 1
error: Recipe `cli` failed on line 89 with exit code 1
error: Recipe `init` failed on line 64 with exit code 1
error: Recipe `init` failed on line 304 with exit code 1
```

### On this branch

`ov just init` should run successfully without intervention


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
