### PR TITLE
Only show audio message when track ID matches active

### DIFF
--- a/frontend/src/components/VAudioTrack/VAudioTrack.vue
+++ b/frontend/src/components/VAudioTrack/VAudioTrack.vue
@@ -296,9 +296,9 @@ watch(
 
 /* Timekeeping */
 
-const message = computed(() =>
-  activeMediaStore.message
-    ? t(`audioTrack.messages.${activeMediaStore.message}`)
+const message = computed(() => 
+  activeMediaStore.id === props.audio.id && activeMediaStore.message 
+    ? i18n.t(`audioTrack.messages.${activeMediaStore.message}`).toString() 
     : ""
 )
 

--- a/frontend/src/components/VAudioTrack/VAudioTrack.vue
+++ b/frontend/src/components/VAudioTrack/VAudioTrack.vue
@@ -298,7 +298,7 @@ watch(
 
 const message = computed(() =>
   activeMediaStore.id === props.audio.id && activeMediaStore.message
-   ? t(`audioTrack.messages.${activeMediaStore.message}`)
+    ? t(`audioTrack.messages.${activeMediaStore.message}`)
     : ""
 )
 

--- a/frontend/src/components/VAudioTrack/VAudioTrack.vue
+++ b/frontend/src/components/VAudioTrack/VAudioTrack.vue
@@ -296,9 +296,9 @@ watch(
 
 /* Timekeeping */
 
-const message = computed(() => 
-  activeMediaStore.id === props.audio.id && activeMediaStore.message 
-    ? i18n.t(`audioTrack.messages.${activeMediaStore.message}`).toString() 
+const message = computed(() =>
+  activeMediaStore.id === props.audio.id && activeMediaStore.message
+   ? t(`audioTrack.messages.${activeMediaStore.message}`)
     : ""
 )
 

--- a/frontend/src/components/VAudioTrack/VWaveform.vue
+++ b/frontend/src/components/VAudioTrack/VWaveform.vue
@@ -481,6 +481,7 @@ const seekTimeLeft = computed(() => ({
     <div
       v-else
       class="loading absolute inset-0 flex items-center justify-center text-xs font-bold"
+      data-testid="error-message"
     >
       {{ message }}
     </div>

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -166,10 +166,10 @@ describe("AudioTrack", () => {
       state: {
         id: audioId,
         message: "playing",
-        type: "audio"
-      }
+        type: "audio",
+      },
     })
-    
+
     const { getByText } = await render(VAudioTrack, options)
     expect(getByText(/playing/i)).toBeVisible()
   })
@@ -180,12 +180,11 @@ describe("AudioTrack", () => {
       state: {
         id: "different-id",
         message: "playing",
-        type: "audio"
-      }
+        type: "audio",
+      },
     })
-    
+
     const { queryByText } = await render(VAudioTrack, options)
     expect(queryByText(/playing/i)).not.toBeInTheDocument()
   })
 })
-

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -22,6 +22,7 @@ const RouterLinkStub = createApp({}).component("RouterLink", {
   },
 })._context.components.RouterLink
 
+const ACTIVE_AUDIO = getAudioObj()
 const stubs = {
   VLicense: true,
   VWaveform: true,
@@ -33,21 +34,17 @@ describe("AudioTrack", () => {
   let options = null
   let props = null
 
+  const activeMediaStore = useActiveMediaStore()
+  activeMediaStore.setActiveMediaItem({
+    type: "audio",
+    id: ACTIVE_AUDIO.id,
+  })
+
   beforeEach(() => {
     props = {
-      audio: getAudioObj(),
+      audio: ACTIVE_AUDIO,
       layout: "full",
     }
-    const activeMediaStore = useActiveMediaStore()
-    activeMediaStore.$patch({
-      state: {
-        type: "audio",
-        id: "e19345b8-6937-49f7-a0fd-03bf057efc28",
-        message: null,
-        state: "paused",
-      },
-    })
-
     options = {
       props: props,
       global: {
@@ -103,8 +100,6 @@ describe("AudioTrack", () => {
       options.global.stubs.VWaveform = false
       options.global.stubs.VAudioThumbnail = true
 
-      vi.clearAllMocks()
-
       const pauseStub = vi.fn(() => undefined)
       const playStub = vi.fn(() => Promise.reject(playError))
       const playError = new DOMException("msg", errorType)
@@ -117,13 +112,18 @@ describe("AudioTrack", () => {
         playStub
       )
 
-      const { getByRole, getByText } = await render(VAudioTrack, options)
+      const { getByRole, getByText, getByTestId } = await render(
+        VAudioTrack,
+        options
+      )
 
       await fireEvent.click(getByRole("button", { name: /play/i }))
       await nextTick()
       expect(playStub).toHaveBeenCalledTimes(1)
       expect(pauseStub).toHaveBeenCalledTimes(1)
+
       expect(getByText(errorText)).toBeVisible()
+      expect(getByTestId("error-message").textContent).toMatch(errorText)
     }
   )
 
@@ -159,32 +159,12 @@ describe("AudioTrack", () => {
     expect(screen.queryAllByAltText(match)).toEqual([])
   })
 
-  it("should show message when audio ID matches active ID", async () => {
-    const activeMediaStore = useActiveMediaStore()
-    const audioId = props.audio.id
-    activeMediaStore.$patch({
-      state: {
-        id: audioId,
-        message: "playing",
-        type: "audio",
-      },
-    })
-
-    const { getByText } = await render(VAudioTrack, options)
-    expect(getByText(/playing/i)).toBeVisible()
-  })
-
   it("should not show message when audio ID doesn't match active ID", async () => {
-    const activeMediaStore = useActiveMediaStore()
-    activeMediaStore.$patch({
-      state: {
-        id: "different-id",
-        message: "playing",
-        type: "audio",
-      },
-    })
+    activeMediaStore.id = "different-id"
+    activeMediaStore.setMessage({ message: "err_network" })
+    options.global.stubs.VWaveform = false
 
-    const { queryByText } = await render(VAudioTrack, options)
-    expect(queryByText(/playing/i)).not.toBeInTheDocument()
+    const { queryByTestId } = await render(VAudioTrack, options)
+    expect(queryByTestId("error-message")).not.toBeInTheDocument()
   })
 })

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -188,3 +188,4 @@ describe("AudioTrack", () => {
     expect(queryByText(/playing/i)).not.toBeInTheDocument()
   })
 })
+

--- a/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/frontend/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -158,4 +158,33 @@ describe("AudioTrack", () => {
     expect(screen.queryAllByTitle(match)).toEqual([])
     expect(screen.queryAllByAltText(match)).toEqual([])
   })
+
+  it("should show message when audio ID matches active ID", async () => {
+    const activeMediaStore = useActiveMediaStore()
+    const audioId = props.audio.id
+    activeMediaStore.$patch({
+      state: {
+        id: audioId,
+        message: "playing",
+        type: "audio"
+      }
+    })
+    
+    const { getByText } = await render(VAudioTrack, options)
+    expect(getByText(/playing/i)).toBeVisible()
+  })
+
+  it("should not show message when audio ID doesn't match active ID", async () => {
+    const activeMediaStore = useActiveMediaStore()
+    activeMediaStore.$patch({
+      state: {
+        id: "different-id",
+        message: "playing",
+        type: "audio"
+      }
+    })
+    
+    const { queryByText } = await render(VAudioTrack, options)
+    expect(queryByText(/playing/i)).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2202  by @obulat 

## Description
An audio-related error is observed across all audio cells in the content view. Specifically, all cells incorrectly display an error message regardless of their state. This occurs because the application does not validate whether the audio.id matches the activeMediaStore.id when setting the message. As a result, messages intended for the active audio track are incorrectly shown for all audio tracks.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
A reliable way to test this behavior is to find `.oga` audio files in Safari.
1. Run the app locally and go to http://localhost:8443/search/audio?q=cat&extension=oga
2. Click on Play: you should see the error message only on the active track.
<img width="688" alt="Screenshot 2025-01-16 at 1 26 59 PM" src="https://github.com/user-attachments/assets/d54094c1-a32a-43a1-afb4-4b9db2f0ffa8" />

Compare with the same in production: you see that the error message is displayed on every track.
<img width="690" alt="Screenshot 2025-01-16 at 1 27 33 PM" src="https://github.com/user-attachments/assets/ed3313cc-d673-4d37-a7ef-b9ea9749f9ed" />


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
