### PR TITLE
Add bodyserializer/accept header to openverse api client to correctly authenticate with the API

### DIFF
--- a/packages/js/api-client/src/auth.ts
+++ b/packages/js/api-client/src/auth.ts
@@ -136,6 +136,12 @@ export class OpenverseAuthMiddleware implements OpenverseMiddleware {
             client_id: this.credentials.clientId,
             client_secret: this.credentials.clientSecret,
           },
+          bodySerializer(body) {
+            return new URLSearchParams(body).toString()
+          },
+          headers: {
+            Accept: "x-www-form-encoded",
+          },
         })
         .then((tokenResponse) => {
           if (!tokenResponse.response.ok || !tokenResponse.data) {

--- a/packages/js/api-client/tests/client.test.ts
+++ b/packages/js/api-client/tests/client.test.ts
@@ -26,7 +26,15 @@ describe("OpenverseClient", () => {
       })
 
       const scope = nock
-        .post("/v1/auth_tokens/token/", /test-secret/)
+        .post("/v1/auth_tokens/token/", (body) => {
+          const params = new URLSearchParams(body)
+
+          // Check if the required parameter matches
+          return (
+            params.get("client_id") === "test" &&
+            params.get("client_secret") === "test-secret"
+          )
+        })
         .reply(200, {
           access_token: "test-access-token",
           scope: "test-scope",


### PR DESCRIPTION
Add bodyserializer/accept header to openverse api client to correctly authenticate with the API

<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #5314 by @obulat 

## Description
The @openverse/api-client package sends the requests for token to the Openverse Django API with the correct parameters but does not serialize the body to the required x-www-form-urlencoded format. This causes the requests to be sent with an empty body. The new changes adds a bodySerializer[1](https://github.com/WordPress/openverse/issues/5314#user-content-fn-1-8e20f977105496140c35bcca5a5a2040) that creates new URLSearchParams from the body object, and stringifies it, thus allowing requests to be sent with correct body objects.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
