### PR TITLE
Fix missing `dag` parameter in Slack notification

### DIFF
--- a/catalog/dags/maintenance/rotate_envfiles.py
+++ b/catalog/dags/maintenance/rotate_envfiles.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from airflow.decorators import dag, task
-from airflow.models import Variable
+from airflow.models import DAG, Variable
 from airflow.providers.amazon.aws.hooks.ec2 import EC2Hook
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -281,14 +281,18 @@ def delete_stale_envfiles(
 
 
 @task
-def notify_complete(deleted_envfiles: dict[str, list[str]]):
+def notify_complete(
+    deleted_envfiles: dict[str, list[str]],
+    dag: DAG | None = None,
+):
     if deleted_envfiles:
         message = ""
         for env, envfiles in deleted_envfiles.items():
             files = ", ".join(envfiles)
             message += f"{env}: {files}\n"
         notify_slack.function(
-            text=f"Deleted the following environment files:\n{message}"
+            text=f"Deleted the following environment files:\n{message}",
+            dag=dag,
         )
 
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR fixes the bug with missing `dag` param when `notify_slack` is invoked as a function.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
