### PR TITLE
fix for issue #3817 -- add visual regression test for sketchfab result

### DIFF
--- a/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
+++ b/frontend/test/playwright/visual-regression/pages/pages-single-result.spec.ts
@@ -64,6 +64,29 @@ for (const mediaType of supportedMediaTypes) {
 
 for (const dir of languageDirections) {
   breakpoints.describeMobileAndDesktop(({ breakpoint, expectSnapshot }) => {
+    test(`${dir} Sketchfab single result page snapshot`, async ({ page }) => {
+      await preparePageForTests(page, breakpoint)
+
+      const SKETCHFAB_ID = "da5cb478-c093-4d62-b721-cda18797e3fb"
+      const path = pathWithDir(`/image/${SKETCHFAB_ID}`, dir)
+
+      await page.goto(path)
+
+      // Wait a bit for the Sketchfab iframe to fully load
+      await sleep(3000)
+
+      await expectSnapshot(
+        `${dir}-sketchfab-single-result`,
+        page,
+        { fullPage: true },
+        { maxDiffPixelRatio: 0.01 }
+      )
+    })
+  })
+}
+
+for (const dir of languageDirections) {
+  breakpoints.describeMobileAndDesktop(({ breakpoint, expectSnapshot }) => {
     test(`${dir} full-page report snapshots`, async ({ page }) => {
       await preparePageForTests(page, breakpoint)
 


### PR DESCRIPTION
## Fixes
Fixes #3817 by @dhruvkb

## Description
Adds a visual regression test for a known Sketchfab 3D model result page: `/image/da5cb478-c093-4d62-b721-cda18797e3fb`.

This test ensures that the Sketchfab embedded viewer renders correctly on the single result page across different breakpoints and language directions (LTR/RTL). It helps catch future layout or rendering regressions that could affect the 3D viewer.

The test was added to the existing `pages-single-result.spec.ts` file using Playwright's snapshot comparison.

## Testing Instructions
1. Run the test: pnpm test:e2e --grep "Sketchfab"
2. Confirm that a snapshot is generated in the appropriate `__snapshots__` directory.
3. Verify that the iframe loads and the page renders as expected before the screenshot is taken.
4. Optionally modify layout/CSS and re-run to confirm visual diff detection.

## Checklist
- [x] Descriptive PR title
- [x] Targets `main` branch
- [x] Commit messages follow best practices
- [x] Code follows project style
- [x] Test added for the change
- [ ] Documentation updated (not applicable)
- [x] Project runs locally without errors
- [ ] DAG or API docs generated (not applicable)