### PR TITLE
docs: Add quick-start sections to component README files

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,3 +2,18 @@
 
 This service is documented at
 [docs.openverse.org/api](https://docs.openverse.org/api/index.html).
+
+## Quick Start
+
+```bash
+# Start the API server
+just api/up
+
+# Run tests
+just api/test
+
+# Run linting
+just lint
+```
+
+See the [justfile](justfile) for more available commands.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -2,3 +2,18 @@
 
 This service is documented at
 [docs.openverse.org/catalog](https://docs.openverse.org/catalog/index.html).
+
+## Quick Start
+
+```bash
+# Start the catalog (Airflow)
+just catalog/up
+
+# Run tests
+just catalog/test
+
+# Run linting
+just lint
+```
+
+See the [justfile](justfile) for more available commands.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,3 +2,18 @@
 
 This service is documented at
 [docs.openverse.org/frontend](https://docs.openverse.org/frontend/index.html).
+
+## Quick Start
+
+```bash
+# Start the development server
+pnpm run dev
+
+# Run unit tests
+pnpm run test:unit
+
+# Run E2E tests
+pnpm run test:playwright
+```
+
+See [package.json](package.json) for all available scripts.

--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -2,3 +2,18 @@
 
 This service is documented at
 [docs.openverse.org/ingestion_server](https://docs.openverse.org/ingestion_server/index.html).
+
+## Quick Start
+
+```bash
+# Start the ingestion server
+just ingestion_server/up
+
+# Run tests
+just ingestion_server/test
+
+# Run linting
+just lint
+```
+
+See the [justfile](justfile) for more available commands.

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,3 +2,17 @@
 
 Learn more about these packages in the
 [documentation](https://docs.openverse.org/packages/index.html).
+
+## Available Packages
+
+### JavaScript Packages
+
+- `@openverse/api-client` - API client library
+- `@openverse/eslint-plugin` - ESLint configuration
+- `k6` - Performance testing scripts
+
+### Python Packages
+
+- `openverse-attribution` - Attribution utilities
+
+See individual package directories for more details.


### PR DESCRIPTION
## Description

Added quick-start sections to component README files (api, catalog, frontend, ingestion_server, packages) with commonly used commands. This helps developers quickly see how to run each component without navigating to full documentation.

## Changes

- Add quick-start commands to 5 README files
- Include common commands: `just up`, `just test`, etc.
- Maintain links to full documentation