### PR TITLE
Add a new error message for non-zero exit codes to lint hook in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -134,7 +134,11 @@ precommit:
 
 # Run pre-commit to lint and reformat files
 lint hook="" *files="": precommit
+    #!/usr/bin/env bash
     python3 pre-commit.pyz run {{ hook }} {{ if files == "" { "--all-files" } else { "--files" } }}  {{ files }}
+    if [ $? -ne 0 ]; then
+        echo "error: Recipe 'lint' failed. Look above this line for the exact error."
+    fi
 
 # Run codeowners validator locally. Only enable experimental hooks if there are no uncommitted changes.
 lint-codeowners checks="stable":


### PR DESCRIPTION
Fixes #2441 by @CharlesKnell

## Description
In justfile, the lint hook will issue the following message when a non-zero exit code is encountered:
"error: Recipe 'lint' failed. Look above this line for the exact error."

Currently, the message would be similar to the following:
"error: Recipe `lint` failed on line 92 with exit code 1"

## Testing Instructions
To generate a lint error, execute the following:
ov sudo chmod o-rwx /opt
ov just lint

To remove the lint error, execute the following:
ov sudo chmod o+rwx /opt
ov just lint

## Checklist
- [ x ] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [ x ] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [ x ] My commit messages follow [best practices][best_practices].
- [ x ] My code follows the established code style of the repository.
- [   ] I added or updated tests for the changes I made (if applicable).
- [   ] I added or updated documentation (if applicable).
- [ x ] I tried running the project locally and verified that there are no visible errors.
- [   ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
