### PR TITLE
Hide audio thumbnail from screen readers

### DIFF
--- a/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
+++ b/frontend/src/components/VAudioThumbnail/VAudioThumbnail.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 /**
  * Displays the cover art for the audio in a square aspect ratio.
+ *
+ * The thumbnail is hidden from screen readers because it is purely
+ * decorative. When no cover art exists, a generative SVG pattern is
+ * shown instead, which has no meaningful alternative text.
  */
-import { useI18n } from "#imports"
 import { toRefs, ref, onMounted } from "vue"
 
 import { rand, hash } from "#shared/utils/prng"
@@ -19,14 +22,6 @@ const props = defineProps<{
 
 const { audio } = toRefs(props)
 const { isHidden: shouldBlur } = useSensitiveMedia(audio)
-
-const { t } = useI18n({ useScope: "global" })
-const helpText = shouldBlur.value
-  ? t("sensitiveContent.title.audio")
-  : t("audioThumbnail.alt", {
-      title: props.audio.title,
-      creator: props.audio.creator,
-    })
 
 /* Switching */
 
@@ -68,7 +63,7 @@ const radius = (i: number, j: number) => {
 
 <template>
   <!-- Should be wrapped by a fixed-width parent -->
-  <div class="relative h-0 w-full overflow-hidden pt-full" :title="helpText">
+  <div class="relative h-0 w-full overflow-hidden pt-full" aria-hidden="true">
     <!-- Programmatic thumbnail -->
     <svg
       v-if="!isOk"
@@ -100,7 +95,7 @@ const radius = (i: number, j: number) => {
         class="h-full w-full overflow-clip object-cover object-center duration-200 motion-safe:transition-[filter,transform]"
         :class="{ 'scale-150 blur-image': shouldBlur }"
         :src="audio.thumbnail"
-        :alt="helpText"
+        alt=""
         @load="handleLoad"
       />
     </div>


### PR DESCRIPTION
## Fixes

Fixes #497 by @dhruvkb

## Description

The audio thumbnail component (`VAudioThumbnail`) previously used a `title` attribute on the wrapper and a dynamic `alt` text on the `<img>` element. This was misleading because:

- The generative SVG fallback (dot pattern) is not actual cover art, but the `title` read "Cover art for ..."
- The thumbnail is purely decorative and provides no useful information to screen reader users
- The `title`/`alt` text duplicated information already available in the audio track metadata nearby

Following the approach agreed upon in the issue discussion, this PR:

1. Adds `aria-hidden="true"` to the thumbnail wrapper `<div>`, hiding the entire element from the accessibility tree
2. Removes the `:title` binding from the wrapper
3. Sets `alt=""` on the `<img>` element (empty alt for decorative images per WCAG)
4. Removes the unused `helpText` computed property and `useI18n` import

## Testing Instructions

1. Open any audio search results page (e.g., search for "piano")
2. Inspect the audio thumbnail element in DevTools and verify `aria-hidden="true"` is present on the wrapper div
3. Verify the `<img>` element has `alt=""`
4. Verify there is no `title` attribute on the thumbnail wrapper
5. Use a screen reader (VoiceOver on macOS: Cmd+F5) and navigate through an audio result to confirm the thumbnail is skipped
6. Check that the thumbnail still renders correctly visually (both with cover art and with the generative SVG fallback)
7. Check sensitive content: the visual blur effect still works correctly

## Checklist

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

I have read and agree to the Developer Certificate of Origin version 1.1.

</details>