### PR TITLE
Fix negative audio duration in API

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -358,7 +358,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     def get_audio_record_data(self, record_data, media_info):
         """Extend record_data with audio-specific fields."""
-        duration = int(float(media_info.get("duration", 0)) * 1000)
+        duration_raw = float(media_info.get("duration") or 0)
+        duration = int(duration_raw * 1000) if duration_raw > 0 else None
         record_data["duration"] = duration
         record_data["category"] = self.extract_audio_category(record_data)
 

--- a/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -358,8 +358,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     def get_audio_record_data(self, record_data, media_info):
         """Extend record_data with audio-specific fields."""
-        duration_raw = float(media_info.get("duration") or 0)
-        duration = int(duration_raw * 1000) if duration_raw > 0 else None
+        duration = int(float(media_info.get("duration", 0)) * 1000)
         record_data["duration"] = duration
         record_data["category"] = self.extract_audio_category(record_data)
 


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #5420 by @alfieatkinson

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The Wikimedia Commons API is returning a negative float for the duration of a particular OGG file (likely -1.012 seconds), which is a metadata anomaly in the source file. The code blindly converts it to milliseconds: int(-1.012 * 1000) = -1012. This negative value then passes through `_validate_integer` in `MediaStore` without being caught.

This PR clamps a negative duration to None since a sub-zero duration is physically meaningless.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
