### PR TITLE
Redirect unsupported locale prefixes to English

### DIFF
--- a/frontend/i18n/data/en.json5
+++ b/frontend/i18n/data/en.json5
@@ -24,6 +24,13 @@ _{link}_ part of "The translation for English locale is incomplete. Help us get 
   */
   "notification.analytics.link": "the privacy page",
   "notification.analytics.close": "Close the analytics notice banner.",
+  "notification.unsupportedLocale.text": "{'Openverse'} isn’t translated into the language you requested yet, so we’ve shown you the English version. Help us translate {'Openverse'} by {link}.",
+  /**
+  Interpolated into notification.unsupportedLocale.text:
+  _{link}_ part of "Help us translate Openverse by _{link}_."
+  */
+  "notification.unsupportedLocale.link": "contributing a translation",
+  "notification.unsupportedLocale.close": "Close the unsupported language notice banner.",
   "notification.new": "New",
   "notification.more": "See more",
   "header.homeLink": "{'Openverse'} Home",

--- a/frontend/shared/types/banners.ts
+++ b/frontend/shared/types/banners.ts
@@ -1,4 +1,4 @@
 import type { LocaleObject } from "@nuxtjs/i18n"
 
 export type TranslationBannerId = `translation-${LocaleObject["code"]}`
-export type BannerId = TranslationBannerId | "analytics"
+export type BannerId = TranslationBannerId | "analytics" | "unsupported-locale"

--- a/frontend/shared/utils/translation-banner.ts
+++ b/frontend/shared/utils/translation-banner.ts
@@ -1,6 +1,7 @@
 import type { LocaleObject } from "@nuxtjs/i18n"
 
-const BASE_URL = "https://translate.wordpress.org/projects/meta/openverse/"
+export const BASE_URL =
+  "https://translate.wordpress.org/projects/meta/openverse/"
 // We show the banner if the translation is less than this percentage
 const MINIMUM_TRANSLATION_PERCENTAGE = 90
 

--- a/frontend/shared/utils/unsupported-locale.ts
+++ b/frontend/shared/utils/unsupported-locale.ts
@@ -1,0 +1,34 @@
+/**
+ * Matches a URL first-segment that looks like a locale code: two letters,
+ * optionally followed by a hyphenated region (e.g. `cn`, `es-ar`).
+ */
+const LOCALE_LIKE = /^[a-z]{2}(-[a-z]{2,4})?$/i
+
+/**
+ * Given a path and the set of supported locale codes, decide whether the path
+ * starts with an *unsupported* locale-shaped prefix (e.g. `/cn`) and, if so,
+ * return the path with that prefix stripped. Since the default locale is
+ * English, the stripped path is the English equivalent of the original path.
+ *
+ * Returns `null` when the path should be left alone (not locale-shaped, or the
+ * prefix is a supported locale).
+ *
+ * @param path - the incoming path, e.g. `/cn/search`.
+ * @param supportedCodes - configured locale codes, e.g. `["en", "es"]`.
+ */
+export function getUnsupportedLocaleRedirect(
+  path: string,
+  supportedCodes: string[]
+): string | null {
+  const firstSegment = path.split("/")[1] ?? ""
+
+  if (!LOCALE_LIKE.test(firstSegment)) {
+    return null
+  }
+  if (supportedCodes.includes(firstSegment)) {
+    return null
+  }
+
+  const rest = path.slice(firstSegment.length + 1) // drop "/xx"
+  return rest || "/"
+}

--- a/frontend/src/components/VBanner/VBanners.vue
+++ b/frontend/src/components/VBanner/VBanners.vue
@@ -14,6 +14,9 @@ const VTranslationStatusBanner = defineAsyncComponent(
 const VAnalyticsNotice = defineAsyncComponent(
   () => import("~/components/VBanner/VAnalyticsNotice.vue")
 )
+const VUnsupportedLocaleBanner = defineAsyncComponent(
+  () => import("~/components/VBanner/VUnsupportedLocaleBanner.vue")
+)
 const uiStore = useUiStore()
 const localeProperties = useNuxtApp().$i18n.localeProperties
 
@@ -22,6 +25,9 @@ const shouldShowTranslationBanner = computed(() =>
 )
 const shouldShowAnalyticsBanner = computed(
   () => uiStore.shouldShowAnalyticsBanner
+)
+const shouldShowUnsupportedLocaleBanner = computed(
+  () => uiStore.shouldShowUnsupportedLocaleBanner
 )
 
 const translationBannerId = computed<TranslationBannerId>(
@@ -37,10 +43,18 @@ const dismissBanner = (bannerKey: BannerId) => {
   uiStore.dismissBanner(bannerKey)
 }
 
+// The unsupported-locale banner is a one-time popup rather than a permanently
+// dismissible banner, so closing it just hides the current instance.
+const closeUnsupportedLocaleBanner = () => {
+  uiStore.setUnsupportedLocaleBannerVisible(false)
+}
+
 const showBanners = computed(() =>
-  [shouldShowTranslationBanner, shouldShowAnalyticsBanner].some(
-    (item) => item.value
-  )
+  [
+    shouldShowTranslationBanner,
+    shouldShowAnalyticsBanner,
+    shouldShowUnsupportedLocaleBanner,
+  ].some((item) => item.value)
 )
 </script>
 
@@ -57,6 +71,11 @@ const showBanners = computed(() =>
         :variant="variant"
         :banner-key="translationBannerId"
         @close="dismissBanner(translationBannerId)"
+      />
+      <VUnsupportedLocaleBanner
+        v-if="shouldShowUnsupportedLocaleBanner"
+        :variant="variant"
+        @close="closeUnsupportedLocaleBanner"
       />
     </div>
   </div>

--- a/frontend/src/components/VBanner/VUnsupportedLocaleBanner.vue
+++ b/frontend/src/components/VBanner/VUnsupportedLocaleBanner.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { BannerVariant } from "#shared/constants/banners"
+import { BASE_URL } from "#shared/utils/translation-banner"
+
+import VLink from "~/components/VLink.vue"
+import VNotificationBanner from "~/components/VBanner/VNotificationBanner.vue"
+
+defineProps<{
+  variant?: BannerVariant
+}>()
+
+defineEmits<{
+  close: []
+}>()
+
+// Link to the general Openverse project page, where the user can find or start
+// a translation for their language, rather than the English one.
+const translationLink = BASE_URL
+</script>
+
+<template>
+  <VNotificationBanner
+    id="unsupported-locale"
+    nature="warning"
+    :variant="variant"
+    :close-button-label="$t('notification.unsupportedLocale.close')"
+    @close="$emit('close')"
+  >
+    <i18n-t
+      scope="global"
+      tag="span"
+      keypath="notification.unsupportedLocale.text"
+    >
+      <template #link>
+        <VLink :href="translationLink" class="text-curr underline">{{
+          $t("notification.unsupportedLocale.link")
+        }}</VLink>
+      </template>
+    </i18n-t>
+  </VNotificationBanner>
+</template>

--- a/frontend/src/middleware/unsupported-locale.global.ts
+++ b/frontend/src/middleware/unsupported-locale.global.ts
@@ -1,0 +1,47 @@
+import { defineNuxtRouteMiddleware, navigateTo, useNuxtApp } from "#imports"
+
+import { getUnsupportedLocaleRedirect } from "#shared/utils/unsupported-locale"
+import { useUiStore } from "~/stores/ui"
+
+import type { LocaleObject } from "@nuxtjs/i18n"
+
+
+/**
+ * A locale-shaped prefix we don't support (e.g. `/cn`) matches no route, so we
+ * redirect it to the English equivalent and show a one-time banner about the
+ * missing translation.
+ *
+ * The redirect sets a persisted flag so it survives the server-side 302. The
+ * landing page shows the banner and clears the flag. Any later navigation hides
+ * it. So the banner shows once, and only another redirect brings it back.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  const nuxtApp = useNuxtApp()
+  const uiStore = useUiStore()
+  const i18n = nuxtApp.$i18n
+
+  // Full configured locale set, not `availableLocales`, which only reflects
+  // lazily-loaded message bundles.
+  const supportedCodes: string[] = (i18n.locales.value as LocaleObject[]).map(
+    (l) => l.code
+  )
+
+  // Only consider paths that redirect to a 404
+  if (to.matched.length === 0) {
+    const newPath = getUnsupportedLocaleRedirect(to.path, supportedCodes)
+    if (newPath !== null) {
+      uiStore.setUnsupportedLocaleRedirect(true)
+      return navigateTo({ path: newPath, query: to.query, hash: to.hash })
+    }
+  }
+
+  if (uiStore.unsupportedLocaleRedirect) {
+    // This is the page the visitor landed on straight after the redirect above.
+    // Show the banner once and consume the carrier so it can't re-show later.
+    uiStore.setUnsupportedLocaleBannerVisible(true)
+    uiStore.setUnsupportedLocaleRedirect(false)
+  } else if (!nuxtApp.isHydrating) {
+    // Once the visitor navigates somewhere else, hide the banner.
+    uiStore.setUnsupportedLocaleBannerVisible(false)
+  }
+})

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -52,6 +52,17 @@ export interface UiState {
    */
   dismissedBanners: BannerId[]
   /**
+   * Set when the visitor is redirected here from an unsupported locale prefix
+   * (e.g. `/cn`). Persisted only so it survives the redirect, then consumed on
+   * the next navigation.
+   */
+  unsupportedLocaleRedirect: boolean
+  /**
+   * Whether the one-time "language not supported" banner is showing. Transient:
+   * turned on for the landing page and cleared on the next navigation.
+   */
+  unsupportedLocaleBannerVisible: boolean
+  /**
    * Whether to blur sensitive content in search and single result pages.
    * Value should *not* be set directly, use setShouldBlurSensitive(value: boolean)
    * to ensure necessary side-effects are executed.
@@ -76,6 +87,8 @@ export const defaultUiState: UiState = {
   isDesktopLayout: false,
   breakpoint: "sm",
   dismissedBanners: [],
+  unsupportedLocaleRedirect: false,
+  unsupportedLocaleBannerVisible: false,
   shouldBlurSensitive: true,
   revealedSensitiveResults: [],
   headerHeight: 80,
@@ -93,6 +106,7 @@ export const useUiStore = defineStore("ui", {
         isFilterDismissed: state.isFilterDismissed,
         breakpoint: state.breakpoint,
         dismissedBanners: Array.from(this.dismissedBanners),
+        unsupportedLocaleRedirect: state.unsupportedLocaleRedirect,
         colorMode: state.colorMode,
         isDarkModeSeen: state.isDarkModeSeen,
       }
@@ -126,6 +140,14 @@ export const useUiStore = defineStore("ui", {
      */
     shouldShowAnalyticsBanner(): boolean {
       return !this.dismissedBanners.includes("analytics")
+    },
+    /**
+     * A one-time notice shown on the page the visitor lands on after being
+     * redirected from an unsupported locale prefix. Not dismissible like the
+     * other banners; the middleware controls when it shows.
+     */
+    shouldShowUnsupportedLocaleBanner(): boolean {
+      return this.unsupportedLocaleBannerVisible
     },
   },
 
@@ -187,6 +209,10 @@ export const useUiStore = defineStore("ui", {
 
       if (Array.isArray(cookies.dismissedBanners)) {
         this.dismissedBanners = cookies.dismissedBanners
+      }
+
+      if (typeof cookies.unsupportedLocaleRedirect === "boolean") {
+        this.unsupportedLocaleRedirect = cookies.unsupportedLocaleRedirect
       }
 
       if (isColorMode(cookies.colorMode)) {
@@ -272,6 +298,26 @@ export const useUiStore = defineStore("ui", {
     },
     isBannerDismissed(bannerId: BannerId) {
       return this.dismissedBanners.includes(bannerId)
+    },
+    /**
+     * Record (and persist) that the visitor was just redirected from an
+     * unsupported locale prefix, so the flag survives the redirect.
+     * @param value - whether the redirect just happened.
+     */
+    setUnsupportedLocaleRedirect(value: boolean) {
+      if (this.unsupportedLocaleRedirect === value) {
+        return
+      }
+      this.unsupportedLocaleRedirect = value
+      this.writeToCookie()
+    },
+    /**
+     * Show or hide the one-time unsupported-locale banner. Transient, so it is
+     * never written to the cookie and won't re-show on a later visit.
+     * @param value - whether the banner should be visible.
+     */
+    setUnsupportedLocaleBannerVisible(value: boolean) {
+      this.unsupportedLocaleBannerVisible = value
     },
     /**
      * Similar to CSS `@media` queries, this function returns a boolean

--- a/frontend/test/unit/specs/utils/unsupported-locale.spec.ts
+++ b/frontend/test/unit/specs/utils/unsupported-locale.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { getUnsupportedLocaleRedirect } from "#shared/utils/unsupported-locale"
+
+const supported = ["en", "es", "es-ar"]
+
+describe("getUnsupportedLocaleRedirect", () => {
+  it.each`
+    path                | expected
+    ${"/cn"}            | ${"/"}
+    ${"/cn/search"}     | ${"/search"}
+    ${"/xx-yy/about"}   | ${"/about"}
+    ${"/zz/"}           | ${"/"}
+  `(
+    "strips the unsupported prefix `$path` -> `$expected`",
+    ({ path, expected }) => {
+      expect(getUnsupportedLocaleRedirect(path, supported)).toBe(expected)
+    }
+  )
+
+  it.each`
+    path            | reason
+    ${"/es"}        | ${"supported base locale"}
+    ${"/es/search"} | ${"supported base locale with sub-path"}
+    ${"/es-ar"}     | ${"supported regional locale"}
+  `("leaves supported locale `$path` alone ($reason)", ({ path }) => {
+    expect(getUnsupportedLocaleRedirect(path, supported)).toBeNull()
+  })
+
+  it.each`
+    path             | reason
+    ${"/"}           | ${"homepage"}
+    ${"/about"}      | ${"a real page name"}
+    ${"/search"}     | ${"a real page name"}
+    ${"/image/uuid"} | ${"a multi-segment path"}
+    ${"/123"}        | ${"a numeric segment"}
+  `("leaves non-locale-shaped path `$path` alone ($reason)", ({ path }) => {
+    expect(getUnsupportedLocaleRedirect(path, supported)).toBeNull()
+  })
+
+  it("preserves nested paths beyond the first segment", () => {
+    expect(getUnsupportedLocaleRedirect("/cn/search/audio", supported)).toBe(
+      "/search/audio"
+    )
+  })
+})


### PR DESCRIPTION
<!-- prettier-ignore -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #575 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Currently, visiting a path with an unsupported, locale-shaped prefix (e.g. `openverse.org/cn`) matches no route and renders a 404 page.

This PR adds a global route middleware that detects these paths, strips the locale-shaped prefix, and redirects to the English equivalent. On the page the visitor lands on, a one-time banner explains that Openverse isn't translated into the requested language yet and links to the project page where they can contribute a translation.

Details:
- `getUnsupportedLocaleRedirect` util detects a locale-shaped first path segment (two letters, optional hyphenated region — e.g. `cn`, `es-ar`) that isn't in the configured locale set, and returns the prefix-stripped (English) path.
- `unsupported-locale.global` middleware performs the redirect for unmatched routes and controls banner visibility.
- The `ui` store persists an `unsupportedLocaleRedirect` flag so it survives the server-side redirect, then consumes it on the landing page to show the transient banner once. The banner is hidden on any subsequent navigation.
- New `VUnsupportedLocaleBanner` component, wired into `VBanners`, with new `notification.unsupportedLocale.*` strings.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run the frontend locally.
2. Visit an unsupported, locale-shaped path such as `http://localhost:8443/cn` (or `/cn/search?q=cat`).
3. Verify you are redirected to the English equivalent (`/` or `/search?q=cat`) rather than seeing a 404, and that the "language not supported" banner appears once.
4. Navigate elsewhere and confirm the banner disappears and does not reappear.
5. Confirm a supported locale (e.g. `/es`) and a genuinely unknown path (e.g. `/foobar`) are unaffected.
6. Run the unit tests: `ov just frontend/run test:unit unsupported-locale`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like`Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [ ] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog
      PRs) or the media properties generator (`ov just catalog/generate-docs media-props`
      for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
