### PR TITLE
Fix UnicodeDecodeError when parsing WordPress titles containing emoji

### DIFF
--- a/catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -11,7 +11,7 @@ Notes:                  <https://wordpress.org/photos/wp-json/wp/v2>
 """
 
 import logging
-
+import re
 import lxml.html as html
 
 from common import constants
@@ -172,9 +172,12 @@ class WordPressDataIngester(ProviderDataIngester):
         if title := image.get("content", {}).get("rendered"):
             try:
                 title = html.fromstring(title).text_content()
-            except UnicodeDecodeError as e:
-                logger.warning(f"Can't save the image's title ('{title}') due to {e}")
-                return None
+            except UnicodeDecodeError:
+                # lxml's HTML parser can raise UnicodeDecodeError on titles
+                # containing certain emoji. Fall back to a regex-based tag
+                # strip, which operates on the original str and never
+                # re-encodes it, so emoji are preserved correctly.
+                title = re.sub(r"<[^<]+?>", "", title).strip()
         return title
 
     @staticmethod

--- a/catalog/tests/dags/providers/provider_api_scripts/test_wordpress.py
+++ b/catalog/tests/dags/providers/provider_api_scripts/test_wordpress.py
@@ -93,6 +93,11 @@ def test_get_title(ingester):
     expected_result = "Coffee Bean with bags"
     assert actual_result == expected_result
 
+def test_get_title_handles_emoji(ingester):
+    image_data = {"content": {"rendered": "<p>Tomato Basil \U0001F33F Soup</p>\n"}}
+    actual_result = ingester._get_title(image_data)
+    expected_result = "Tomato Basil \U0001F33F Soup"
+    assert actual_result == expected_result
 
 def test_get_file_info(ingester):
     image_details = (


### PR DESCRIPTION
Fixes #1550 by @aelhaddadi715-beep

## Description
`lxml.html.fromstring` raises a `UnicodeDecodeError` when parsing WordPress
photo titles that contain certain emoji, causing the title to be silently
dropped (set to `None`) instead of saved.

This adds a fallback: when the `UnicodeDecodeError` is caught, the title is
instead cleaned using a regex-based HTML tag strip, which operates on the
original string and never re-encodes it — so the emoji is preserved
correctly.

## Testing Instructions
Run the WordPress provider tests:
`just test tests/dags/providers/provider_api_scripts/test_wordpress.py`

A new test, `test_get_title_handles_emoji`, covers a title containing an
emoji and confirms it comes through unchanged.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.