### PR TITLE
Scrub the database hostname from Sentry events

### DIFF
--- a/api/api/utils/sentry.py
+++ b/api/api/utils/sentry.py
@@ -1,0 +1,58 @@
+"""
+Utilities for scrubbing sensitive infrastructure values out of Sentry events.
+
+``send_default_pii=False`` and Sentry's server-side scrubbing only cover known
+PII fields by key. Infrastructure hostnames such as the database DNS name can
+still reach Sentry as free text — inside breadcrumbs, span descriptions or
+exception messages — where key-based scrubbing never sees them. This redacts
+those known-sensitive values from an event before it leaves the process.
+
+See https://github.com/WordPress/openverse/issues/670.
+"""
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+FILTERED = "[Filtered]"
+
+# Hostnames that are not sensitive and are too broad to be worth redacting.
+IGNORED_HOSTS = frozenset({"", "localhost", "127.0.0.1", "::1"})
+
+
+def _redact(value: Any, secrets: list[str]) -> Any:
+    if isinstance(value, str):
+        for secret in secrets:
+            value = value.replace(secret, FILTERED)
+        return value
+    if isinstance(value, dict):
+        return {key: _redact(item, secrets) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact(item, secrets) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact(item, secrets) for item in value)
+    return value
+
+
+def make_sensitive_value_scrubber(hostnames: Iterable[str]) -> Callable:
+    """
+    Build a Sentry ``before_send`` / ``before_send_transaction`` hook that
+    replaces the given hostnames wherever they appear, as substrings, anywhere
+    in the event.
+
+    Longer hostnames are redacted first so that a host which is a substring of
+    another (e.g. ``db.example.com`` inside ``replica.db.example.com``) does not
+    leave a partial value behind.
+    """
+    secrets = sorted(
+        {host for host in hostnames if host not in IGNORED_HOSTS},
+        key=len,
+        reverse=True,
+    )
+
+    def before_send(event: Any, hint: Any = None) -> Any:
+        if not secrets:
+            return event
+        return _redact(event, secrets)
+
+    return before_send

--- a/api/conf/settings/sentry.py
+++ b/api/conf/settings/sentry.py
@@ -3,7 +3,9 @@ from decouple import config
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
+from api.utils.sentry import make_sensitive_value_scrubber
 from conf.settings.base import ENVIRONMENT
+from conf.settings.databases import DATABASES
 from conf.settings.security import DEBUG
 
 
@@ -43,6 +45,10 @@ INTEGRATIONS = [
     LoggingIntegration(event_level=None, level=None),
 ]
 
+# Redact infrastructure hostnames (e.g. the database DNS name) that can leak
+# into events as free text, where key-based scrubbing never sees them.
+scrub_sensitive_values = make_sensitive_value_scrubber([DATABASES["default"]["HOST"]])
+
 if not DEBUG and SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -51,6 +57,8 @@ if not DEBUG and SENTRY_DSN:
         profiles_sampler=profiles_sampler,
         send_default_pii=False,
         environment=ENVIRONMENT,
+        before_send=scrub_sensitive_values,
+        before_send_transaction=scrub_sensitive_values,
     )
 
     # ALLOW_HOSTS is correctly configured so ignore this to prevent

--- a/api/test/unit/utils/test_sentry.py
+++ b/api/test/unit/utils/test_sentry.py
@@ -1,0 +1,48 @@
+import pytest
+
+from api.utils.sentry import FILTERED, make_sensitive_value_scrubber
+
+
+def test_redacts_hostname_anywhere_in_a_nested_event():
+    scrub = make_sensitive_value_scrubber(["db.internal.example.com"])
+    event = {
+        "message": "could not connect to db.internal.example.com:5432",
+        "breadcrumbs": {
+            "values": [{"message": "SELECT 1 -- db.internal.example.com"}],
+        },
+        "extra": {"hosts": ("db.internal.example.com", "unrelated-host")},
+    }
+
+    scrubbed = scrub(event)
+
+    assert "db.internal.example.com" not in repr(scrubbed)
+    assert FILTERED in scrubbed["message"]
+    assert scrubbed["breadcrumbs"]["values"][0]["message"].endswith(FILTERED)
+    # unrelated values are left untouched (and tuples stay tuples)
+    assert scrubbed["extra"]["hosts"] == (FILTERED, "unrelated-host")
+
+
+@pytest.mark.parametrize("hostname", ["", "localhost", "127.0.0.1", "::1"])
+def test_ignores_non_sensitive_default_hosts(hostname):
+    scrub = make_sensitive_value_scrubber([hostname])
+    event = {"message": f"connected to {hostname}"}
+
+    # nothing to redact, so the event is returned unchanged
+    assert scrub(event) is event
+
+
+def test_returns_event_unchanged_when_no_hostnames_given():
+    scrub = make_sensitive_value_scrubber([])
+    event = {"message": "hello"}
+
+    assert scrub(event) is event
+
+
+def test_redacts_longer_overlapping_hostname_first():
+    scrub = make_sensitive_value_scrubber(["db.example.com", "replica.db.example.com"])
+    event = {"message": "replica.db.example.com and db.example.com"}
+
+    scrubbed = scrub(event)
+
+    assert "example.com" not in scrubbed["message"]
+    assert scrubbed["message"] == f"{FILTERED} and {FILTERED}"


### PR DESCRIPTION
## Fixes

Fixes #670

## Description

`send_default_pii=False` and Sentry's server-side scrubbing only cover known PII **fields by key**. Infrastructure hostnames such as the database DNS name can still reach Sentry as **free text** — inside breadcrumbs, span descriptions or exception messages — where key-based scrubbing never sees them.

This adds a `before_send` / `before_send_transaction` hook that redacts the configured database hostname wherever it appears, as a substring, anywhere in an event.

A note on approach: the issue links to Sentry's *server-side* scrubbing docs, but doing this client-side is strictly safer — the value is redacted **before the event leaves the process**, so it is never stored in Sentry at all. It also keeps the rule in version control next to the rest of the Sentry config.

Details:
- The scrubber lives in `api/utils/sentry.py` as a small, dependency-free helper so it can be unit-tested in isolation.
- Non-sensitive defaults (`localhost`, `127.0.0.1`, `::1`, empty) are ignored, so local/dev never redacts noise.
- Longer hostnames are redacted first, so a host that is a substring of another does not leave a partial value behind.

## Testing Instructions

`just api/test test/unit/utils/test_sentry.py` — or, since the helper is dependency-free:

```python
from api.utils.sentry import make_sensitive_value_scrubber, FILTERED

scrub = make_sensitive_value_scrubber(["db.internal.example.com"])
event = {"message": "could not connect to db.internal.example.com:5432"}
assert FILTERED in scrub(event)["message"]
```

The added unit tests cover redaction across a nested event, ignored default hosts, the no-op case, and the overlapping-hostname ordering.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the default branch of the repository (`main`).
- [x] My change is covered by tests where possible.

## Note / follow-up

This covers the **API** (Django) side. The ingestion server initialises Sentry separately (`ingestion_server/ingestion_server/api.py`); happy to extend the same approach there in this PR or a follow-up — whichever the maintainers prefer.
