### PR TITLE
Improve error handling and fix format issues

### DIFF
--- a/api/api/serializers/image_serializers.py
+++ b/api/api/serializers/image_serializers.py
@@ -118,7 +118,7 @@ class OembedRequestSerializer(Serializer):
             uuid = UUID(identifier)
         except ValueError:
             raise serializers.ValidationError(
-                {"Could not parse identifier from URL.": data["url"]}
+                {"url": ["Could not parse identifier from URL."]}
             )
 
         data["identifier"] = uuid

--- a/api/api/views/image_views.py
+++ b/api/api/views/image_views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from PIL import Image as PILImage
+import structlog
 
 from api.constants.media_types import IMAGE_TYPE
 from api.docs.image_docs import (
@@ -29,6 +30,9 @@ from api.serializers.image_serializers import (
 from api.utils import image_proxy
 from api.utils.aiohttp import get_aiohttp_session
 from api.views.media_views import MediaViewSet
+
+
+logger = structlog.get_logger(__name__)
 
 
 @extend_schema(tags=["images"])
@@ -81,20 +85,26 @@ class ImageViewSet(MediaViewSet):
         image = await aget_object_or_404(Image, identifier=identifier)
 
         if not (image.height and image.width):
-            session = await get_aiohttp_session()
+            try:
+                session = await get_aiohttp_session()
 
-            async with session.get(
-                image.url, headers=self.OEMBED_HEADERS
-            ) as image_file:
-                image_content = await image_file.content.read()
-
-            with PILImage.open(io.BytesIO(image_content)) as image_file:
-                width, height = image_file.size
-
-            context |= {
-                "width": width,
-                "height": height,
-            }
+                async with session.get(
+                    image.url, headers=self.OEMBED_HEADERS
+                ) as image_file:
+                    if image_file.status == 200:
+                        image_content = await image_file.content.read()
+                        with PILImage.open(io.BytesIO(image_content)) as image_file_obj:
+                            width, height = image_file_obj.size
+                        context |= {
+                            "width": width,
+                            "height": height,
+                        }
+            except Exception:
+                logger.warning(
+                    "failed_to_get_image_dimensions_for_oembed",
+                    image_identifier=image.identifier,
+                    image_url=image.url,
+                )
 
         serializer = self.get_serializer(image, context=context)
         return Response(data=await serializer.adata)

--- a/dag-sync.sh
+++ b/dag-sync.sh
@@ -36,6 +36,9 @@ fi
 
 # Pull out the subject from the new commit
 subject=$(git log -1 --format='%s')
+# Escape backslashes and double quotes for JSON payload safety
+subject=${subject//\\/\\\\}
+subject=${subject//\"/\\\"}
 # Swap the < & > characters for their HTML entities so they aren't
 # interpreted as delimiters by Slack
 subject=${subject//>/&gt;}

--- a/frontend/src/components/VSkipToContentButton.vue
+++ b/frontend/src/components/VSkipToContentButton.vue
@@ -16,7 +16,7 @@ import VButton from "~/components/VButton.vue"
 </template>
 
 <style scoped>
-.skip-button:not(:focus-visible) {
+.skip-button:not(:focus, :focus-visible) {
   @apply sr-only;
 }
 </style>


### PR DESCRIPTION
Fix DRF serializer error format, oEmbed exception handling, shell JSON escaping, and skip button focus CSS

## Description
This pull request addresses several reliability, compatibility, and accessibility issues across the repository:

- **Fix serializer error format to be DRF-compliant in `OembedRequestSerializer`**:
  Updated the `ValidationError` error dictionary structure from `{"Could not parse identifier from URL.": data["url"]}` to standard DRF-compliant structure `{"url": ["Could not parse identifier from URL."]}` in `api/api/serializers/image_serializers.py`. This aligns with the OpenAPI specification (`image_oembed_400_example`) and standard PHP / WordPress client expectations.

- **Add error handling and logging for image dimension fetching in oEmbed endpoint**:
  Wrapped out-of-band image downloading and PIL image dimension parsing in a `try...except` block in `api/api/views/image_views.py`. Structured warnings (`failed_to_get_image_dimensions_for_oembed`) are logged when network or parsing errors occur, preventing unhandled HTTP 500 responses.

- **Add HTTP status check before processing image content**:
  Added explicit `image_file.status == 200` verification before reading image content bytes and attempting PIL dimension extraction in `image_views.py`.

- **Escape special characters in `dag-sync.sh` JSON payload for robustness**:
  Added parameter expansion rules `${subject//\\/\\\\}` and `${subject//\"/\\\"}` in `dag-sync.sh` to escape backslashes and double quotes in commit messages before constructing Slack webhook JSON payloads.

- **Update skip button CSS selector for better browser compatibility**:
  Updated the CSS selector in `frontend/src/components/VSkipToContentButton.vue` to `.skip-button:not(:focus, :focus-visible)` so the skip-to-content button is visually displayed whenever focused across all browser focus modes.

## Testing Instructions
1. **API / oEmbed Serializer & View**:
   - Query `v1/images/oembed/` with an invalid `url` parameter (e.g., `?url=invalid`) and verify that the 400 response body is formatted as `{"url": ["Could not parse identifier from URL."]}`.
   - Query `v1/images/oembed/` for an image whose remote URL returns 404 or times out, and verify that the view returns a valid 200 oEmbed response without throwing a 500 Internal Server Error.
2. **Shell Script**:
   - Run `bash -n dag-sync.sh` to verify syntax correctness.
3. **Frontend**:
   - Tab into the frontend application and verify that the "Skip to content" button displays properly upon receiving focus.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
- [x] I ran the DAG documentation generator (`ov just catalog/generate-docs` for catalog PRs) or the media properties generator (`ov just catalog/generate-docs media-props` for the catalog or `ov just api/generate-docs` for the API) where applicable.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
