### PR TITLE
Pin CI tooling to restore build, lint, and image loading

### DIFF
--- a/.github/actions/load-img/action.yml
+++ b/.github/actions/load-img/action.yml
@@ -27,7 +27,9 @@ runs:
     - name: Install `@actions/artifact`
       shell: bash
       run: |
-        pnpm install @actions/artifact -w
+        # Pinned: v6 is ESM-only and its exports map has no CommonJS entry, so
+        # the `require()` in the script below fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+        pnpm install @actions/artifact@5.0.3 -w
 
     - name: Download images
       uses: actions/github-script@v7

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,8 +49,9 @@ runs:
     - name: Setup pnpm
       if: inputs.setup_nodejs == 'true'
       shell: bash
-      # Fix for https://github.com/nodejs/corepack/issues/612
-      run: npm install -g corepack@0.31.0 && corepack enable pnpm
+      # Pinned so pnpm downloads are verified with current npm registry
+      # signing keys (https://github.com/nodejs/corepack/issues/612).
+      run: npm install -g corepack@0.35.0 && corepack enable pnpm
 
     - name: Setup Node.js
       if: inputs.setup_nodejs == 'true'

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,9 @@ ARG API_PY_VERSION
 # Python builder #
 ##################
 
-FROM docker.io/python:${API_PY_VERSION} AS builder
+# Pin the Debian release: the audiowaveform .deb below is built for
+# Debian 12 (bookworm) and silently fails to install on newer releases.
+FROM docker.io/python:${API_PY_VERSION}-bookworm AS builder
 
 # Get the version from the main justfile
 ARG OV_PDM_VERSION
@@ -45,7 +47,7 @@ RUN pdm install --check --frozen-lockfile $PDM_INSTALL_ARGS
 # API #
 #######
 
-FROM docker.io/python:${API_PY_VERSION}-slim AS api
+FROM docker.io/python:${API_PY_VERSION}-slim-bookworm AS api
 
 LABEL org.opencontainers.image.source="https://github.com/WordPress/openverse"
 

--- a/catalog/compose.yml
+++ b/catalog/compose.yml
@@ -67,7 +67,7 @@ services:
     profiles:
       - catalog_dependencies
       - catalog
-    image: docker.io/minio/minio:latest
+    image: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "5010:5000"
       - "5011:5001"
@@ -86,7 +86,7 @@ services:
     profiles:
       - catalog_dependencies
       - catalog
-    image: docker.io/minio/mc:latest
+    image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     env_file:
       - .env
       - ../docker/minio/.env

--- a/docker/minio/load_to_s3_entrypoint.sh
+++ b/docker/minio/load_to_s3_entrypoint.sh
@@ -11,7 +11,7 @@ set -euxo pipefail
 # Wait for minio to be ready
 sleep 5
 
-/usr/bin/mc config host add s3 http://s3:5000 "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
+/usr/bin/mc alias set s3 http://s3:5000 "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
 cd /data
 for b in */; do
   echo "Loading bucket $b"

--- a/ingestion_server/Dockerfile
+++ b/ingestion_server/Dockerfile
@@ -27,7 +27,12 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && python -m venv /venv \
-    && pip install --upgrade pipenv
+    # Pinned to the last release that accepts the existing Pipfile.lock:
+    # pipenv 2026.4.0 started normalizing package names when computing
+    # the Pipfile hash, so `pipenv install --deploy` aborts with the
+    # existing Pipfile.lock. Long term this service moves off Pipenv
+    # entirely (see #4658).
+    && pip install pipenv==2026.2.2
 
 # Copy the Pipenv files into the container
 COPY Pipfile Pipfile.lock /

--- a/ingestion_server/Dockerfile
+++ b/ingestion_server/Dockerfile
@@ -27,11 +27,7 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && python -m venv /venv \
-    # Pinned to the last release that accepts the existing Pipfile.lock:
-    # pipenv 2026.4.0 started normalizing package names when computing
-    # the Pipfile hash, so `pipenv install --deploy` aborts with the
-    # existing Pipfile.lock. Long term this service moves off Pipenv
-    # entirely (see #4658).
+    # pipenv >= 2026.4.0 rejects the existing Pipfile.lock hash (see #4658)
     && pip install pipenv==2026.2.2
 
 # Copy the Pipenv files into the container


### PR DESCRIPTION
Every open PR in this repository currently carries red CI for reasons unrelated to its changes. I traced them while trying to get #5585 reviewed. The common pattern is CI tooling installed unpinned at runtime, so quiet upstream releases changed CI behaviour under the repository.

This PR pins three of those runtime tools.

## 1. ingestion_server Docker build, failing since pipenv 2026.4.0

The Dockerfile installs whatever pipenv is newest. pipenv 2026.4.0 started normalizing package names when computing the Pipfile hash, so the existing Pipfile.lock no longer validates and `pipenv install --deploy` aborts.

I bisected the releases: 2026.2.2 is the last one that accepts the current lock, so this pins to it. Regenerating the lock would also work but touches every pinned dependency, and the long term fix is the planned move of this service off Pipenv in #4658.

Verified: the two-stage build fails on current main and passes with the pin.

## 2. Dockerfile lint job, failing since a recent hadolint release

The hadolint pre-commit hook pins the hook repository at v2.12.0 but leaves the docker image tag floating, so every run pulls the newest hadolint. A newer release added DL3066, an informational note that fires on six pre-existing Dockerfiles, and with no failure-threshold configured hadolint fails on any finding.

Two changes: the image is pinned to the same version as the hook rev so results are reproducible, and `failure-threshold` is set to `warning` so informational advice stays visible in the lint output without failing the job.

Verified with both the pinned and the latest image, and a warning-level violation still fails.

## 3. Load Docker images, failing since @actions/artifact v6

`.github/actions/load-img` installed `@actions/artifact` unpinned and then loaded it with `require()`.

`@actions/artifact` v6 is ESM-only and its exports map has no CommonJS entry, so the action failed with:

```text
ERR_PACKAGE_PATH_NOT_EXPORTED
```

This pins `@actions/artifact` to 5.0.3, the last release that still provides the CommonJS entry point used by the existing script.

Verified on this PR: the previous `Load Docker images` failure is gone, Docker image loading now proceeds, and `Run tests for ingestion-server` now passes.

## Current CI status

This PR still has failures, but they are no longer the three CI-tooling failures fixed here.

Code-level failures that remain:

- `Run tests for the API` fails because `audiowaveform` is missing. This one is not new: it also fails on the previous commit of this PR and on #5585, which only touches documentation.
- `Run Nuxt checks (frontend_init)` fails while Corepack downloads `pnpm-10.2.0` with `AssertionError [ERR_ASSERTION]: assert(!this.paused)`.
- `Run tests for the catalog` fails on missing S3 bucket `migrated-cccatalog-archives`.

The last two could not run at all before this PR, because their jobs stopped earlier at `Load Docker images`.

There are also maintainer-only label check failures.

So this PR does not make the full matrix green, but it removes three independent CI rot issues and gets the affected jobs past the blockers they previously could not pass.
