### PR TITLE
Reduce Actions storage churn: image artifact retention and Renovate cadence

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -212,6 +212,10 @@ jobs:
         with:
           name: ${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
+          # These tarballs are only consumed by later jobs in the same run
+          # (via `load-img`), so they don't need the default 90 day retention.
+          # 2 days still allows re-running failed jobs the next day.
+          retention-days: 2
 
       - name: Show artifact ID
         run: |

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,8 +12,8 @@ on:
           - disabled
           - reset
   schedule:
-    # Run every 30 minutes:
-    - cron: "0,30 * * * *"
+    # Run every 6 hours:
+    - cron: "0 */6 * * *"
 
 # Adding these as env variables makes it easy to reuse them in different steps and in bash.
 env:


### PR DESCRIPTION
## Description

This PR reduces GitHub Actions storage and compute churn in two ways.

### Image artifact retention

The `build-images` job uploads each service's Docker image as a `.tar` artifact (`frontend` alone is ~175 MB) with the repository's default 90-day retention. Every consumer of these artifacts — the test jobs and the ghcr.io publish job, all via the `load-img` action — downloads them using `run_id: ${{ github.run_id }}`, i.e. within the same workflow run. Deployments pull from ghcr.io, never from these artifacts. So the tarballs are useful for about an hour but stored for 90 days.

This month that added up: openverse has accrued ~215 GB-months of Actions storage so far (August 2026), out of ~511 GB-months for the whole WordPress Foundation enterprise, whose plan includes 50 GB — the `frontend` artifact alone projects to ~47 GB of standing storage at steady state. This PR sets `retention-days: 2` on the image uploads, which still allows re-running failed jobs of a recent run the next day. (`renovate.yml` already uses `retention-days: 1` for the same reason.)

### Renovate cadence

The scheduled Renovate workflow moves from every 30 minutes to every 6 hours. Each run uploads a cache artifact (~48/day), and every PR it rebases triggers a full CI + CD run including Docker image builds — constant churn on a mostly idle repository. Renovate still runs 4× daily, plenty for dependency updates, and can always be dispatched manually.

## Testing Instructions

CI on this PR exercises the changed upload step directly; the `load-img`-based jobs downloading the images within the run are unaffected by retention. After merge, image artifacts on new runs will show a 2-day expiry on the run's summary page, and the Renovate workflow's schedule shows the new cadence on its workflow page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
