### PR TITLE
Pin hadolint Docker image to match the hook rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,3 +166,6 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
+        # The upstream hook leaves the image tag floating at `latest`,
+        # ignoring `rev`. Pin it so lint results are reproducible.
+        entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint


### PR DESCRIPTION
## Description

The required "Lint files" check has been failing on every PR (and on `main`) because the upstream `hadolint-docker` pre-commit hook leaves its Docker image tag floating at `latest` — every run pulls the newest hadolint regardless of the pinned `rev: v2.12.0`. A newer hadolint release introduced rule DL3066 ("Non-numeric user-id"), which fires on `frontend`, `api`, `catalog`, and `ingestion_server` Dockerfiles and fails the job.

Pinning the image `entry` to the same version as `rev` makes lint reproducible. Verified locally: **hadolint v2.12.0 with the repository's existing `.hadolint.yaml` produces zero findings across all seven Dockerfiles** (exit 0), so no rule changes or threshold adjustments are needed.

This is the lint half of #5602 (credit to @ekamran for identifying the fix), split out deliberately: #5602 also touches `ingestion_server/Dockerfile`, which triggers the API/catalog/Nuxt test suites that are currently failing for unrelated reasons and are required checks — so it can't merge until those are fixed. This PR touches only `.pre-commit-config.yaml` (the `lint` change group), so the heavy suites skip and the repo-wide lint blockage can be resolved immediately. Unlike #5602, it omits the `failure-threshold: warning` addition, which local verification shows is unnecessary at v2.12.0.

## Testing Instructions

```bash
pre-commit run hadolint-docker --all-files
```
should pass, and the "Lint files" job on this PR should be green — the first green lint run on the repo in months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)