### PR TITLE
Route external link hrefs through a shared URL helper

### DIFF
--- a/frontend/shared/utils/attribution-html.ts
+++ b/frontend/shared/utils/attribution-html.ts
@@ -11,6 +11,7 @@ import {
   getFullLicenseName,
   isPublicDomain,
 } from "#shared/utils/license"
+import { sanitizeHref } from "#shared/utils/sanitize-href"
 import type { Media } from "#shared/types/media"
 
 import type { Composer } from "vue-i18n"
@@ -141,29 +142,6 @@ const licenseElementImg = (licenseElement: LicenseElement): string => {
     src,
     style: "height: 1em; margin-right: 0.125em; display: inline;",
   })
-}
-
-/**
- * Drop URLs with a non-http(s)/mailto scheme to `about:blank`, so a
- * `javascript:` or `data:` URL can't yield an executable link. Escaping the
- * attribute value does not stop these, as they contain nothing to escape.
- *
- * @param href - the untrusted URL to sanitise
- * @returns the URL if its scheme is safe, otherwise `about:blank`
- */
-const sanitizeHref = (href: string): string => {
-  // Strip the C0 controls and spaces a browser ignores when parsing, else `\x01javascript:` or `java\tscript:` evades the check but still runs.
-  const stripped = Array.from(href)
-    .filter((char) => (char.codePointAt(0) ?? 0) > 0x20)
-    .join("")
-  const scheme = stripped.match(/^([a-z][a-z0-9+.-]*):/i)
-  if (
-    scheme &&
-    !["http", "https", "mailto"].includes(scheme[1].toLowerCase())
-  ) {
-    return "about:blank"
-  }
-  return href
 }
 
 /**

--- a/frontend/shared/utils/sanitize-href.ts
+++ b/frontend/shared/utils/sanitize-href.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared URL-scheme guard for values rendered into anchor `href`/`to`
+ * attributes. Both the raw-HTML attribution builder and the shared `VLink`
+ * component route untrusted, provider-supplied URLs (e.g. `creator_url`,
+ * `foreign_landing_url`) through this, so a single allow-list governs every
+ * link sink.
+ */
+
+/**
+ * Schemes permitted to appear in a rendered link. Anything else with an
+ * explicit scheme (`javascript:`, `data:`, `vbscript:`, …) is neutralised.
+ */
+const ALLOWED_SCHEMES = ["http", "https", "mailto"]
+
+/**
+ * Drop URLs with a non-allow-listed scheme to `about:blank`, so a
+ * `javascript:` or `data:` URL can't yield an executable link. Escaping the
+ * attribute value does not stop these, as they contain nothing to escape.
+ * Scheme-relative and relative URLs (no explicit scheme) are left untouched.
+ *
+ * @param href - the untrusted URL to sanitise
+ * @returns the URL if its scheme is safe, otherwise `about:blank`
+ */
+export const sanitizeHref = (href: string): string => {
+  // Strip the C0 controls and spaces a browser ignores when parsing, else `\x01javascript:` or `java\tscript:` evades the check but still runs.
+  const stripped = Array.from(href)
+    .filter((char) => (char.codePointAt(0) ?? 0) > 0x20)
+    .join("")
+  const scheme = stripped.match(/^([a-z][a-z0-9+.-]*):/i)
+  if (scheme && !ALLOWED_SCHEMES.includes(scheme[1].toLowerCase())) {
+    return "about:blank"
+  }
+  return href
+}

--- a/frontend/src/components/VLink.vue
+++ b/frontend/src/components/VLink.vue
@@ -11,6 +11,7 @@
 import { useNuxtApp } from "#imports"
 import { computed, useAttrs } from "vue"
 
+import { sanitizeHref } from "#shared/utils/sanitize-href"
 import { useAnalytics } from "~/composables/use-analytics"
 
 import VIcon from "~/components/VIcon/VIcon.vue"
@@ -89,7 +90,8 @@ const to = computed(() => {
       // Internal link should link to the localized page
       return localePath(props.href) ?? props.href
     } else {
-      return props.href
+      // External href comes from untrusted sources (e.g. provider metadata); block script-bearing schemes.
+      return sanitizeHref(props.href)
     }
   }
   // if href is undefined, return props that make the link disabled

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -56,6 +56,16 @@ describe("VLink", () => {
       expect(link.getAttribute("href")).toEqual(expected)
     }
   )
+  it("re-applies the guard when href changes from safe to unsafe", async () => {
+    options.props = { href: "https://good.example.com/landing" }
+    options.slots = { default: () => "Code is Poetry" }
+    const { rerender } = render(VLink, options)
+    expect(screen.getByRole("link").getAttribute("href")).toEqual(
+      "https://good.example.com/landing"
+    )
+    await rerender({ href: "javascript:alert(1)" })
+    expect(screen.getByRole("link").getAttribute("href")).toEqual("about:blank")
+  })
   it.each`
     href
     ${"/about"}

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -40,12 +40,12 @@ describe("VLink", () => {
     }
   )
   it.each`
-    href                                  | expected
-    ${"javascript:alert(1)"}              | ${"about:blank"}
-    ${"JavaScript:alert(1)"}              | ${"about:blank"}
-    ${"java\tscript:alert(1)"}            | ${"about:blank"}
+    href                                   | expected
+    ${"javascript:alert(1)"}               | ${"about:blank"}
+    ${"JavaScript:alert(1)"}               | ${"about:blank"}
+    ${"java\tscript:alert(1)"}             | ${"about:blank"}
     ${"data:text/html,<script>1</script>"} | ${"about:blank"}
-    ${"https://good.example.com/landing"} | ${"https://good.example.com/landing"}
+    ${"https://good.example.com/landing"}  | ${"https://good.example.com/landing"}
   `(
     "neutralises script-bearing external hrefs ($href)",
     async ({ href, expected }) => {

--- a/frontend/test/unit/specs/components/v-link.spec.js
+++ b/frontend/test/unit/specs/components/v-link.spec.js
@@ -40,6 +40,23 @@ describe("VLink", () => {
     }
   )
   it.each`
+    href                                  | expected
+    ${"javascript:alert(1)"}              | ${"about:blank"}
+    ${"JavaScript:alert(1)"}              | ${"about:blank"}
+    ${"java\tscript:alert(1)"}            | ${"about:blank"}
+    ${"data:text/html,<script>1</script>"} | ${"about:blank"}
+    ${"https://good.example.com/landing"} | ${"https://good.example.com/landing"}
+  `(
+    "neutralises script-bearing external hrefs ($href)",
+    async ({ href, expected }) => {
+      options.props = { href }
+      options.slots = { default: () => "Code is Poetry" }
+      await render(VLink, options)
+      const link = screen.getByRole("link")
+      expect(link.getAttribute("href")).toEqual(expected)
+    }
+  )
+  it.each`
     href
     ${"/about"}
     ${"http://localhost"}

--- a/frontend/test/unit/specs/utils/sanitize-href.spec.ts
+++ b/frontend/test/unit/specs/utils/sanitize-href.spec.ts
@@ -20,9 +20,9 @@ describe("sanitizeHref", () => {
   it.each([0, 1, 9, 31])(
     "blanks a scheme hidden behind leading control char %i",
     (code) => {
-      expect(sanitizeHref(String.fromCharCode(code) + "javascript:alert(1)")).toBe(
-        "about:blank"
-      )
+      expect(
+        sanitizeHref(String.fromCharCode(code) + "javascript:alert(1)")
+      ).toBe("about:blank")
     }
   )
 

--- a/frontend/test/unit/specs/utils/sanitize-href.spec.ts
+++ b/frontend/test/unit/specs/utils/sanitize-href.spec.ts
@@ -6,14 +6,25 @@ describe("sanitizeHref", () => {
   it.each([
     "javascript:alert(1)",
     "JavaScript:alert(document.domain)",
+    "jAvAsCrIpT:alert(1)",
     "java\tscript:alert(1)",
-    "javascript:alert(1)",
+    "java\nscript:alert(1)",
+    "java\rscript:alert(1)",
     " javascript:alert(1)",
     "data:text/html,<script>alert(1)</script>",
     "vbscript:msgbox(1)",
   ])("blanks script-bearing scheme %j", (href) => {
     expect(sanitizeHref(href)).toBe("about:blank")
   })
+
+  it.each([0, 1, 9, 31])(
+    "blanks a scheme hidden behind leading control char %i",
+    (code) => {
+      expect(sanitizeHref(String.fromCharCode(code) + "javascript:alert(1)")).toBe(
+        "about:blank"
+      )
+    }
+  )
 
   it.each([
     "https://example.com/landing?a=1&b=2",
@@ -22,6 +33,9 @@ describe("sanitizeHref", () => {
     "/internal/path",
     "//scheme-relative.example.com",
     "relative/path",
+    // Encoded payloads are not decoded here — and the browser doesn't decode the scheme either, so they stay inert as-is rather than being wrongly rewritten.
+    "%6Aavascript:alert(1)",
+    "&#106;avascript:alert(1)",
   ])("preserves safe or scheme-less URL %j", (href) => {
     expect(sanitizeHref(href)).toBe(href)
   })

--- a/frontend/test/unit/specs/utils/sanitize-href.spec.ts
+++ b/frontend/test/unit/specs/utils/sanitize-href.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeHref } from "#shared/utils/sanitize-href"
+
+describe("sanitizeHref", () => {
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(document.domain)",
+    "java\tscript:alert(1)",
+    "javascript:alert(1)",
+    " javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+  ])("blanks script-bearing scheme %j", (href) => {
+    expect(sanitizeHref(href)).toBe("about:blank")
+  })
+
+  it.each([
+    "https://example.com/landing?a=1&b=2",
+    "http://example.com",
+    "mailto:someone@example.com",
+    "/internal/path",
+    "//scheme-relative.example.com",
+    "relative/path",
+  ])("preserves safe or scheme-less URL %j", (href) => {
+    expect(sanitizeHref(href)).toBe(href)
+  })
+})


### PR DESCRIPTION
## Description

The attribution builder already normalised link URLs through a small private helper. This lifts that logic into a shared `sanitizeHref` util and reuses it in the shared `VLink` component so all external links go through the same URL handling instead of two slightly different paths.

- Extract `sanitizeHref` to `frontend/shared/utils/sanitize-href.ts` (single source of truth; `http`/`https`/`mailto` pass through, other explicit schemes are normalised to `about:blank`, relative/scheme-less URLs untouched).
- `attribution-html.ts` now imports it (behaviour unchanged).
- `VLink.vue` applies it to external hrefs.

Internal (`/…`) links and normal `http(s)`/`mailto` links are unaffected; rendered output is identical for those.

## Testing Instructions

- `cd frontend && pnpm test:unit sanitize-href v-link attribution-html`
- Detail pages, the reuse/attribution panel, and external links render and behave as before.

## Checklist

- [x] Unit tests added and passing.
- [x] Lint passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)