### PR TITLE
Fix typos in documentation

### DIFF
--- a/documentation/projects/proposals/monitoring/run_book_samples/unstable_run_book_sample.md
+++ b/documentation/projects/proposals/monitoring/run_book_samples/unstable_run_book_sample.md
@@ -73,7 +73,7 @@ activity like indexing during a data refresh.
 
 - 2023-06-08 at 03:00 UTC. There was an increase in response time but it was
   brief and for a very short period of time and corresponded with peak traffic
-  hourse. We think we can change the anomaly configuration to 2.5 standard
+  hours. We think we can change the anomaly configuration to 2.5 standard
   deviations above the curve but we need further examples to corroborate this.
 - 2023-06-12 at 16:00 UTC. This happened during low traffic when response time
   is also much lower than peak traffic. We think we might be able to add

--- a/documentation/projects/proposals/search_relevancy_sandbox/20230530-implementation_plan_staging_elasticsearch_reindex_dags.md
+++ b/documentation/projects/proposals/search_relevancy_sandbox/20230530-implementation_plan_staging_elasticsearch_reindex_dags.md
@@ -177,7 +177,7 @@ version for maintainers safety.
    of these tasks as documents in an aggregated form. Then here use Sensors and
    the previously emitted task IDs to wait for reindex tasks to complete.
 7. Once all tasks are finished, trigger an [`indices.refresh`][es_py_refresh] to
-   make the index queyrable.
+   make the index queryable.
 8. Make the alias `<media_type>-subset-by-provider` point to the new index.
    Follow the same procedure to that of `<media_type>-full` alias of the
    previous DAG.


### PR DESCRIPTION
## Description
Fix two spelling mistakes in Openverse documentation.
## Changes
- Changed `peak traffic hourse` to `peak traffic hours` in `documentation/projects/proposals/monitoring/run_book_samples/unstable_run_book_sample.md`.
- Changed `queyrable` to `queryable` in `documentation/projects/proposals/search_relevancy_sandbox/20230530-implementation_plan_staging_elasticsearch_reindex_dags.md`.
## Testing
- Reviewed the changed documentation lines.
- No functional or code changes were made.
## Checklist
- [x] Changes are limited to documentation.
- [x] Corrected spelling mistakes.
- [x] No functional changes were made.
